### PR TITLE
Add param option to connect to external NATS Server

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -127,6 +127,7 @@ func parseFlags() (*stand.Options, *natsd.Options) {
 	flag.StringVar(&stanOpts.ClientCert, "tls_client_cert", "", "Path to a client certificate file")
 	flag.StringVar(&stanOpts.ClientKey, "tls_client_key", "", "Path to a client key file")
 	flag.StringVar(&stanOpts.ClientCA, "tls_client_cacert", "", "Path to a client CA file")
+	flag.BoolVar(&stanOpts.EmbedNATS, "embed", true, "Embed the NATS Server")
 	flag.BoolVar(&stanOpts.FileStoreOpts.CompactEnabled, "file_compact_enabled", stores.DefaultFileStoreOptions.CompactEnabled, "Enable file compaction")
 	flag.IntVar(&stanOpts.FileStoreOpts.CompactFragmentation, "file_compact_frag", stores.DefaultFileStoreOptions.CompactFragmentation, "File fragmentation threshold for compaction")
 	flag.IntVar(&stanOpts.FileStoreOpts.CompactInterval, "file_compact_interval", stores.DefaultFileStoreOptions.CompactInterval, "Minimum interval (in seconds) between file compactions")

--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -127,7 +127,7 @@ func parseFlags() (*stand.Options, *natsd.Options) {
 	flag.StringVar(&stanOpts.ClientCert, "tls_client_cert", "", "Path to a client certificate file")
 	flag.StringVar(&stanOpts.ClientKey, "tls_client_key", "", "Path to a client key file")
 	flag.StringVar(&stanOpts.ClientCA, "tls_client_cacert", "", "Path to a client CA file")
-	flag.BoolVar(&stanOpts.EmbedNATS, "embed", true, "Embed the NATS Server")
+	flag.BoolVar(&stanOpts.EmbedNATS, "embed_nats", stand.DefaultEmbedNATS, "Embed the NATS Server")
 	flag.BoolVar(&stanOpts.FileStoreOpts.CompactEnabled, "file_compact_enabled", stores.DefaultFileStoreOptions.CompactEnabled, "Enable file compaction")
 	flag.IntVar(&stanOpts.FileStoreOpts.CompactFragmentation, "file_compact_frag", stores.DefaultFileStoreOptions.CompactFragmentation, "File fragmentation threshold for compaction")
 	flag.IntVar(&stanOpts.FileStoreOpts.CompactInterval, "file_compact_interval", stores.DefaultFileStoreOptions.CompactInterval, "Minimum interval (in seconds) between file compactions")

--- a/server/server.go
+++ b/server/server.go
@@ -41,6 +41,7 @@ const (
 	DefaultUnSubPrefix    = "_STAN.unsub"
 	DefaultClosePrefix    = "_STAN.close"
 	DefaultStoreType      = stores.TypeMemory
+	DefaultEmbedNATS      = true
 
 	// DefaultChannelLimit defines how many channels (literal subjects) we allow
 	DefaultChannelLimit = 100
@@ -389,7 +390,7 @@ var defaultOptions = Options{
 	FileStoreOpts:  stores.DefaultFileStoreOptions,
 	IOBatchSize:    DefaultIOBatchSize,
 	IOSleepTime:    DefaultIOSleepTime,
-	EmbedNATS:      true,
+	EmbedNATS:      DefaultEmbedNATS,
 }
 
 // GetDefaultOptions returns default options for the STAN server

--- a/server/server.go
+++ b/server/server.go
@@ -378,6 +378,7 @@ type Options struct {
 	ClientCA         string // Client CAs for TLS
 	IOBatchSize      int    // Number of messages we collect from clients before processing them.
 	IOSleepTime      int64  // Duration (in micro-seconds) the server waits for more message to fill up a batch.
+	EmbedNATS        bool   // NATS Streaming Server embeds the NATS Server.
 }
 
 // DefaultOptions are default options for the STAN server
@@ -388,6 +389,7 @@ var defaultOptions = Options{
 	FileStoreOpts:  stores.DefaultFileStoreOptions,
 	IOBatchSize:    DefaultIOBatchSize,
 	IOSleepTime:    DefaultIOSleepTime,
+	EmbedNATS:      true,
 }
 
 // GetDefaultOptions returns default options for the STAN server
@@ -602,7 +604,9 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) *StanServer 
 		}
 	}
 
-	s.startNATSServer(nOpts)
+	if sOpts.EmbedNATS {
+		s.startNATSServer(nOpts)
+	}
 
 	if s.nc, err = createNatsClientConn(sOpts, nOpts); err != nil {
 		panic(fmt.Sprintf("Can't connect to NATS server: %v\n", err))

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	natsd "github.com/nats-io/gnatsd/server"
+	natsdTest "github.com/nats-io/gnatsd/test"
 	"github.com/nats-io/go-nats-streaming"
 	"github.com/nats-io/go-nats-streaming/pb"
 	"github.com/nats-io/nats"
@@ -3275,4 +3276,35 @@ func TestIOChannel(t *testing.T) {
 	sOpts = GetDefaultOptions()
 	sOpts.IOSleepTime = 500
 	run(sOpts)
+}
+
+func TestDontEmbedNATSNotRunning(t *testing.T) {
+	sOpts := GetDefaultOptions()
+	sOpts.EmbedNATS = false
+
+	nOpts := DefaultNatsServerOptions
+	nOpts.Host = "localhost"
+	nOpts.Port = 5222
+
+	var failedServer *StanServer
+	defer func() {
+		if r := recover(); r == nil {
+			failedServer.Shutdown()
+			t.Fatal("Expected streaming server to fail to start")
+		}
+	}()
+	failedServer = RunServerWithOpts(sOpts, &nOpts)
+}
+
+func TestDontEmbedNATRunning(t *testing.T) {
+	sOpts := GetDefaultOptions()
+	sOpts.EmbedNATS = false
+
+	nOpts := DefaultNatsServerOptions
+	nOpts.Host = "localhost"
+	nOpts.Port = 5223
+	natsdTest.RunServer(&nOpts)
+
+	s := RunServerWithOpts(sOpts, &nOpts)
+	defer s.Shutdown()
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3282,9 +3282,8 @@ func TestDontEmbedNATSNotRunning(t *testing.T) {
 	sOpts := GetDefaultOptions()
 	sOpts.EmbedNATS = false
 
-	nOpts := DefaultNatsServerOptions
-	nOpts.Host = "localhost"
-	nOpts.Port = 5222
+	// Don't start a NATS Server, starting streaming server
+	// should fail.
 
 	var failedServer *StanServer
 	defer func() {
@@ -3293,7 +3292,7 @@ func TestDontEmbedNATSNotRunning(t *testing.T) {
 			t.Fatal("Expected streaming server to fail to start")
 		}
 	}()
-	failedServer = RunServerWithOpts(sOpts, &nOpts)
+	failedServer = RunServerWithOpts(sOpts, nil)
 }
 
 func TestDontEmbedNATRunning(t *testing.T) {


### PR DESCRIPTION
By default, the Streaming server embeds the NATS Server.
You can now pass "-embed=false" to connect to an external server.
Still use "-p" or "-a" if needed to connect to the NATS Server.

/cc @ColinSullivan1 @aricart @derekcollison 