### PR TITLE
Add support for basic user authentication

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -683,9 +683,7 @@ func (s *StanServer) configureNATSServerTLS(opts *server.Options) {
 	}
 }
 
-// configureNATSServerTLS sets up TLS for the NATS Server.
-// Additional TLS parameters (e.g. cipher suites) will need to be placed
-// in a configuration file specified through the -config parameter.
+// configureNATSServerAuth sets up user authentication for the NATS Server.
 func (s *StanServer) configureNATSServerAuth(opts *server.Options) server.Auth {
 	// setup authorization
 	var a server.Auth

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3047,7 +3047,7 @@ func TestAuthenticationToken(t *testing.T) {
 
 	_, err := nats.Connect(fmt.Sprintf("nats://%s:%d", nOpts.Host, nOpts.Port))
 	if err == nil {
-		t.Fatalf("Authentcation allowed a plain connection")
+		t.Fatalf("Authentication allowed a plain connection")
 	}
 
 	nc, err := nats.Connect(fmt.Sprintf("nats://%s@%s:%d", nOpts.Authorization, nOpts.Host, nOpts.Port))


### PR DESCRIPTION
Support command line passing of the user/password or auth token arguments to secure the embedded NATS server.

This does not include multi-user authorization.

Resolves #104
