### PR TITLE
Fix data race by returning copy of array of client's subscriptions

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -125,7 +125,8 @@ func (cs *clientStore) GetSubs(ID string) []*subState {
 		return nil
 	}
 	c.RLock()
-	subs := c.subs
+	subs := make([]*subState, len(c.subs))
+	copy(subs, c.subs)
 	c.RUnlock()
 	return subs
 }


### PR DESCRIPTION
When getting the array of a client's subscriptions, we were
incorrectly returning a reference to the client's array instead
of a copy of that array. This was causing possible races if the
original array was changed when going over the array returned
by clients.GetSubs().

Resolves #64
