### PR TITLE
Add CRC checksum for file store

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -132,6 +132,8 @@ func parseFlags() (*stand.Options, *natsd.Options) {
 	flag.IntVar(&stanOpts.FileStoreOpts.CompactInterval, "file_compact_interval", stores.DefaultFileStoreOptions.CompactInterval, "Minimum interval (in seconds) between file compactions")
 	flag.Int64Var(&stanOpts.FileStoreOpts.CompactMinFileSize, "file_compact_min_size", stores.DefaultFileStoreOptions.CompactMinFileSize, "Minimum file size for compaction")
 	flag.IntVar(&stanOpts.FileStoreOpts.BufferSize, "file_buffer_size", stores.DefaultFileStoreOptions.BufferSize, "File buffer size (in bytes)")
+	flag.BoolVar(&stanOpts.FileStoreOpts.DoCRC, "file_crc", stores.DefaultFileStoreOptions.DoCRC, "Enable file CRC-32 checksum")
+	flag.IntVar(&stanOpts.FileStoreOpts.CRCPolynomial, "file_crc_poly", stores.DefaultFileStoreOptions.CRCPolynomial, "Polynomial used to make the table used for CRC-32 checksum")
 	flag.IntVar(&stanOpts.IOBatchSize, "io_batch_size", stand.DefaultIOBatchSize, "# of message to batch in flushing io")
 	flag.Int64Var(&stanOpts.IOSleepTime, "io_sleep_time", stand.DefaultIOSleepTime, "duration the server waits for more messages (in micro-seconds, 0 to disable)")
 	// NATS options

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -45,8 +45,8 @@ func TestClientRegister(t *testing.T) {
 	func() {
 		c.RLock()
 		defer c.RUnlock()
-		if sc.ClientID != clientID {
-			t.Fatalf("Expected client id to be %v, got %v", clientID, sc.ClientID)
+		if sc.ID != clientID {
+			t.Fatalf("Expected client id to be %v, got %v", clientID, sc.ID)
 		}
 		if sc.HbInbox != hbInbox {
 			t.Fatalf("Expected client hbInbox to be %v, got %v", hbInbox, sc.HbInbox)

--- a/spb/protocol.pb.go
+++ b/spb/protocol.pb.go
@@ -13,6 +13,8 @@
 		SubStateDelete
 		SubStateUpdate
 		ServerInfo
+		ClientInfo
+		ClientDelete
 */
 package spb
 
@@ -78,11 +80,31 @@ func (m *ServerInfo) Reset()         { *m = ServerInfo{} }
 func (m *ServerInfo) String() string { return proto.CompactTextString(m) }
 func (*ServerInfo) ProtoMessage()    {}
 
+// ClientInfo contains information related to a Client
+type ClientInfo struct {
+	ID      string `protobuf:"bytes,1,opt,name=ID,proto3" json:"ID,omitempty"`
+	HbInbox string `protobuf:"bytes,2,opt,name=HbInbox,proto3" json:"HbInbox,omitempty"`
+}
+
+func (m *ClientInfo) Reset()         { *m = ClientInfo{} }
+func (m *ClientInfo) String() string { return proto.CompactTextString(m) }
+func (*ClientInfo) ProtoMessage()    {}
+
+type ClientDelete struct {
+	ID string `protobuf:"bytes,1,opt,name=ID,proto3" json:"ID,omitempty"`
+}
+
+func (m *ClientDelete) Reset()         { *m = ClientDelete{} }
+func (m *ClientDelete) String() string { return proto.CompactTextString(m) }
+func (*ClientDelete) ProtoMessage()    {}
+
 func init() {
 	proto.RegisterType((*SubState)(nil), "spb.SubState")
 	proto.RegisterType((*SubStateDelete)(nil), "spb.SubStateDelete")
 	proto.RegisterType((*SubStateUpdate)(nil), "spb.SubStateUpdate")
 	proto.RegisterType((*ServerInfo)(nil), "spb.ServerInfo")
+	proto.RegisterType((*ClientInfo)(nil), "spb.ClientInfo")
+	proto.RegisterType((*ClientDelete)(nil), "spb.ClientDelete")
 }
 func (m *SubState) Marshal() (data []byte, err error) {
 	size := m.Size()
@@ -257,6 +279,60 @@ func (m *ServerInfo) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
+func (m *ClientInfo) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *ClientInfo) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.ID) > 0 {
+		data[i] = 0xa
+		i++
+		i = encodeVarintProtocol(data, i, uint64(len(m.ID)))
+		i += copy(data[i:], m.ID)
+	}
+	if len(m.HbInbox) > 0 {
+		data[i] = 0x12
+		i++
+		i = encodeVarintProtocol(data, i, uint64(len(m.HbInbox)))
+		i += copy(data[i:], m.HbInbox)
+	}
+	return i, nil
+}
+
+func (m *ClientDelete) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *ClientDelete) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.ID) > 0 {
+		data[i] = 0xa
+		i++
+		i = encodeVarintProtocol(data, i, uint64(len(m.ID)))
+		i += copy(data[i:], m.ID)
+	}
+	return i, nil
+}
+
 func encodeFixed64Protocol(data []byte, offset int, v uint64) int {
 	data[offset] = uint8(v)
 	data[offset+1] = uint8(v >> 8)
@@ -367,6 +443,30 @@ func (m *ServerInfo) Size() (n int) {
 		n += 1 + l + sovProtocol(uint64(l))
 	}
 	l = len(m.Close)
+	if l > 0 {
+		n += 1 + l + sovProtocol(uint64(l))
+	}
+	return n
+}
+
+func (m *ClientInfo) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.ID)
+	if l > 0 {
+		n += 1 + l + sovProtocol(uint64(l))
+	}
+	l = len(m.HbInbox)
+	if l > 0 {
+		n += 1 + l + sovProtocol(uint64(l))
+	}
+	return n
+}
+
+func (m *ClientDelete) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.ID)
 	if l > 0 {
 		n += 1 + l + sovProtocol(uint64(l))
 	}
