### PR TITLE
Fix durable restart when ack pending >= MaxInFlight

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1343,7 +1343,8 @@ func (s *StanServer) performDurableRedelivery(sub *subState) {
 		m.Redelivered = true
 
 		sub.Lock()
-		s.sendMsgToSub(sub, m, honorMaxInFlight)
+		// Force delivery
+		s.sendMsgToSub(sub, m, true)
 		sub.Unlock()
 	}
 }
@@ -1874,6 +1875,7 @@ func (s *StanServer) processSubscriptionRequest(m *nats.Msg) {
 			sub.AckInbox = ackInbox
 			sub.ClientID = sr.ClientID
 			sub.Inbox = sr.Inbox
+			sub.stalled = false
 			sub.Unlock()
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -1344,6 +1344,7 @@ func (s *StanServer) performDurableRedelivery(sub *subState) {
 
 		sub.Lock()
 		// Force delivery
+		// TODO(ik): Should we instead clean the acks pending when the durable is closed?
 		s.sendMsgToSub(sub, m, true)
 		sub.Unlock()
 	}


### PR DESCRIPTION
When a durable is restarted, we need to force the delivery, even
if the number of pending acks is greater or equal to the current
MaxInFlight, otherwise, the durable would not receive messages
until after multiple failed redeliveries.

Resolves #117