### PR TITLE
Fix recover when starting server

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -438,7 +438,7 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) *StanServer 
 				s.store.Close()
 			}
 			// Issue the original panic now that the store is closed.
-			panic(r.(error))
+			panic(r)
 		}
 	}()
 


### PR DESCRIPTION
When propagating the recovered error, do not assume we are dealing
with an error, it could be a string.
