### PR TITLE
Fix reconnect issues and restart of applications with same client ID

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1614,7 +1614,7 @@ func TestConnectsWithDupCID(t *testing.T) {
 	}
 
 	// Start this go routine that will try to connect 2*total-1
-	// times. These all shoul fail (quickly) since the one
+	// times. These all should fail (quickly) since the one
 	// connecting below should be the one that connects.
 	go func() {
 		defer wg.Done()


### PR DESCRIPTION
To allow an application to restart (important for durables) without
being rejected with a duplicate client ID error, we had reduced the
client HB and timeout to a very low value. This had caused issues
with clients actually reconnecting to NATS after a server restart.
STAN server would timeout those clients since they would not
reply to HB requests fast enough (still in the process of reconnecting
to NATS).
The new approach is, when processing a connect request for a client
ID already registered, to ping that known client with a timeout of
1 second. If client replies, reject the incoming request. If it
fails, delete the old client and accept the new one. AckInboxes of
subscribers are re-created avoiding any old client that would not
have replied to the request, but not actually be dead, to cause
duplicate acks received by the server.

Resolves #31
