### PR TITLE
Add missing hbt.Stop() when timing-out a client

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -614,7 +614,10 @@ func (s *StanServer) checkClientHealth(clientID string) {
 		client.fhb++
 		if client.fhb > DefaultMaxFailedHeartBeats {
 			Debugf("STAN: [Client:%s]  Timed out on hearbeats.", client.clientID)
-			defer s.closeClient(client.clientID)
+			client.hbt.Stop()
+			client.Unlock()
+			s.closeClient(client.clientID)
+			return
 		}
 	} else {
 		client.fhb = 0


### PR DESCRIPTION
When a client is not responding to heartbeats, it is closed (state
is cleaned-up). However, the heartbeat timer was not stopped.

/cc @ColinSullivan1
