### PR TITLE
Fix import path of stan client fixes #50

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/nats-io/gnatsd/logger"
 	"github.com/nats-io/gnatsd/server"
+	"github.com/nats-io/go-stan/pb"
 	"github.com/nats-io/nats"
 	"github.com/nats-io/nuid"
 	"github.com/nats-io/stan-server/spb"
-	"github.com/nats-io/stan/pb"
 
 	natsd "github.com/nats-io/gnatsd/test"
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/go-stan"
+	"github.com/nats-io/go-stan/pb"
 	"github.com/nats-io/nats"
-	"github.com/nats-io/stan"
 	"github.com/nats-io/stan-server/stores"
-	"github.com/nats-io/stan/pb"
 
 	natsd "github.com/nats-io/gnatsd/server"
 )

--- a/stan-server.go
+++ b/stan-server.go
@@ -10,7 +10,7 @@ import (
 
 	"fmt"
 	natsd "github.com/nats-io/gnatsd/server"
-	"github.com/nats-io/stan"
+	"github.com/nats-io/go-stan"
 	stand "github.com/nats-io/stan-server/server"
 	"github.com/nats-io/stan-server/stores"
 )

--- a/stores/common.go
+++ b/stores/common.go
@@ -6,8 +6,8 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/nats-io/go-stan/pb"
 	"github.com/nats-io/stan-server/spb"
-	"github.com/nats-io/stan/pb"
 )
 
 // commonStore contains everything that is common to any type of store

--- a/stores/common_test.go
+++ b/stores/common_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/go-stan/pb"
 	"github.com/nats-io/nuid"
 	"github.com/nats-io/stan-server/spb"
-	"github.com/nats-io/stan/pb"
 )
 
 var testDefaultChannelLimits = ChannelLimits{

--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -10,9 +10,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/nats-io/go-stan/pb"
 	"github.com/nats-io/stan-server/spb"
 	"github.com/nats-io/stan-server/util"
-	"github.com/nats-io/stan/pb"
 )
 
 const (

--- a/stores/memstore.go
+++ b/stores/memstore.go
@@ -5,7 +5,7 @@ package stores
 import (
 	"time"
 
-	"github.com/nats-io/stan/pb"
+	"github.com/nats-io/go-stan/pb"
 )
 
 // MemoryStore is a factory for message and subscription stores.

--- a/stores/store.go
+++ b/stores/store.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/nats-io/gnatsd/server"
+	"github.com/nats-io/go-stan/pb"
 	"github.com/nats-io/stan-server/spb"
-	"github.com/nats-io/stan/pb"
 )
 
 const (


### PR DESCRIPTION
Change import path from `github.com/nats-io/stan` to `github.com/nats-io/go-stan`.
