### PR TITLE
Use NATS default options when server creates connection to NATS Server

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -408,9 +408,13 @@ func buildConnectURL(opts *server.Options) string {
 // connection url, and for other future items (e.g. auth)
 func createNatsClientConn(sOpts *Options, nOpts *server.Options) (*nats.Conn, error) {
 	var err error
-	var ncOpts = nats.Options{}
+	ncOpts := nats.DefaultOptions
 
 	ncOpts.Url = buildConnectURL(nOpts)
+	ncOpts.Servers = strings.Split(ncOpts.Url, ",")
+	for i, s := range ncOpts.Servers {
+		ncOpts.Servers[i] = strings.Trim(s, " ")
+	}
 	ncOpts.Name = fmt.Sprintf("NATS-Streaming-Server-%s", sOpts.ID)
 
 	if err = nats.ErrorHandler(stanErrorHandler)(&ncOpts); err != nil {


### PR DESCRIPTION
Default options are already configured to allow reconnect, etc...
Using the empty Options like we did would have prevented the server
to reconnect should its connection to the NATS Server be disconnected
(like in the case of a slow consumer error).