### PR TITLE
Fix the limits enforcement of message stores

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -21,7 +21,7 @@ import (
 const (
 	// CAUTION! Tests will remove the directory and all its content,
 	// so pick a directory where there is nothing.
-	defaultDataStore = "../data"
+	defaultDataStore = "../server_data"
 )
 
 const (
@@ -658,7 +658,7 @@ func TestRunServerWithFileBased(t *testing.T) {
 	defer s.Shutdown()
 
 	// Create our own NATS connection to control reconnect wait
-	nc, err := nats.Connect(nats.DefaultURL, nats.ReconnectWait(100*time.Millisecond))
+	nc, err := nats.Connect(nats.DefaultURL, nats.ReconnectWait(500*time.Millisecond))
 	if err != nil {
 		t.Fatalf("Unexpected error on connect: %v", err)
 	}
@@ -804,7 +804,7 @@ func TestRunServerWithFileBased(t *testing.T) {
 
 	// Wait more than the reconnect wait, to make sure that
 	// the new publisher's new message is delivered
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(700 * time.Millisecond)
 
 	// For now, we need to use a new connection for the new message
 	// because on restart PUB inbox is different.

--- a/stores/memstore.go
+++ b/stores/memstore.go
@@ -98,8 +98,9 @@ func (ms *MemoryMsgStore) Store(reply string, data []byte) (*pb.MsgProto, error)
 	ms.totalCount++
 	ms.totalBytes += uint64(len(data))
 
-	// Check if we need to remove any.
-	if ms.totalCount > ms.limits.MaxNumMsgs || ms.totalBytes > ms.limits.MaxMsgBytes {
+	// Check if we need to remove any (but leave at least the last added)
+	for ms.totalCount > ms.limits.MaxNumMsgs ||
+		((ms.totalCount > 1) && (ms.totalBytes > ms.limits.MaxMsgBytes)) {
 		firstMsg := ms.msgs[ms.first]
 		ms.totalBytes -= uint64(len(firstMsg.Data))
 		ms.totalCount--

--- a/stores/memstore_test.go
+++ b/stores/memstore_test.go
@@ -72,14 +72,7 @@ func TestMSMaxMsgs(t *testing.T) {
 	ms := createDefaultMemStore(t)
 	defer ms.Close()
 
-	limitCount := 100
-
-	limits := testDefaultChannelLimits
-	limits.MaxNumMsgs = limitCount
-
-	ms.SetChannelLimits(limits)
-
-	testMaxMsgs(t, ms, limitCount)
+	testMaxMsgs(t, ms)
 }
 
 func TestMSMaxChannels(t *testing.T) {


### PR DESCRIPTION
File message stores use multiple files to store messages on a given
channel. The idea is that the amount of messages is spread accross
multiple files, but allows for 25% more messages. When reaching
125%, the first file is removed, and files are shifted.
The problem was that the user should still see strict enforcement
of the limits, in otherwords, when quering the stats of a message
store, we should never get more than 100% of the limit.

Adding also a different test default datastore per package to
avoid clashes during parallel tests.

Tweaked a test to reduce flapping on Windows.

Resolves #39
