### PR TITLE
Fixed some issues with durables

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -880,6 +880,11 @@ func (s *StanServer) processRecoveredChannels(subscriptions stores.RecoveredSubs
 			} else if len(sub.acksPending) > 0 {
 				// Prevent delivery of new messages until resent of old ones
 				sub.newOnHold = true
+				// We may not need to set this because this would be set
+				// during the initial redelivery attempt, but does not hurt.
+				if int32(len(sub.acksPending)) >= sub.MaxInFlight {
+					sub.stalled = true
+				}
 			}
 			// Copy over fields from SubState protobuf
 			sub.SubState = *recSub.Sub
@@ -954,6 +959,13 @@ func (s *StanServer) performRedeliveryOnStartup(recoveredSubs []*subState) {
 		// may need to reset the timer (which would not work if timer is nil).
 		// Set it to a high value, it will be correctly reset or cleared.
 		s.setupAckTimer(sub, time.Hour)
+		// If this is a durable and it is offline, then skip the rest.
+		if sub.DurableName != "" && sub.ClientID == "" {
+			sub.newOnHold = false
+			sub.Unlock()
+			continue
+		}
+
 		// Unlock in order to call function below
 		sub.Unlock()
 		// Send old messages (lock is acquired in that function)
@@ -1414,7 +1426,6 @@ func (s *StanServer) performDurableRedelivery(sub *subState) {
 
 		sub.Lock()
 		// Force delivery
-		// TODO(ik): Should we instead clean the acks pending when the durable is closed?
 		s.sendMsgToSub(sub, m, true)
 		sub.Unlock()
 	}
@@ -1434,11 +1445,6 @@ func (s *StanServer) performAckExpirationRedelivery(sub *subState) {
 	stalledRedeliveries := sub.stalledRdlv
 	sub.RUnlock()
 
-	if s.debug {
-		Debugf("STAN: [Client:%s] Redelivering on ack expiration, subject=%s, inbox=%s",
-			clientID, subject, inbox)
-	}
-
 	// If we don't find the client, we are done.
 	client := s.clients.Lookup(clientID)
 	if client == nil {
@@ -1455,7 +1461,16 @@ func (s *StanServer) performAckExpirationRedelivery(sub *subState) {
 			sub.ackTimer.Reset(sub.ackWait)
 		}
 		sub.Unlock()
+		if s.debug {
+			Debugf("STAN: [Client:%s] Skipping redelivering on ack expiration due to client missed hearbeat, subject=%s, inbox=%s",
+				clientID, subject, inbox)
+		}
 		return
+	}
+
+	if s.debug {
+		Debugf("STAN: [Client:%s] Redelivering on ack expiration, subject=%s, inbox=%s",
+			clientID, subject, inbox)
 	}
 
 	var cs *stores.ChannelStore
@@ -1574,6 +1589,13 @@ func (s *StanServer) sendMsgToSub(sub *subState, m *pb.MsgProto, force bool) boo
 		return false
 	}
 
+	// Setup the ackTimer as needed now. I don't want to use defer in this
+	// function, and want to make sure that if we exit before the end, the
+	// timer is set. It will be adjusted/stopped as needed.
+	if sub.ackTimer == nil {
+		s.setupAckTimer(sub, sub.ackWait)
+	}
+
 	// If this message is already pending, nothing else to do.
 	if sub.acksPending[m.Sequence] != nil {
 		return true
@@ -1592,12 +1614,6 @@ func (s *StanServer) sendMsgToSub(sub *subState, m *pb.MsgProto, force bool) boo
 
 	// Store in ackPending.
 	sub.acksPending[m.Sequence] = m
-
-	// Setup the ackTimer as needed.
-	if sub.ackTimer == nil {
-		s.setupAckTimer(sub, sub.ackWait)
-		sub.ackTimeFloor = m.Timestamp
-	}
 
 	return true
 }

--- a/server/server.go
+++ b/server/server.go
@@ -965,7 +965,6 @@ func (s *StanServer) performRedeliveryOnStartup(recoveredSubs []*subState) {
 			sub.Unlock()
 			continue
 		}
-
 		// Unlock in order to call function below
 		sub.Unlock()
 		// Send old messages (lock is acquired in that function)


### PR DESCRIPTION
When a durable was stopped and restarted, everything would be fine.
However, if durable was stopped, then the server restarted (applies
only to server with file store - since with memory based stores,
no state is recovered), when the durable was once again started,
it would get the error: "stan: duplicate durable registration".
This was because the ClientID, which was recovered from the
subscription info, was not cleared from memory, preventing the
durable to restart.