### PR TITLE
[ADDED] Ability to enable/disable file sync during Flush()

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -135,6 +135,7 @@ func parseFlags() (*stand.Options, *natsd.Options) {
 	flag.IntVar(&stanOpts.FileStoreOpts.BufferSize, "file_buffer_size", stores.DefaultFileStoreOptions.BufferSize, "File buffer size (in bytes)")
 	flag.BoolVar(&stanOpts.FileStoreOpts.DoCRC, "file_crc", stores.DefaultFileStoreOptions.DoCRC, "Enable file CRC-32 checksum")
 	flag.Int64Var(&stanOpts.FileStoreOpts.CRCPolynomial, "file_crc_poly", stores.DefaultFileStoreOptions.CRCPolynomial, "Polynomial used to make the table used for CRC-32 checksum")
+	flag.BoolVar(&stanOpts.FileStoreOpts.DoSync, "file_sync", stores.DefaultFileStoreOptions.DoSync, "Enable File.Sync on Flush")
 	flag.IntVar(&stanOpts.IOBatchSize, "io_batch_size", stand.DefaultIOBatchSize, "# of message to batch in flushing io")
 	flag.Int64Var(&stanOpts.IOSleepTime, "io_sleep_time", stand.DefaultIOSleepTime, "duration the server waits for more messages (in micro-seconds, 0 to disable)")
 	// NATS options

--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -75,6 +75,9 @@ type FileStoreOptions struct {
 
 	// CRCPoly is a polynomial used to make the table used in CRC computation.
 	CRCPolynomial int64
+
+	// DoSync indicates if `File.Sync()`` is called during a flush.
+	DoSync bool
 }
 
 // DefaultFileStoreOptions defines the default options for a File Store.
@@ -86,6 +89,7 @@ var DefaultFileStoreOptions = FileStoreOptions{
 	CompactMinFileSize:   1024 * 1024,
 	DoCRC:                true,
 	CRCPolynomial:        int64(crc32.IEEE),
+	DoSync:               true,
 }
 
 // BufferSize is a FileStore option that sets the size of the buffer used
@@ -151,6 +155,15 @@ func DoCRC(enableCRC bool) FileStoreOption {
 func CRCPolynomial(polynomial int64) FileStoreOption {
 	return func(o *FileStoreOptions) error {
 		o.CRCPolynomial = polynomial
+		return nil
+	}
+}
+
+// DoSync is a FileStore option that defines if `File.Sync()` should be called
+// during a `Flush()` call.
+func DoSync(enableFileSync bool) FileStoreOption {
+	return func(o *FileStoreOptions) error {
+		o.DoSync = enableFileSync
 		return nil
 	}
 }
@@ -1244,7 +1257,10 @@ func (ms *FileMsgStore) flush() error {
 	if err := ms.bw.Flush(); err != nil {
 		return err
 	}
-	return ms.file.Sync()
+	if ms.opts.DoSync {
+		return ms.file.Sync()
+	}
+	return nil
 }
 
 // Flush flushes outstanding data into the store.
@@ -1628,7 +1644,10 @@ func (ss *FileSubStore) flush() error {
 	if err := ss.bw.Flush(); err != nil {
 		return err
 	}
-	return ss.file.Sync()
+	if ss.opts.DoSync {
+		return ss.file.Sync()
+	}
+	return nil
 }
 
 // Flush persists buffered operations to disk.


### PR DESCRIPTION
Using `-file_sync=false` will disable fsync during Flush().

Resolves #127