### PR TITLE
[FIXED] Behavior of queue subscriber when leaving a group

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -304,7 +304,7 @@ func (ss *subStore) updateState(sub *subState) {
 
 // Remove a subscriber from the subscription store, leaving durable
 // subscriptions unless `force` is true.
-func (s *StanServer) Remove(ss *subStore, sub *subState, force bool) {
+func (ss *subStore) Remove(s *StanServer, sub *subState, force bool) {
 	if sub == nil {
 		return
 	}
@@ -349,19 +349,16 @@ func (s *StanServer) Remove(ss *subStore, sub *subState, force bool) {
 		// for which we don't have substore lock held.
 		qs.Lock()
 		qs.subs, _ = sub.deleteFromList(qs.subs)
-		empty := len(qs.subs) == 0
-		qs.Unlock()
-		// If it was the last being removed, just remove the
-		// queue group from the subStore map of queue groups.
-		if empty {
+		if len(qs.subs) == 0 {
+			// If it was the last being removed, also remove the
+			// queue group from the subStore map.
 			delete(ss.qsubs, qgroup)
 		} else {
 			// If there are pending messages in this sub, they need to be
 			// transfered to remaining queue subscribers.
 			// Also, we may need to update the store to keep track of the
-			// group's LastSent if it happens that this leaving member was
-			// carring the LastSent sequence.
-			qs.Lock()
+			// group's LastSent if the leaving member was the one with
+			// the queue group's lastSent value.
 			numQSubs := len(qs.subs)
 			idx := 0
 			sub.RLock()
@@ -403,20 +400,17 @@ func (s *StanServer) Remove(ss *subStore, sub *subState, force bool) {
 				}
 			}
 			sub.RUnlock()
-			// We need to update if the leaving queue subscriber was the
-			// one with the group's lastSent. If it had no pending messages,
-			// or none of the pending messages had the lastSent, we need
-			// to update on store, one of the remaining queue sub. Any will
-			// do, so take the first.
 			if needUpdate {
+				// if we need to update use any of the queue subscriber.
+				// The first will do.
 				qsub := qs.subs[0]
 				qsub.Lock()
 				qsub.LastSent = qs.lastSent
 				qsub.store.UpdateSub(&qsub.SubState)
 				qsub.Unlock()
 			}
-			qs.Unlock()
 		}
+		qs.Unlock()
 	} else {
 		ss.psubs, _ = sub.deleteFromList(ss.psubs)
 	}
@@ -1909,7 +1903,7 @@ func (s *StanServer) removeAllNonDurableSubscribers(client *client) {
 		// Get the subStore from the ChannelStore
 		ss := cs.UserData.(*subStore)
 		// Don't remove durables
-		s.Remove(ss, sub, false)
+		ss.Remove(s, sub, false)
 	}
 }
 
@@ -1950,7 +1944,7 @@ func (s *StanServer) processUnSubscribeRequest(m *nats.Msg) {
 	}
 
 	// Remove the subscription, force removal if durable.
-	s.Remove(ss, sub, true)
+	ss.Remove(s, sub, true)
 
 	Debugf("STAN: [Client:%s] Unsubscribing subject=%s.", req.ClientID, sub.subject)
 

--- a/server/server.go
+++ b/server/server.go
@@ -302,8 +302,9 @@ func (ss *subStore) updateState(sub *subState) {
 	}
 }
 
-// Remove
-func (ss *subStore) Remove(sub *subState, force bool) {
+// Remove a subscriber from the subscription store, leaving durable
+// subscriptions unless `force` is true.
+func (s *StanServer) Remove(ss *subStore, sub *subState, force bool) {
 	if sub == nil {
 		return
 	}
@@ -324,6 +325,7 @@ func (ss *subStore) Remove(sub *subState, force bool) {
 	}
 	subid := sub.ID
 	store := sub.store
+	qgroup := sub.QGroup
 	sub.Unlock()
 
 	if force {
@@ -347,7 +349,74 @@ func (ss *subStore) Remove(sub *subState, force bool) {
 		// for which we don't have substore lock held.
 		qs.Lock()
 		qs.subs, _ = sub.deleteFromList(qs.subs)
+		empty := len(qs.subs) == 0
 		qs.Unlock()
+		// If it was the last being removed, just remove the
+		// queue group from the subStore map of queue groups.
+		if empty {
+			delete(ss.qsubs, qgroup)
+		} else {
+			// If there are pending messages in this sub, they need to be
+			// transfered to remaining queue subscribers.
+			// Also, we may need to update the store to keep track of the
+			// group's LastSent if it happens that this leaving member was
+			// carring the LastSent sequence.
+			qs.Lock()
+			numQSubs := len(qs.subs)
+			idx := 0
+			sub.RLock()
+			needUpdate := sub.LastSent == qs.lastSent
+			for _, m := range sub.acksPending {
+				// Get one of the remaning queue subscribers.
+				qsub := qs.subs[idx]
+				qsub.Lock()
+				// Store in storage
+				if err := qsub.store.AddSeqPending(qsub.ID, m.Sequence); err != nil {
+					Errorf("STAN: [Client:%s] Unable to update subscription for %s:%v (%v)",
+						qsub.ClientID, m.Subject, m.Sequence, err)
+					qsub.Unlock()
+					continue
+				}
+				// We don't need to update if the sub's lastSent is transfered
+				// to another queue subscriber.
+				if needUpdate && m.Sequence == qs.lastSent {
+					needUpdate = false
+				}
+				// Update LastSent if applicable
+				if m.Sequence > qsub.LastSent {
+					qsub.LastSent = m.Sequence
+				}
+				// Store in ackPending.
+				qsub.acksPending[m.Sequence] = m
+				// Make sure we set its ack timer if none already set, otherwise
+				// adjust the ackTimer floor as needed.s
+				if qsub.ackTimer == nil {
+					s.setupAckTimer(qsub, qsub.ackWait)
+				} else if qsub.ackTimeFloor > 0 && qsub.ackTimeFloor > m.Timestamp {
+					qsub.ackTimeFloor = m.Timestamp
+				}
+				qsub.Unlock()
+				// Move to the next queue subscriber, going back to first if needed.
+				idx++
+				if idx == numQSubs {
+					idx = 0
+				}
+			}
+			sub.RUnlock()
+			// We need to update if the leaving queue subscriber was the
+			// one with the group's lastSent. If it had no pending messages,
+			// or none of the pending messages had the lastSent, we need
+			// to update on store, one of the remaining queue sub. Any will
+			// do, so take the first.
+			if needUpdate {
+				qsub := qs.subs[0]
+				qsub.Lock()
+				qsub.LastSent = qs.lastSent
+				qsub.store.UpdateSub(&qsub.SubState)
+				qsub.Unlock()
+			}
+			qs.Unlock()
+		}
 	} else {
 		ss.psubs, _ = sub.deleteFromList(ss.psubs)
 	}
@@ -1840,7 +1909,7 @@ func (s *StanServer) removeAllNonDurableSubscribers(client *client) {
 		// Get the subStore from the ChannelStore
 		ss := cs.UserData.(*subStore)
 		// Don't remove durables
-		ss.Remove(sub, false)
+		s.Remove(ss, sub, false)
 	}
 }
 
@@ -1881,7 +1950,7 @@ func (s *StanServer) processUnSubscribeRequest(m *nats.Msg) {
 	}
 
 	// Remove the subscription, force removal if durable.
-	ss.Remove(sub, true)
+	s.Remove(ss, sub, true)
 
 	Debugf("STAN: [Client:%s] Unsubscribing subject=%s.", req.ClientID, sub.subject)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3671,3 +3671,194 @@ func TestFileStoreNoPanicOnShutdown(t *testing.T) {
 		test()
 	}
 }
+
+func TestQueueGroupRemovedOnLastMemberLeaving(t *testing.T) {
+	s := RunServer(clusterName)
+	defer s.Shutdown()
+
+	sc := NewDefaultConnection(t)
+	defer sc.Close()
+
+	if err := sc.Publish("foo", []byte("msg1")); err != nil {
+		t.Fatalf("Unexpected error on publish: %v", err)
+	}
+	ch := make(chan bool)
+	cb := func(m *stan.Msg) {
+		if m.Sequence == 1 {
+			ch <- true
+		}
+	}
+	// Create a queue subscriber
+	if _, err := sc.QueueSubscribe("foo", "group", cb, stan.DeliverAllAvailable()); err != nil {
+		t.Fatalf("Unexpected error on subscribe: %v", err)
+	}
+	// Wait to receive the message
+	if err := Wait(ch); err != nil {
+		t.Fatal("Did not get our message")
+	}
+	// Close the connection which will remove the queue subscriber
+	sc.Close()
+
+	// Create a new connection
+	sc = NewDefaultConnection(t)
+	defer sc.Close()
+	// Send a new message
+	if err := sc.Publish("foo", []byte("msg2")); err != nil {
+		t.Fatalf("Unexpected error on publish: %v", err)
+	}
+	// Start a queue subscriber. The group should have been destroyed
+	// when the last member left, so even with a new name, this should
+	// be a new group and start from msg seq 1
+	qsub, err := sc.QueueSubscribe("foo", "group", cb, stan.DeliverAllAvailable())
+	if err != nil {
+		t.Fatalf("Unexpected error on subscribe: %v", err)
+	}
+	// Wait to receive the message
+	if err := Wait(ch); err != nil {
+		t.Fatal("Did not get our message")
+	}
+	// Test with unsubscribe
+	if err := qsub.Unsubscribe(); err != nil {
+		t.Fatalf("Error during Unsubscribe: %v", err)
+	}
+	// Recreate a queue subscriber, it should again receive from msg1
+	if _, err := sc.QueueSubscribe("foo", "group", cb, stan.DeliverAllAvailable()); err != nil {
+		t.Fatalf("Unexpected error on subscribe: %v", err)
+	}
+	// Wait to receive the message
+	if err := Wait(ch); err != nil {
+		t.Fatal("Did not get our message")
+	}
+}
+
+func TestQueueSubscriberTransferPendingMsgsOnClose(t *testing.T) {
+	s := RunServer(clusterName)
+	defer s.Shutdown()
+
+	sc := NewDefaultConnection(t)
+	defer sc.Close()
+
+	if err := sc.Publish("foo", []byte("msg1")); err != nil {
+		t.Fatalf("Unexpected error on publish: %v", err)
+	}
+	var sub1 stan.Subscription
+	var sub2 stan.Subscription
+	var err error
+	ch := make(chan bool)
+	qsetup := make(chan bool)
+	cb := func(m *stan.Msg) {
+		<-qsetup
+		if m.Sub == sub1 && m.Sequence == 1 && m.Redelivered == false {
+			ch <- true
+		} else if m.Sub == sub2 && m.Sequence == 1 && m.Redelivered == true {
+			ch <- true
+		}
+	}
+	// Create a queue subscriber with MaxInflight == 1 and manual ACK
+	// so that it does not ack it and see if it will be redelivered.
+	sub1, err = sc.QueueSubscribe("foo", "group", cb,
+		stan.DeliverAllAvailable(),
+		stan.MaxInflight(1),
+		stan.SetManualAckMode())
+	if err != nil {
+		t.Fatalf("Unexpected error on subscribe: %v", err)
+	}
+	qsetup <- true
+	// Wait to receive the message
+	if err := Wait(ch); err != nil {
+		t.Fatal("Did not get our message")
+	}
+	// Start 2nd queue subscriber on same group
+	sub2, err = sc.QueueSubscribe("foo", "group", cb, stan.AckWait(time.Second))
+	if err != nil {
+		t.Fatalf("Unexpected error on subscribe: %v", err)
+	}
+	// Unsubscribe the first member
+	sub1.Unsubscribe()
+	qsetup <- true
+	// The second queue subscriber should receive the first message.
+	if err := Wait(ch); err != nil {
+		t.Fatal("Did not get our message")
+	}
+}
+
+func TestFileStoreQueueSubLeavingUpdateQGroupLastSent(t *testing.T) {
+	cleanupDatastore(t, defaultDataStore)
+	defer cleanupDatastore(t, defaultDataStore)
+
+	opts := GetDefaultOptions()
+	opts.StoreType = stores.TypeFile
+	opts.FilestoreDir = defaultDataStore
+	s := RunServerWithOpts(opts, nil)
+	defer shutdownRestartedServerOnTestExit(&s)
+
+	sc := NewDefaultConnection(t)
+	defer sc.Close()
+
+	if err := sc.Publish("foo", []byte("msg1")); err != nil {
+		t.Fatalf("Unexpected error on publish: %v", err)
+	}
+	ch := make(chan bool)
+	cb := func(m *stan.Msg) {
+		ch <- true
+	}
+	// Create a queue subscriber with MaxInflight == 1 and manual ACK
+	// so that it does not ack it and see if it will be redelivered.
+	if _, err := sc.QueueSubscribe("foo", "group", cb,
+		stan.DeliverAllAvailable(),
+		stan.MaxInflight(1),
+		stan.SetManualAckMode()); err != nil {
+		t.Fatalf("Unexpected error on subscribe: %v", err)
+	}
+	// Wait to receive the message
+	if err := Wait(ch); err != nil {
+		t.Fatal("Did not get our message")
+	}
+	// send second message
+	if err := sc.Publish("foo", []byte("msg2")); err != nil {
+		t.Fatalf("Unexpected error on publish: %v", err)
+	}
+	// Start 2nd queue subscriber on same group
+	sub2, err := sc.QueueSubscribe("foo", "group", cb, stan.DeliverAllAvailable())
+	if err != nil {
+		t.Fatalf("Unexpected error on subscribe: %v", err)
+	}
+	// The second queue subscriber should receive the second message.
+	if err := Wait(ch); err != nil {
+		t.Fatal("Did not get our message")
+	}
+	// Unsubscribe the second member
+	sub2.Unsubscribe()
+	// Restart server
+	s.Shutdown()
+	s = RunServerWithOpts(opts, nil)
+	// Send a third message
+	if err := sc.Publish("foo", []byte("msg3")); err != nil {
+		t.Fatalf("Unexpected error on publish: %v", err)
+	}
+	// Start a third queue subscriber, it should receive message 3
+	msgCh := make(chan *stan.Msg)
+	lastMsgCb := func(m *stan.Msg) {
+		msgCh <- m
+	}
+	if _, err := sc.QueueSubscribe("foo", "group", lastMsgCb, stan.DeliverAllAvailable()); err != nil {
+		t.Fatalf("Unexpected error on subscribe: %v", err)
+	}
+	// Wait for msg3 or an error to occur
+	gotIt := false
+	select {
+	case m := <-msgCh:
+		if m.Sequence != 3 {
+			t.Fatalf("Unexpected message: %v", m)
+		} else {
+			gotIt = true
+			break
+		}
+	case <-time.After(time.Second):
+		// Wait for a bit to see if we receive extraneous messages
+		break
+	}
+	if !gotIt {
+		t.Fatal("Did not get message 3")
+	}
+}


### PR DESCRIPTION
- Transfer all unacknowledged messages to rest of the group.
- When last queue subscriber is removed, group is removed.
- Update group's LastSent on disk if leaving member was
 carrying the value.

Resolves #157