### PR TITLE
Change CreateChannel API signature

### DIFF
--- a/stores/bench_test.go
+++ b/stores/bench_test.go
@@ -48,7 +48,7 @@ func BenchmarkRecoverMsgs(b *testing.B) {
 	s := benchCreateDefaultFileStore(b)
 	defer s.Close()
 
-	cs, err := s.CreateChannel("foo", nil)
+	cs, _, err := s.CreateChannel("foo", nil)
 	if err != nil {
 		b.Fatalf("Error creating channel foo: %v", err)
 	}
@@ -90,7 +90,7 @@ func BenchmarkRecoverSubs(b *testing.B) {
 	s := benchCreateDefaultFileStore(b)
 	defer s.Close()
 
-	cs, err := s.CreateChannel("foo", nil)
+	cs, _, err := s.CreateChannel("foo", nil)
 	if err != nil {
 		b.Fatalf("Error creating channel foo: %v", err)
 	}

--- a/stores/filestore_test.go
+++ b/stores/filestore_test.go
@@ -415,7 +415,7 @@ func TestFSRecoveryLimitsNotApplied(t *testing.T) {
 	}
 
 	// Now check that any new addition would be rejected
-	if _, err := fs.CreateChannel("new.channel", nil); err == nil {
+	if _, _, err := fs.CreateChannel("new.channel", nil); err == nil {
 		t.Fatal("Expected trying to create a new channel to fail")
 	}
 	channelOne := fs.LookupChannel("channel.1")

--- a/stores/memstore.go
+++ b/stores/memstore.go
@@ -36,18 +36,18 @@ func NewMemoryStore(limits *ChannelLimits) (*MemoryStore, error) {
 	return ms, nil
 }
 
-// CreateChannel creates a ChannelStore for the given channel, or returns
-// an error if one already exists.
-func (ms *MemoryStore) CreateChannel(channel string, userData interface{}) (*ChannelStore, error) {
+// CreateChannel creates a ChannelStore for the given channel, and returns
+// `true` to indicate that the channel is new, false if it already exists.
+func (ms *MemoryStore) CreateChannel(channel string, userData interface{}) (*ChannelStore, bool, error) {
 	ms.Lock()
 	defer ms.Unlock()
 	channelStore := ms.channels[channel]
 	if channelStore != nil {
-		return nil, ErrAlreadyExists
+		return channelStore, false, nil
 	}
 
 	if err := ms.canAddChannel(); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	msgStore := &MemoryMsgStore{}
@@ -64,7 +64,7 @@ func (ms *MemoryStore) CreateChannel(channel string, userData interface{}) (*Cha
 
 	ms.channels[channel] = channelStore
 
-	return channelStore, nil
+	return channelStore, true, nil
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/stores/store.go
+++ b/stores/store.go
@@ -25,7 +25,6 @@ const (
 
 // Errors.
 var (
-	ErrAlreadyExists   = errors.New("already exists")
 	ErrTooManyChannels = errors.New("too many channels")
 	ErrTooManySubs     = errors.New("too many subscriptions per channel")
 )
@@ -113,9 +112,9 @@ type Store interface {
 	// to be retroactive.
 	SetChannelLimits(limits ChannelLimits)
 
-	// CreateChannel creates a ChannelStore for the given channel, or returns
-	// an error if one already exists.
-	CreateChannel(channel string, userData interface{}) (*ChannelStore, error)
+	// CreateChannel creates a ChannelStore for the given channel, and returns
+	// `true` to indicate that the channel is new, false if it already exists.
+	CreateChannel(channel string, userData interface{}) (*ChannelStore, bool, error)
 
 	// LookupChannel returns a ChannelStore for the given channel, nil if channel
 	// does not exist.


### PR DESCRIPTION
Now return a boolean, instead of an error,  to indicate if the
channel already exists.
