### PR TITLE
[CHANGED] Option parameter to connect to external NATS Server

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -27,6 +27,7 @@ Streaming Server Options:
     -max_subs <number>           Max number of subscriptions per channel
     -max_msgs <number>           Max number of messages per channel
     -max_bytes <number>          Max messages total size per channel
+    -nats_server <url>           Connect to this external NATS Server (embedded otherwise)
 
 Streaming Server TLS Options:
     -secure                      Use a TLS connection to the NATS server without
@@ -127,7 +128,7 @@ func parseFlags() (*stand.Options, *natsd.Options) {
 	flag.StringVar(&stanOpts.ClientCert, "tls_client_cert", "", "Path to a client certificate file")
 	flag.StringVar(&stanOpts.ClientKey, "tls_client_key", "", "Path to a client key file")
 	flag.StringVar(&stanOpts.ClientCA, "tls_client_cacert", "", "Path to a client CA file")
-	flag.BoolVar(&stanOpts.EmbedNATS, "embed_nats", stand.DefaultEmbedNATS, "Embed the NATS Server")
+	flag.StringVar(&stanOpts.NATSServerURL, "nats_server", "", "URL of the NATS Server to connect to (embedded by default)")
 	flag.BoolVar(&stanOpts.FileStoreOpts.CompactEnabled, "file_compact_enabled", stores.DefaultFileStoreOptions.CompactEnabled, "Enable file compaction")
 	flag.IntVar(&stanOpts.FileStoreOpts.CompactFragmentation, "file_compact_frag", stores.DefaultFileStoreOptions.CompactFragmentation, "File fragmentation threshold for compaction")
 	flag.IntVar(&stanOpts.FileStoreOpts.CompactInterval, "file_compact_interval", stores.DefaultFileStoreOptions.CompactInterval, "Minimum interval (in seconds) between file compactions")

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nats-io/nats"
 	"github.com/nats-io/nats-streaming-server/stores"
 
+	"github.com/nats-io/gnatsd/auth"
 	"io/ioutil"
 	"sync"
 	"sync/atomic"
@@ -3280,7 +3281,14 @@ func TestIOChannel(t *testing.T) {
 
 func TestDontEmbedNATSNotRunning(t *testing.T) {
 	sOpts := GetDefaultOptions()
-	sOpts.EmbedNATS = false
+	// Make sure that with empty string (normally the default), we
+	// can run the streaming server (will embed NATS)
+	sOpts.NATSServerURL = ""
+	s := RunServerWithOpts(sOpts, nil)
+	s.Shutdown()
+
+	// Point to a NATS Server that will not be running
+	sOpts.NATSServerURL = "nats://localhost:5223"
 
 	// Don't start a NATS Server, starting streaming server
 	// should fail.
@@ -3295,15 +3303,62 @@ func TestDontEmbedNATSNotRunning(t *testing.T) {
 	failedServer = RunServerWithOpts(sOpts, nil)
 }
 
-func TestDontEmbedNATRunning(t *testing.T) {
+func TestDontEmbedNATSRunning(t *testing.T) {
 	sOpts := GetDefaultOptions()
-	sOpts.EmbedNATS = false
+	sOpts.NATSServerURL = "nats://localhost:5223"
 
 	nOpts := DefaultNatsServerOptions
 	nOpts.Host = "localhost"
 	nOpts.Port = 5223
-	natsdTest.RunServer(&nOpts)
+	natsd := natsdTest.RunServer(&nOpts)
+	defer natsd.Shutdown()
 
 	s := RunServerWithOpts(sOpts, &nOpts)
 	defer s.Shutdown()
+}
+
+func TestDontEmbedNATSMultipleURLs(t *testing.T) {
+	nOpts := DefaultNatsServerOptions
+	nOpts.Host = "localhost"
+	nOpts.Port = 5223
+	nOpts.Username = "ivan"
+	nOpts.Password = "pwd"
+	natsServer := natsdTest.RunServer(&nOpts)
+	defer natsServer.Shutdown()
+	auth := &auth.Plain{Username: nOpts.Username, Password: nOpts.Password}
+	natsServer.SetClientAuthMethod(auth)
+
+	sOpts := GetDefaultOptions()
+
+	workingURLs := []string{
+		"nats://localhost:5223",
+		"nats://ivan:pwd@localhost:5223",
+		"nats://ivan:pwd@localhost:5223, nats://ivan:pwd@localhost:5224",
+	}
+	for _, url := range workingURLs {
+		sOpts.NATSServerURL = url
+		s := RunServerWithOpts(sOpts, &nOpts)
+		s.Shutdown()
+	}
+
+	notWorkingURLs := []string{
+		"nats://ivan:incorrect@localhost:5223",
+		"nats://localhost:5223,nats://ivan:pwd@localhost:5224",
+		"nats://localhost",
+		"localhost:5223",
+		"localhost",
+	}
+	for _, url := range notWorkingURLs {
+		func() {
+			var s *StanServer
+			defer func() {
+				if r := recover(); r == nil {
+					s.Shutdown()
+					t.Fatalf("Expected streaming server to fail to start with url=%v", url)
+				}
+			}()
+			sOpts.NATSServerURL = url
+			s = RunServerWithOpts(sOpts, &nOpts)
+		}()
+	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3347,6 +3347,8 @@ func TestDontEmbedNATSMultipleURLs(t *testing.T) {
 		"nats://localhost",
 		"localhost:5223",
 		"localhost",
+		"nats://ivan:pwd@:5224",
+		" ",
 	}
 	for _, url := range notWorkingURLs {
 		func() {


### PR DESCRIPTION
You can now use `-nats_server <url>` instead. When you provide
the url to connect to a NATS server that requires authentication,
you can pass the username and password in the url itself, or
with `-user` and `-pass`. If username and password is present
in the url, they will override the one passed through the
command line.

This PR is related to #125