### PR TITLE
[FIXED] Server losing track of last sent after compact

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -32,7 +32,7 @@ import (
 // Server defaults.
 const (
 	// VERSION is the current version for the NATS Streaming server.
-	VERSION = "0.2.2"
+	VERSION = "0.2.3"
 
 	DefaultClusterID      = "test-cluster"
 	DefaultDiscoverPrefix = "_STAN.discover"


### PR DESCRIPTION
There were two issues:
- FileStore was storing a reference to the server's SubState object,
  which was wrong.
- During a compact, the subscription record was written but LastSent
  was potentially wrong. Make sure the store keeps track of the
  lastSent when adding a pending message to a given subscription.

Resolves #154