@@ -1016,6 +1116,193 @@ func (m *ServerInfo) Unmarshal(data []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Close = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipProtocol(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthProtocol
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ClientInfo) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowProtocol
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ClientInfo: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ClientInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowProtocol
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthProtocol
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ID = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HbInbox", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowProtocol
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthProtocol
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.HbInbox = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipProtocol(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthProtocol
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ClientDelete) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowProtocol
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ClientDelete: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ClientDelete: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowProtocol
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthProtocol
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ID = string(data[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/spb/protocol.proto
+++ b/spb/protocol.proto
@@ -33,8 +33,8 @@ message SubStateDelete {
 
 // SubStateUpdate represents a subscription update (either Msg or Ack)
 message SubStateUpdate {
-  uint64        ID 	  = 1; // Subscription ID
-  uint64	    seqno = 2; // Sequence of the message (pending or ack'ed)
+  uint64 ID 	 = 1; // Subscription ID
+  uint64 seqno = 2; // Sequence of the message (pending or ack'ed)
 }
 
 // ServerInfo contains basic information regarding the Server
@@ -45,4 +45,14 @@ message ServerInfo {
 	string Subscribe   = 4; // Subject server receives subscription requests on.
 	string Unsubscribe = 5; // Subject server receives unsubscribe requests on.
 	string Close       = 6; // Subject server receives close requests on.
+}
+
+// ClientInfo contains information related to a Client
+message ClientInfo {
+  string ID      = 1; // Client ID
+  string HbInbox = 2; // The inbox heartbeats are sent to
+}
+
+message ClientDelete {
+  string ID = 1; // ID of the client being unregistered
 }

--- a/stores/common.go
+++ b/stores/common.go
@@ -136,14 +136,14 @@ func (gs *genericStore) canAddChannel() error {
 
 // AddClient stores information about the client identified by `clientID`.
 func (gs *genericStore) AddClient(clientID, hbInbox string, userData interface{}) (*Client, bool, error) {
-	c := &Client{ClientID: clientID, HbInbox: hbInbox, UserData: userData}
+	c := &Client{spb.ClientInfo{ID: clientID, HbInbox: hbInbox}, userData}
 	gs.Lock()
 	oldClient := gs.clients[clientID]
 	if oldClient != nil {
 		gs.Unlock()
 		return oldClient, false, nil
 	}
-	gs.clients[c.ClientID] = c
+	gs.clients[c.ID] = c
 	gs.Unlock()
 	return c, true, nil
 }

--- a/stores/store.go
+++ b/stores/store.go
@@ -68,8 +68,7 @@ type RecoveredState struct {
 // Client represents a client with ID, Heartbeat Inbox and user data sets
 // when adding it to the store.
 type Client struct {
-	ClientID string
-	HbInbox  string
+	spb.ClientInfo
 	UserData interface{}
 }
 
@@ -89,7 +88,7 @@ type RecoveredSubState struct {
 
 // ChannelStore contains a reference to both Subscription and Message stores.
 type ChannelStore struct {
-	// UserData allows the user of a ChannelStore to store private data.
+	// UserData is set when the channel is created.
 	UserData interface{}
 	// Subs is the Subscriptions Store.
 	Subs SubStore

--- a/util/util.go
+++ b/util/util.go
@@ -18,7 +18,9 @@ func init() {
 // EnsureBufBigEnough checks that given buffer is big enough to hold 'needed'
 // bytes, otherwise returns a buffer of a size of at least 'needed' bytes.
 func EnsureBufBigEnough(buf []byte, needed int) []byte {
-	if buf == nil || needed > len(buf) {
+	if buf == nil {
+		return make([]byte, needed)
+	} else if needed > len(buf) {
 		return make([]byte, int(float32(needed)*1.1))
 	}
 	return buf

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -17,6 +17,10 @@ func TestEnsureBufBigEnough(t *testing.T) {
 	if len(newBuf) <= 10 {
 		t.Fatalf("Buffer should be at least 10, it is: %v", len(newBuf))
 	}
+	newBuf = EnsureBufBigEnough(nil, 5)
+	if len(newBuf) != 5 {
+		t.Fatalf("Buffer should be exactly 5, it is: %v", len(newBuf))
+	}
 }
 
 func TestWriteInt(t *testing.T) {


### PR DESCRIPTION
- Converted Clients file to use protobuf
- Each record has now a CRC-32 checksum field
- Ability to disable CRC check for reads (only occur on startup atm)