### PR TITLE
Fix NATS Streaming Quickstart link [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The best way to get the NATS Streaming Server is to use one of the pre-built rel
 
 Of course you can build the latest version of the server from the master branch. The master branch will always build and pass tests, but may not work correctly in your environment. You will first need Go installed on your machine (version 1.5+ is required) to build the NATS server.
 
-See also the NATS Streaming Quickstart [tutorial](http://site-nats-streaming-staging.zeppole.buffalo.im/documentation/tutorials/nats-streaming-quickstart/).
+See also the NATS Streaming Quickstart [tutorial](https://nats.io/documentation/streaming/nats-streaming-quickstart/).
 
 ### Running
 


### PR DESCRIPTION
I believe that this is the correct link. The current one returns 404 for me.

Any plans or estimates for a Node.js client release? If it's just around the corner I wont bother hacking my own because of the lack of time to do it properly.