### PR TITLE
[FIXED] Remove non durable subscription from store on connection close

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -322,11 +322,12 @@ func (ss *subStore) Remove(sub *subState, force bool) {
 	if sub.DurableName != "" {
 		durableKey = sub.durableKey()
 	}
+	nondurable := durableKey == ""
 	subid := sub.ID
 	store := sub.store
 	sub.Unlock()
 
-	if force {
+	if nondurable || force {
 		// Delete from storage
 		store.DeleteSub(subid)
 	}


### PR DESCRIPTION
Even without call to Unsubscribe() a non durable subscription should
be removed from the store when its connection is closed.

Resolves #159