### PR TITLE
Many changes for next release

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,19 @@ The NATS Streaming Server embeds a NATS Server. Starting the server with no argu
 
 ```
 > ./nats-streaming-server
-[73781] 2016/06/20 21:06:52.753188 [INF] Starting nats-streaming-server[test-cluster] version 0.0.1.alpha
-[73781] 2016/06/20 21:06:52.754773 [INF] Starting nats-server version 0.8.2
-[73781] 2016/06/20 21:06:52.754782 [INF] Listening for client connections on localhost:4222
-[73781] 2016/06/20 21:06:52.757134 [INF] Server is ready
-[73781] 2016/06/20 21:06:53.094875 [INF] STAN: Message store is MEMORY
-[73781] 2016/06/20 21:06:53.094887 [INF] STAN: Maximum of 1000000 will be stored
+[53638] 2016/10/18 10:05:15.718693 [INF] Starting nats-streaming-server[test-cluster] version 0.3.0
+[53638] 2016/10/18 10:05:15.721356 [INF] Starting nats-server version 0.9.4
+[53638] 2016/10/18 10:05:15.721366 [INF] Listening for client connections on 0.0.0.0:4222
+[53638] 2016/10/18 10:05:15.721941 [INF] Server is ready
+[53638] 2016/10/18 10:05:16.063714 [INF] STAN: Message store is MEMORY
+[53638] 2016/10/18 10:05:16.063726 [INF] STAN: --------- Store Limits ---------
+[53638] 2016/10/18 10:05:16.063732 [INF] STAN: Channels:                  100 *
+[53638] 2016/10/18 10:05:16.063734 [INF] STAN: -------- channels limits -------
+[53638] 2016/10/18 10:05:16.063738 [INF] STAN:   Subscriptions:          1000 *
+[53638] 2016/10/18 10:05:16.063741 [INF] STAN:   Messages     :       1000000 *
+[53638] 2016/10/18 10:05:16.063786 [INF] STAN:   Bytes        :     976.56 MB *
+[53638] 2016/10/18 10:05:16.063789 [INF] STAN:   Age          :     unlimited *
+[53638] 2016/10/18 10:05:16.063791 [INF] STAN: --------------------------------
 ```
 
 The server will be started and listening for client connections on port 4222 (the default) from all available interfaces. The logs will be displayed to stderr as shown above.
@@ -39,29 +46,47 @@ Note that you do not need to start the embedded NATS Server. It is started autom
 
 ## Configuring
 
+### Command line arguments
+
 The NATS Streaming Server accepts command line arguments to control its behavior. There is a set of parameters specific to the NATS Streaming Server and some to the embedded NATS Server.
 
 ```
+Usage: nats-streaming-server [options]
+
 Streaming Server Options:
-    -cluster_id  <cluster ID>    Cluster ID (default: test-cluster)
-    -store <type>                Store type: MEMORY|FILE (default: MEMORY)
-    -dir <directory>             For FILE store type, this is the root directory
-    -max_channels <number>       Max number of channels
-    -max_subs <number>           Max number of subscriptions per channel
-    -max_msgs <number>           Max number of messages per channel
-    -max_bytes <number>          Max messages total size per channel
+    -cid, --cluster_id  <cluster ID> Cluster ID (default: test-cluster)
+    -st,  --store <type>             Store type: MEMORY|FILE (default: MEMORY)
+          --dir <directory>          For FILE store type, this is the root directory
+    -mc,  --max_channels <number>    Max number of channels (0 for unlimited)
+    -msu, --max_subs <number>        Max number of subscriptions per channel (0 for unlimited)
+    -mm,  --max_msgs <number>        Max number of messages per channel (0 for unlimited)
+    -mb,  --max_bytes <number>       Max messages total size per channel (0 for unlimited)
+    -ma,  --max_age <seconds>        Max duration a message can be stored ("0s" for unlimited)
+    -ns,  --nats_server <url>        Connect to this external NATS Server (embedded otherwise)
+    -sc,  --stan_config <file>       Streaming server configuration file
+
+Streaming Server File Store Options:
+    --file_compact_enabled           Enable file compaction
+    --file_compact_frag              File fragmentation threshold for compaction
+    --file_compact_interval <int>    Minimum interval (in seconds) between file compactions
+    --file_compact_min_size <int>    Minimum file size for compaction
+    --file_buffer_size <int>         File buffer size (in bytes)
+    --file_crc                       Enable file CRC-32 checksum
+    --file_crc_poly <int>            Polynomial used to make the table used for CRC-32 checksum
+    --file_sync                      Enable File.Sync on Flush
+    --file_cache                     Enable messages caching
 
 Streaming Server TLS Options:
-    -secure                      Use a TLS connection to the NATS server without
-	                             verification; weaker than specifying certificates.
-    -tls_client_key              Client key for the streaming server
-    -tls_client_cert             Client certificate for the streaming server
-    -tls_client_cacert           Client certificate CA for the streaming server
+    -secure                          Use a TLS connection to the NATS server without
+                                     verification; weaker than specifying certificates.
+    -tls_client_key                  Client key for the streaming server
+    -tls_client_cert                 Client certificate for the streaming server
+    -tls_client_cacert               Client certificate CA for the streaming server
 
 Streaming Server Logging Options:
-    -SD, --stan_debug            Enable STAN debugging output
-    -SV, --stan_trace            Trace the raw STAN protocol
-    -SDV                         Debug and trace STAN
+    -SD, --stan_debug                Enable STAN debugging output
+    -SV, --stan_trace                Trace the raw STAN protocol
+    -SDV                             Debug and trace STAN
     (See additional NATS logging options below)
 
 Embedded NATS Server Options:
@@ -102,6 +127,212 @@ Common Options:
     -v, --version                    Show version
         --help_tls                   TLS help.
 ```
+
+### Configuration file
+
+You can use a configuration file to configure the options specific to the NATS Streaming server.
+
+Use the `-sc` or `-stan_config` command line parameter to specify the file to use.
+
+Note the order in which options are applied during the start of a NATS Streaming server:
+
+1. Start with some reasonable default options.
+2. If a configuration file is specified, override those options
+  with all options defined in the file. This include options that are defined
+  but have no value specified. In this case, the zero value for the type of the
+  option will be used.
+3. Any command line parameter override all of the previous set options.
+
+In general the configuration parameters are the same as the command line arguments.
+But see an example configuration file below for more details:
+
+```
+# Define the cluster name.
+# Can be id, cid or cluster_id
+id: "my_cluster_name"
+
+# Store type
+# Can be st, store, store_type or StoreType
+# Possible values are file or memory (case insensitive)
+store: "file"
+
+# When using a file store, need to provide the root directory.
+# Can be dir or datastore
+dir: "/path/to/storage"
+
+# Debug flag.
+# Can be sd or stand_debug
+sd: false
+
+# Trace flag.
+# Can be sv or stan_trace
+sv: false
+
+# If specified, connects to an external NATS server, otherwise
+# starts and embedded server.
+# Can be ns, nats_server or nats_server_url
+ns: "nats://localhost:4222"
+
+# This flag creates a TLS connection to the server but without
+# the need to use a TLS configuration (no NATS server certificate verification).
+secure: false
+
+# Define store limits.
+# Can be limits, store_limits or StoreLimits.
+# See Store Limits chapter below for more details.
+store_limits: {
+    # Define maximum number of channels.
+    # Can be mc, max_channels or MaxChannels
+    max_channels: 100
+
+    # Define maximum number of subscriptions per channel.
+    # Can be msu, max_sybs, max_subscriptions or MaxSubscriptions
+    max_subs: 100
+
+    # Define maximum number of messages per channel.
+    # Can be mm, max_msgs, MaxMsgs, max_count or MaxCount
+    max_msgs: 10000
+
+    # Define total size of messages per channel.
+    # Can be mb, max_bytes or MaxBytes. Expressed in bytes
+    max_bytes: 10240000
+
+    # Define how long messages can stay in the log, expressed
+    # as a duration, for example: "24h" or "1h15m", etc...
+    # Can be ma, max_age, MaxAge.
+    max_age: "24h"
+}
+
+# TLS configuration.
+tls: {
+    client_cert: "/path/to/client/cert_file"
+    client_key: "/path/to/client/key_file"
+    # Can be client_ca or client_cacert
+    client_ca: "/path/to/client/ca_file"
+}
+
+# Configure file store specific options.
+# Can be file or file_options
+file: {
+    # Enable/disable file compaction.
+    # Can be compact or compact_enabled
+    compact: true
+
+    # Define compaction threshold (in percentage)
+    # Can be compact_frag or compact_fragmemtation
+    compact_frag: 50
+
+    # Define minimum interval between attempts to compact files.
+    # Expressed in seconds
+    compact_interval: 300
+
+    # Define minimum size of a file before compaction can be attempted
+    # Expressed in bytes
+    compact_min_size: 10485760
+
+    # Define the size of buffers that can be used to buffer write operations.
+    # Expressed in bytes
+    buffer_size: 2097152
+
+    # Define if CRC of records should be computed on reads.
+    # Can be crc or do_crc
+    crc: true
+
+    # You can select the CRC polynomial. Note that changing the value
+    # after records have been persisted would result in server failing
+    # to start complaining about data corruption.
+    crc_poly: 3988292384
+
+    # Define if server should perform "file sync" operations during a flush.
+    # Can be sync, do_sync, sync_on_flush
+    sync: true
+
+    # Enable/disable caching of messages once stored. If enabled, it saves
+    # on disk reads (improved performance at the expense of memory).
+    # Can be cache, do_cache, cache_msgs
+    cache: true
+}
+```
+
+### Store Limits
+
+:warning: Although it is possible to configure *Maximum Age* limits, those limits
+are currently not implemented in the server.
+
+The `store_limits` section in the configuration file (or the command line parameters
+`-mc`, `-mm`, etc..) allow you to configure the global limits.
+
+These limits somewhat offer some upper bound on the size of the storage. By multiplying
+the limits per channel with the maximum number of channels, you will get a total limit.
+
+It is also possible to define specific limits per channel. Here is how:
+
+```
+...
+store_limits: {
+    # Override some global limits
+    max_channels: 10
+    max_msgs: 10000
+    max_bytes: 10485760
+    max_age: "1h"
+
+    # Per channel configuration.
+    # Can be channels, channels_limits, per_channel, per_channel_limits or ChannelsLimits
+    channels: {
+        # Configuration for channel "foo"
+        "foo": {
+            # Possible options are the same than in the store_limits section
+            # except for max_channels.
+            max_msgs: 300
+            max_subs: 50
+        }
+        "bar": {
+            max_msgs:50
+            max_bytes:1000
+        }
+    }
+}
+...
+```
+
+Note the following restrictions:
+- The total of channels configured must be less than the store's maximum number of channels.
+- No limit can be negative.
+- No limit can be greater than its corresponding global limit.
+
+### Limits inheritance
+
+Global limits that are not specified (configuration file or command line parameters)
+are inherited from default limits selected by the server.
+
+Per-channel limits that are not explicitly configured inherit from the corresponding
+global limit (which can itself be inherited from default limit).
+
+On startup the server displays the store limits. Notice the `*` at the right of a
+limit to indicate that the limit was inherited (either from global or default limits).
+This is what would be displayed with the above store limits configuration:
+
+```
+[53904] 2016/10/18 10:10:50.581799 [INF] STAN: --------- Store Limits ---------
+[53904] 2016/10/18 10:10:50.581807 [INF] STAN: Channels:                   10
+[53904] 2016/10/18 10:10:50.581810 [INF] STAN: -------- channels limits -------
+[53904] 2016/10/18 10:10:50.581816 [INF] STAN:   Subscriptions:          1000 *
+[53904] 2016/10/18 10:10:50.581821 [INF] STAN:   Messages     :         10000
+[53904] 2016/10/18 10:10:50.581846 [INF] STAN:   Bytes        :      10.00 MB
+[53904] 2016/10/18 10:10:50.581859 [INF] STAN:   Age          :        1h0m0s
+[53904] 2016/10/18 10:10:50.581867 [INF] STAN: Channel: "foo"
+[53904] 2016/10/18 10:10:50.581872 [INF] STAN:   Subscriptions:            50
+[53904] 2016/10/18 10:10:50.581877 [INF] STAN:   Messages     :           300
+[53904] 2016/10/18 10:10:50.581883 [INF] STAN:   Bytes        :      10.00 MB *
+[53904] 2016/10/18 10:10:50.581889 [INF] STAN:   Age          :        1h0m0s *
+[53904] 2016/10/18 10:10:50.581893 [INF] STAN: Channel: "bar"
+[53904] 2016/10/18 10:10:50.581897 [INF] STAN:   Subscriptions:          1000 *
+[53904] 2016/10/18 10:10:50.581902 [INF] STAN:   Messages     :            50
+[53904] 2016/10/18 10:10:50.581916 [INF] STAN:   Bytes        :        1000 B
+[53904] 2016/10/18 10:10:50.581926 [INF] STAN:   Age          :        1h0m0s *
+[53904] 2016/10/18 10:10:50.581930 [INF] STAN: --------------------------------
+```
+
 
 ## Securing NATS Streaming Server
 

--- a/README.md
+++ b/README.md
@@ -256,9 +256,6 @@ file: {
 
 ### Store Limits
 
-:warning: Although it is possible to configure *Maximum Age* limits, those limits
-are currently not implemented in the server.
-
 The `store_limits` section in the configuration file (or the command line parameters
 `-mc`, `-mm`, etc..) allow you to configure the global limits.
 

--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -144,6 +144,7 @@ func parseFlags() (*stand.Options, *natsd.Options) {
 	flag.BoolVar(&stanOpts.FileStoreOpts.DoCRC, "file_crc", stores.DefaultFileStoreOptions.DoCRC, "Enable file CRC-32 checksum")
 	flag.Int64Var(&stanOpts.FileStoreOpts.CRCPolynomial, "file_crc_poly", stores.DefaultFileStoreOptions.CRCPolynomial, "Polynomial used to make the table used for CRC-32 checksum")
 	flag.BoolVar(&stanOpts.FileStoreOpts.DoSync, "file_sync", stores.DefaultFileStoreOptions.DoSync, "Enable File.Sync on Flush")
+	flag.BoolVar(&stanOpts.FileStoreOpts.CacheMsgs, "file_cache", stores.DefaultFileStoreOptions.CacheMsgs, "Enable messages caching")
 	flag.IntVar(&stanOpts.IOBatchSize, "io_batch_size", stand.DefaultIOBatchSize, "# of message to batch in flushing io")
 	flag.Int64Var(&stanOpts.IOSleepTime, "io_sleep_time", stand.DefaultIOSleepTime, "duration the server waits for more messages (in micro-seconds, 0 to disable)")
 	// NATS options

--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -4,12 +4,11 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"runtime"
 	"strings"
-
-	"fmt"
 
 	natsd "github.com/nats-io/gnatsd/server"
 	stand "github.com/nats-io/nats-streaming-server/server"
@@ -117,14 +116,14 @@ func parseFlags() (*stand.Options, *natsd.Options) {
 	flag.StringVar(&stanOpts.StoreType, "store", stores.TypeMemory, fmt.Sprintf("Store type: (%s|%s)", stores.TypeMemory, stores.TypeFile))
 	flag.StringVar(&stanOpts.StoreType, "st", stores.TypeMemory, fmt.Sprintf("Store type: (%s|%s)", stores.TypeMemory, stores.TypeFile))
 	flag.StringVar(&stanOpts.FilestoreDir, "dir", "", "Root directory")
-	flag.IntVar(&stanOpts.MaxChannels, "max_channels", stand.DefaultChannelLimit, "Max number of channels")
-	flag.IntVar(&stanOpts.MaxChannels, "mc", stand.DefaultChannelLimit, "Max number of channels")
-	flag.IntVar(&stanOpts.MaxSubscriptions, "max_subs", stand.DefaultSubStoreLimit, "Max number of subscriptions per channel")
-	flag.IntVar(&stanOpts.MaxSubscriptions, "msu", stand.DefaultSubStoreLimit, "Max number of subscriptions per channel")
-	flag.IntVar(&stanOpts.MaxMsgs, "max_msgs", stand.DefaultMsgStoreLimit, "Max number of messages per channel")
-	flag.IntVar(&stanOpts.MaxMsgs, "mm", stand.DefaultMsgStoreLimit, "Max number of messages per channel")
-	flag.Uint64Var(&stanOpts.MaxBytes, "max_bytes", stand.DefaultMsgSizeStoreLimit, "Max messages total size per channel")
-	flag.Uint64Var(&stanOpts.MaxBytes, "mb", stand.DefaultMsgSizeStoreLimit, "Max messages total size per channel")
+	flag.IntVar(&stanOpts.MaxChannels, "max_channels", stand.DefaultChannelLimit, "Max number of channels (-1 for unlimited)")
+	flag.IntVar(&stanOpts.MaxChannels, "mc", stand.DefaultChannelLimit, "Max number of channels (-1 for unlimited)")
+	flag.IntVar(&stanOpts.MaxSubscriptions, "max_subs", stand.DefaultSubStoreLimit, "Max number of subscriptions per channel (-1 for unlimited)")
+	flag.IntVar(&stanOpts.MaxSubscriptions, "msu", stand.DefaultSubStoreLimit, "Max number of subscriptions per channel (-1 for unlimited)")
+	flag.IntVar(&stanOpts.MaxMsgs, "max_msgs", stand.DefaultMsgStoreLimit, "Max number of messages per channel (-1 for unlimited)")
+	flag.IntVar(&stanOpts.MaxMsgs, "mm", stand.DefaultMsgStoreLimit, "Max number of messages per channel (-1 for unlimited)")
+	flag.Int64Var(&stanOpts.MaxBytes, "max_bytes", stand.DefaultMsgSizeStoreLimit, "Max messages total size per channel (-1 for unlimited)")
+	flag.Int64Var(&stanOpts.MaxBytes, "mb", stand.DefaultMsgSizeStoreLimit, "Max messages total size per channel (-1 for unlimited)")
 	flag.BoolVar(&stanOpts.Debug, "SD", false, "Enable STAN Debug logging.")
 	flag.BoolVar(&stanOpts.Debug, "stan_debug", false, "Enable STAN Debug logging.")
 	flag.BoolVar(&stanOpts.Trace, "SV", false, "Enable STAN Trace logging.")

--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -5,6 +5,7 @@ rm -rf ./cov
 mkdir cov
 go test -v -covermode=atomic -coverprofile=./cov/server.out ./server
 go test -v -covermode=atomic -coverprofile=./cov/stores.out ./stores
+go test -v -covermode=atomic -coverprofile=./cov/stores_nocaching.out -run=TestFS ./stores -cache=false
 go test -v -covermode=atomic -coverprofile=./cov/util.out ./util
 gocovmerge ./cov/*.out > acc.out
 rm -rf ./cov

--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -5,8 +5,9 @@ rm -rf ./cov
 mkdir cov
 go test -v -covermode=atomic -coverprofile=./cov/server.out ./server
 go test -v -covermode=atomic -coverprofile=./cov/stores.out ./stores
-go test -v -covermode=atomic -coverprofile=./cov/stores_nocaching.out -run=TestFS ./stores -no_cache
-go test -v -covermode=atomic -coverprofile=./cov/stores_nobuffer.out -run=TestFS ./stores -no_buffer
+go test -v -covermode=atomic -coverprofile=./cov/stores_no_cache.out -run=TestFS ./stores -no_cache
+go test -v -covermode=atomic -coverprofile=./cov/stores_no_buffer.out -run=TestFS ./stores -no_buffer
+go test -v -covermode=atomic -coverprofile=./cov/stores_no_cache_buffer.out -run=TestFS ./stores -no_cache -no_buffer
 go test -v -covermode=atomic -coverprofile=./cov/util.out ./util
 gocovmerge ./cov/*.out > acc.out
 rm -rf ./cov

--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -5,7 +5,8 @@ rm -rf ./cov
 mkdir cov
 go test -v -covermode=atomic -coverprofile=./cov/server.out ./server
 go test -v -covermode=atomic -coverprofile=./cov/stores.out ./stores
-go test -v -covermode=atomic -coverprofile=./cov/stores_nocaching.out -run=TestFS ./stores -cache=false
+go test -v -covermode=atomic -coverprofile=./cov/stores_nocaching.out -run=TestFS ./stores -no_cache
+go test -v -covermode=atomic -coverprofile=./cov/stores_nobuffer.out -run=TestFS ./stores -no_buffer
 go test -v -covermode=atomic -coverprofile=./cov/util.out ./util
 gocovmerge ./cov/*.out > acc.out
 rm -rf ./cov

--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -3,12 +3,12 @@
 
 rm -rf ./cov
 mkdir cov
-go test -v -covermode=atomic -coverprofile=./cov/server.out ./server
-go test -v -covermode=atomic -coverprofile=./cov/stores.out ./stores
-go test -v -covermode=atomic -coverprofile=./cov/stores_no_cache.out -run=TestFS ./stores -no_cache
-go test -v -covermode=atomic -coverprofile=./cov/stores_no_buffer.out -run=TestFS ./stores -no_buffer
-go test -v -covermode=atomic -coverprofile=./cov/stores_no_cache_buffer.out -run=TestFS ./stores -no_cache -no_buffer
-go test -v -covermode=atomic -coverprofile=./cov/util.out ./util
+go test -v -covermode=count -coverprofile=./cov/server.out ./server
+go test -v -covermode=count -coverprofile=./cov/stores.out ./stores
+go test -v -covermode=count -coverprofile=./cov/stores_no_cache.out -run=TestFS ./stores -no_cache
+go test -v -covermode=count -coverprofile=./cov/stores_no_buffer.out -run=TestFS ./stores -no_buffer
+go test -v -covermode=count -coverprofile=./cov/stores_no_cache_buffer.out -run=TestFS ./stores -no_cache -no_buffer
+go test -v -covermode=count -coverprofile=./cov/util.out ./util
 gocovmerge ./cov/*.out > acc.out
 rm -rf ./cov
 

--- a/server/conf.go
+++ b/server/conf.go
@@ -1,0 +1,272 @@
+// Copyright 2016 Apcera Inc. All rights reserved.
+
+package server
+
+import (
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/nats-io/gnatsd/conf"
+	"github.com/nats-io/nats-streaming-server/stores"
+)
+
+// ProcessConfigFile parses the configuration file `configFile` and updates
+// the given Streaming options `opts`.
+func ProcessConfigFile(configFile string, opts *Options) error {
+	data, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return err
+	}
+	m, err := conf.Parse(string(data))
+	if err != nil {
+		return err
+	}
+	for k, v := range m {
+		name := strings.ToLower(k)
+		switch name {
+		case "id", "cid", "cluster_id":
+			if err := checkType(k, reflect.String, v); err != nil {
+				return err
+			}
+			opts.ID = v.(string)
+		case "discover_prefix":
+			if err := checkType(k, reflect.String, v); err != nil {
+				return err
+			}
+			opts.DiscoverPrefix = v.(string)
+		case "st", "store_type", "store", "storetype":
+			if err := checkType(k, reflect.String, v); err != nil {
+				return err
+			}
+			switch strings.ToUpper(v.(string)) {
+			case stores.TypeFile:
+				opts.StoreType = stores.TypeFile
+			case stores.TypeMemory:
+				opts.StoreType = stores.TypeMemory
+			default:
+				return fmt.Errorf("Unknown store type: %v", v.(string))
+			}
+		case "dir", "datastore":
+			if err := checkType(k, reflect.String, v); err != nil {
+				return err
+			}
+			opts.FilestoreDir = v.(string)
+		case "sd", "stan_debug":
+			if err := checkType(k, reflect.Bool, v); err != nil {
+				return err
+			}
+			opts.Debug = v.(bool)
+		case "sv", "stan_trace":
+			if err := checkType(k, reflect.Bool, v); err != nil {
+				return err
+			}
+			opts.Trace = v.(bool)
+		case "ns", "nats_server", "nats_server_url":
+			if err := checkType(k, reflect.String, v); err != nil {
+				return err
+			}
+			opts.NATSServerURL = v.(string)
+		case "secure":
+			if err := checkType(k, reflect.Bool, v); err != nil {
+				return err
+			}
+			opts.Secure = v.(bool)
+		case "tls":
+			if err := parseTLS(v, opts); err != nil {
+				return err
+			}
+		case "limits", "store_limits", "storelimits":
+			if err := parseStoreLimits(v, opts); err != nil {
+				return err
+			}
+		case "file", "file_options":
+			if err := parseFileOptions(v, opts); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// checkType returns a formatted error if `v` is not of the expected kind.
+func checkType(name string, kind reflect.Kind, v interface{}) error {
+	actualKind := reflect.TypeOf(v).Kind()
+	if actualKind != kind {
+		return fmt.Errorf("Parameter %q value is expected to be %v, got %v",
+			name, kind.String(), actualKind.String())
+	}
+	return nil
+}
+
+// parseTLS updates `opts` with TLS config
+func parseTLS(itf interface{}, opts *Options) error {
+	m, ok := itf.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("Expected TLS to be a map/struct, got %v", itf)
+	}
+	for k, v := range m {
+		name := strings.ToLower(k)
+		switch name {
+		case "client_cert":
+			if err := checkType(k, reflect.String, v); err != nil {
+				return err
+			}
+			opts.ClientCert = v.(string)
+		case "client_key":
+			if err := checkType(k, reflect.String, v); err != nil {
+				return err
+			}
+			opts.ClientKey = v.(string)
+		case "client_ca", "client_cacert":
+			if err := checkType(k, reflect.String, v); err != nil {
+				return err
+			}
+			opts.ClientCA = v.(string)
+		}
+	}
+	return nil
+}
+
+// parseStoreLimits updates `opts` with store limits
+func parseStoreLimits(itf interface{}, opts *Options) error {
+	m, ok := itf.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("Expected store limits to be a map/struct, got %v", itf)
+	}
+	for k, v := range m {
+		name := strings.ToLower(k)
+		switch name {
+		case "mc", "max_channels", "maxchannels":
+			if err := checkType(k, reflect.Int64, v); err != nil {
+				return err
+			}
+			opts.MaxChannels = int(v.(int64))
+		case "channels", "channels_limits", "channelslimits", "per_channel", "per_channel_limits":
+			if err := parsePerChannelLimits(v, opts); err != nil {
+				return err
+			}
+		default:
+			// Check for the global limits (MaxMsgs, MaxBytes, etc..)
+			if err := parseChannelLimits(&opts.ChannelLimits, k, name, v); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// parseChannelLimits updates `cl` with channel limits.
+func parseChannelLimits(cl *stores.ChannelLimits, k, name string, v interface{}) error {
+	switch name {
+	case "msu", "max_subs", "max_subscriptions", "maxsubscriptions":
+		if err := checkType(k, reflect.Int64, v); err != nil {
+			return err
+		}
+		cl.MaxSubscriptions = int(v.(int64))
+	case "mm", "max_msgs", "maxmsgs", "max_count", "maxcount":
+		if err := checkType(k, reflect.Int64, v); err != nil {
+			return err
+		}
+		cl.MaxMsgs = int(v.(int64))
+	case "mb", "max_bytes", "maxbytes":
+		if err := checkType(k, reflect.Int64, v); err != nil {
+			return err
+		}
+		cl.MaxBytes = v.(int64)
+	case "ma", "max_age", "maxage":
+		if err := checkType(k, reflect.String, v); err != nil {
+			return err
+		}
+		dur, err := time.ParseDuration(v.(string))
+		if err != nil {
+			return err
+		}
+		cl.MaxAge = dur
+	}
+	return nil
+}
+
+// parsePerChannelLimits updates `opts` with per channel limits.
+func parsePerChannelLimits(itf interface{}, opts *Options) error {
+	m, ok := itf.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("Expected per channel limits to be a map/struct, got %v", itf)
+	}
+	for channelName, limits := range m {
+		limitsMap, ok := limits.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("Expected channel limits to be a map/struct, got %v", limits)
+		}
+		cl := &stores.ChannelLimits{}
+		for k, v := range limitsMap {
+			name := strings.ToLower(k)
+			if err := parseChannelLimits(cl, k, name, v); err != nil {
+				return err
+			}
+		}
+		sl := &opts.StoreLimits
+		sl.AddPerChannel(channelName, cl)
+	}
+	return nil
+}
+
+func parseFileOptions(itf interface{}, opts *Options) error {
+	m, ok := itf.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("Expected file options to be a map/struct, got %v", itf)
+	}
+	for k, v := range m {
+		name := strings.ToLower(k)
+		switch name {
+		case "compact", "compact_enabled":
+			if err := checkType(k, reflect.Bool, v); err != nil {
+				return err
+			}
+			opts.FileStoreOpts.CompactEnabled = v.(bool)
+		case "compact_frag", "compact_fragmentation":
+			if err := checkType(k, reflect.Int64, v); err != nil {
+				return err
+			}
+			opts.FileStoreOpts.CompactFragmentation = int(v.(int64))
+		case "compact_interval":
+			if err := checkType(k, reflect.Int64, v); err != nil {
+				return err
+			}
+			opts.FileStoreOpts.CompactInterval = int(v.(int64))
+		case "compact_min_size":
+			if err := checkType(k, reflect.Int64, v); err != nil {
+				return err
+			}
+			opts.FileStoreOpts.CompactMinFileSize = v.(int64)
+		case "buffer_size":
+			if err := checkType(k, reflect.Int64, v); err != nil {
+				return err
+			}
+			opts.FileStoreOpts.BufferSize = int(v.(int64))
+		case "crc", "do_crc":
+			if err := checkType(k, reflect.Bool, v); err != nil {
+				return err
+			}
+			opts.FileStoreOpts.DoCRC = v.(bool)
+		case "crc_poly":
+			if err := checkType(k, reflect.Int64, v); err != nil {
+				return err
+			}
+			opts.FileStoreOpts.CRCPolynomial = v.(int64)
+		case "sync", "do_sync", "sync_on_flush":
+			if err := checkType(k, reflect.Bool, v); err != nil {
+				return err
+			}
+			opts.FileStoreOpts.DoSync = v.(bool)
+		case "cache", "do_cache", "cache_msgs":
+			if err := checkType(k, reflect.Bool, v); err != nil {
+				return err
+			}
+			opts.FileStoreOpts.CacheMsgs = v.(bool)
+		}
+	}
+	return nil
+}

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -5,6 +5,7 @@ package server
 import (
 	"io/ioutil"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -138,6 +139,9 @@ func TestParseConfig(t *testing.T) {
 }
 
 func TestParsePermError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
 	tmpDir, err := ioutil.TempDir("", "streaming")
 	if err != nil {
 		t.Fatalf("Could not create tmp dir: %v", err)

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -1,0 +1,252 @@
+// Copyright 2016 Apcera Inc. All rights reserved.
+
+package server
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-streaming-server/stores"
+)
+
+const (
+	mapStructErr = "map/struct"
+	wrongTypeErr = "value is expected to be"
+	wrongTimeErr = "time: "
+)
+
+func TestParseConfig(t *testing.T) {
+	opts := Options{}
+	if err := ProcessConfigFile("../test/configs/test_parse.conf", &opts); err != nil {
+		t.Fatalf("Unexpected error on config file parsing: %v", err)
+	}
+	// This test depends on the expected values in the config file.
+	// Any modification there should be reflected here.
+	if opts.ID != "me" {
+		t.Fatalf("Expected ID to be %q, got %q", "me", opts.ID)
+	}
+	if opts.DiscoverPrefix != "discover" {
+		t.Fatalf("Expected DiscoverPrefix to be %q, got %q", "discover", opts.DiscoverPrefix)
+	}
+	if opts.StoreType != stores.TypeFile {
+		t.Fatalf("Expected StoreType to be %q, got %q", stores.TypeFile, opts.StoreType)
+	}
+	if opts.FilestoreDir != "/path/to/datastore" {
+		t.Fatalf("Expected FilestoreDir to be %q, got %q", "file", opts.FilestoreDir)
+	}
+	if !opts.Debug {
+		t.Fatalf("Expected Debug to be true, got false")
+	}
+	if !opts.Trace {
+		t.Fatalf("Expected Trace to be true, got false")
+	}
+	if !opts.Secure {
+		t.Fatalf("Expected Secure to be true, got false")
+	}
+	if opts.NATSServerURL != "nats://localhost:4222" {
+		t.Fatalf("Expected NATSServerURL to be %q, got %q", "nats://localhost:4222", opts.NATSServerURL)
+	}
+	if opts.ClientCert != "/path/to/client/cert_file" {
+		t.Fatalf("Expected ClientCert to be %q, got %q", "/path/to/client/cert_file", opts.ClientCert)
+	}
+	if opts.ClientKey != "/path/to/client/key_file" {
+		t.Fatalf("Expected ClientKey to be %q, got %q", "/path/to/client/key_file", opts.ClientKey)
+	}
+	if opts.ClientCA != "/path/to/client/ca_file" {
+		t.Fatalf("Expected ClientCA to be %q, got %q", "/path/to/client/ca_file", opts.ClientCA)
+	}
+	if !opts.FileStoreOpts.CompactEnabled {
+		t.Fatalf("Expected CompactEnabled to be true, got false")
+	}
+	if !opts.FileStoreOpts.DoCRC {
+		t.Fatalf("Expected DoCRC to be true, got false")
+	}
+	if !opts.FileStoreOpts.DoSync {
+		t.Fatalf("Expected DoSync to be true, got false")
+	}
+	if !opts.FileStoreOpts.CacheMsgs {
+		t.Fatalf("Expected CacheMsgs to be true, got false")
+	}
+	if opts.FileStoreOpts.CompactFragmentation != 1 {
+		t.Fatalf("Expected CompactFragmentation to be 1, got %v", opts.FileStoreOpts.CompactFragmentation)
+	}
+	if opts.FileStoreOpts.CompactInterval != 2 {
+		t.Fatalf("Expected CompactInterval to be 1, got %v", opts.FileStoreOpts.CompactInterval)
+	}
+	if opts.FileStoreOpts.CompactMinFileSize != 3 {
+		t.Fatalf("Expected CompactMinFileSize to be 3, got %v", opts.FileStoreOpts.CompactMinFileSize)
+	}
+	if opts.FileStoreOpts.BufferSize != 4 {
+		t.Fatalf("Expected BufferSize to be 4, got %v", opts.FileStoreOpts.BufferSize)
+	}
+	if opts.FileStoreOpts.CRCPolynomial != 5 {
+		t.Fatalf("Expected CRCPolynomial to be 5, got %v", opts.FileStoreOpts.CRCPolynomial)
+	}
+	if opts.MaxChannels != 11 {
+		t.Fatalf("Expected MaxChannels to be 11, got %v", opts.MaxChannels)
+	}
+	if opts.MaxMsgs != 12 {
+		t.Fatalf("Expected MaxMsgs to be 12, got %v", opts.MaxMsgs)
+	}
+	if opts.MaxBytes != 13 {
+		t.Fatalf("Expected MaxBytes to be 13, got %v", opts.MaxBytes)
+	}
+	if opts.MaxAge != 14*time.Second {
+		t.Fatalf("Expected MaxAge to be 14, got %v", opts.MaxAge)
+	}
+	if opts.MaxSubscriptions != 15 {
+		t.Fatalf("Expected MaxSubscriptions to be 15, got %v", opts.MaxSubscriptions)
+	}
+	if len(opts.PerChannel) != 2 {
+		t.Fatalf("Expected PerChannel map to have 2 elements, got %v", len(opts.PerChannel))
+	}
+	cl, ok := opts.PerChannel["foo"]
+	if !ok {
+		t.Fatal("Expected channel foo to be found")
+	}
+	if cl.MaxMsgs != 1 {
+		t.Fatalf("Expected MaxMsgs to be 1, got %v", cl.MaxMsgs)
+	}
+	if cl.MaxBytes != 2 {
+		t.Fatalf("Expected MaxBytes to be 2, got %v", cl.MaxBytes)
+	}
+	if cl.MaxAge != 3*time.Second {
+		t.Fatalf("Expected MaxAge to be 3, got %v", cl.MaxAge)
+	}
+	if cl.MaxSubscriptions != 4 {
+		t.Fatalf("Expected MaxSubscriptions to be 4, got %v", cl.MaxSubscriptions)
+	}
+	cl, ok = opts.PerChannel["bar"]
+	if !ok {
+		t.Fatal("Expected channel bar to be found")
+	}
+	if cl.MaxMsgs != 5 {
+		t.Fatalf("Expected MaxMsgs to be 5, got %v", cl.MaxMsgs)
+	}
+	if cl.MaxBytes != 6 {
+		t.Fatalf("Expected MaxBytes to be 6, got %v", cl.MaxBytes)
+	}
+	if cl.MaxAge != 7*time.Second {
+		t.Fatalf("Expected MaxAge to be 7, got %v", cl.MaxAge)
+	}
+	if cl.MaxSubscriptions != 8 {
+		t.Fatalf("Expected MaxSubscriptions to be 8, got %v", cl.MaxSubscriptions)
+	}
+}
+
+func TestParsePermError(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "streaming")
+	if err != nil {
+		t.Fatalf("Could not create tmp dir: %v", err)
+	}
+	file, err := ioutil.TempFile(tmpDir, "config.conf")
+	os.Chmod(tmpDir, 0400)
+
+	defer file.Close()
+	defer os.RemoveAll(tmpDir)
+	defer os.Chmod(tmpDir, 0770)
+
+	if _, err := file.Write([]byte("id=me")); err != nil {
+		t.Fatalf("Error writing to file: %v", err)
+	}
+	opts := Options{}
+	if err := ProcessConfigFile(file.Name(), &opts); err == nil {
+		t.Fatal("Expected failure, did not get one")
+	}
+}
+
+func TestParseParserError(t *testing.T) {
+	confFile := "wrong_config.conf"
+	if err := ioutil.WriteFile(confFile, []byte("x=."), 0660); err != nil {
+		t.Fatalf("Unexpected error creating conf file: %v", err)
+	}
+	defer os.Remove(confFile)
+	opts := Options{}
+	if err := ProcessConfigFile(confFile, &opts); err == nil {
+		t.Fatal("Expected failure, did not get one")
+	}
+}
+
+func TestParseStoreType(t *testing.T) {
+	confFile := "wrong_config.conf"
+	if err := ioutil.WriteFile(confFile, []byte("store=memory"), 0660); err != nil {
+		t.Fatalf("Unexpected error creating conf file: %v", err)
+	}
+	defer os.Remove(confFile)
+	opts := Options{}
+	if err := ProcessConfigFile(confFile, &opts); err != nil {
+		t.Fatalf("Unexpected failure: %v", err)
+	}
+	if opts.StoreType != stores.TypeMemory {
+		t.Fatalf("Expected store type to be %v, got %v", stores.TypeMemory, opts.StoreType)
+	}
+	os.Remove(confFile)
+
+	if err := ioutil.WriteFile(confFile, []byte("store=xyz"), 0660); err != nil {
+		t.Fatalf("Unexpected error creating conf file: %v", err)
+	}
+	defer os.Remove(confFile)
+	opts = Options{}
+	if err := ProcessConfigFile(confFile, &opts); err == nil {
+		t.Fatal("Expected failure due to unkown store type, got none")
+	}
+}
+
+func TestParseMapStruct(t *testing.T) {
+	expectFailureFor(t, "store_limits: xxx", mapStructErr)
+	expectFailureFor(t, "store_limits: {\nchannels: xxx\n}", mapStructErr)
+	expectFailureFor(t, "store_limits: {\nchannels: {\n\"foo\": xxx\n}\n}", mapStructErr)
+	expectFailureFor(t, "tls: xxx", mapStructErr)
+	expectFailureFor(t, "file: xxx", mapStructErr)
+}
+
+func TestParseWrongTypes(t *testing.T) {
+	expectFailureFor(t, "id: 123", wrongTypeErr)
+	expectFailureFor(t, "discover_prefix: 123", wrongTypeErr)
+	expectFailureFor(t, "store: 123", wrongTypeErr)
+	expectFailureFor(t, "dir: 123", wrongTypeErr)
+	expectFailureFor(t, "sd: 123", wrongTypeErr)
+	expectFailureFor(t, "sv: 123", wrongTypeErr)
+	expectFailureFor(t, "ns: 123", wrongTypeErr)
+	expectFailureFor(t, "secure: 123", wrongTypeErr)
+	expectFailureFor(t, "store_limits:{max_channels:false}", wrongTypeErr)
+	expectFailureFor(t, "store_limits:{max_msgs:false}", wrongTypeErr)
+	expectFailureFor(t, "store_limits:{max_bytes:false}", wrongTypeErr)
+	expectFailureFor(t, "store_limits:{max_age:false}", wrongTypeErr)
+	expectFailureFor(t, "store_limits:{max_age:\"foo\"}", wrongTimeErr)
+	expectFailureFor(t, "store_limits:{max_subs:false}", wrongTypeErr)
+	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_msgs:false}}}", wrongTypeErr)
+	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_bytes:false}}}", wrongTypeErr)
+	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_age:\"1h:0m\"}}}", wrongTimeErr)
+	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_age:false}}}", wrongTypeErr)
+	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_subs:false}}}", wrongTypeErr)
+	expectFailureFor(t, "tls:{client_cert:123}", wrongTypeErr)
+	expectFailureFor(t, "tls:{client_key:123}", wrongTypeErr)
+	expectFailureFor(t, "tls:{client_ca:123}", wrongTypeErr)
+	expectFailureFor(t, "file:{compact:123}", wrongTypeErr)
+	expectFailureFor(t, "file:{compact_frag:false}", wrongTypeErr)
+	expectFailureFor(t, "file:{compact_interval:false}", wrongTypeErr)
+	expectFailureFor(t, "file:{compact_min_size:false}", wrongTypeErr)
+	expectFailureFor(t, "file:{buffer_size:false}", wrongTypeErr)
+	expectFailureFor(t, "file:{crc:123}", wrongTypeErr)
+	expectFailureFor(t, "file:{crc_poly:false}", wrongTypeErr)
+	expectFailureFor(t, "file:{sync:123}", wrongTypeErr)
+	expectFailureFor(t, "file:{cache:123}", wrongTypeErr)
+}
+
+func expectFailureFor(t *testing.T, content, errorMatch string) {
+	confFile := "wrong_config.conf"
+	if err := ioutil.WriteFile(confFile, []byte(content), 0660); err != nil {
+		t.Fatalf("Unexpected error creating conf file: %v", err)
+	}
+	defer os.Remove(confFile)
+	opts := Options{}
+	if err := ProcessConfigFile(confFile, &opts); err == nil {
+		t.Fatalf("For content: %q, expected failure, did not get one", content)
+	} else if !strings.Contains(err.Error(), errorMatch) {
+		t.Fatalf("Possible unexpected error: %v", err)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1880,7 +1880,7 @@ func (s *StanServer) assignAndStore(pm *pb.PubMsg) (*stores.ChannelStore, error)
 	if err != nil {
 		return nil, err
 	}
-	if _, err := cs.Msgs.Store(pm.Reply, pm.Data); err != nil {
+	if _, err := cs.Msgs.Store(pm.Data); err != nil {
 		return nil, err
 	}
 	return cs, nil

--- a/server/server.go
+++ b/server/server.go
@@ -2005,12 +2005,12 @@ func (s *StanServer) sendSubscriptionResponseErr(reply string, err error) {
 
 // Check for valid subjects
 func isValidSubject(subject string) bool {
-	tokens := strings.Split(subject, ".")
-	if len(tokens) == 0 {
+	if subject == "" {
 		return false
 	}
-	for _, token := range tokens {
-		if strings.ContainsAny(token, ">*") {
+	for i := 0; i < len(subject); i++ {
+		c := subject[i]
+		if c == '*' || c == '>' {
 			return false
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -1024,6 +1024,7 @@ func (s *StanServer) postRecoveryProcessing(recoveredClients []*stores.Client, r
 				sub.Unlock()
 				return err
 			}
+			sub.ackSub.SetPendingLimits(-1, -1)
 		}
 		sub.Unlock()
 	}
@@ -2348,6 +2349,7 @@ func (s *StanServer) processSubscriptionRequest(m *nats.Msg) {
 		sub.Unlock()
 		panic(fmt.Sprintf("Could not subscribe to ack subject, %v\n", err))
 	}
+	sub.ackSub.SetPendingLimits(-1, -1)
 	sub.Unlock()
 
 	// Create a non-error response
@@ -2549,7 +2551,7 @@ func (s *StanServer) ClusterID() string {
 
 // Shutdown will close our NATS connection and shutdown any embedded NATS server.
 func (s *StanServer) Shutdown() {
-	Debugf("STAN: Shutting down.")
+	Noticef("STAN: Shutting down.")
 
 	s.Lock()
 	if s.shutdown {

--- a/server/server.go
+++ b/server/server.go
@@ -29,7 +29,7 @@ import (
 // Server defaults.
 const (
 	// VERSION is the current version for the NATS Streaming server.
-	VERSION = "0.2.3"
+	VERSION = "0.3.0"
 
 	DefaultClusterID      = "test-cluster"
 	DefaultDiscoverPrefix = "_STAN.discover"

--- a/server/server.go
+++ b/server/server.go
@@ -473,7 +473,7 @@ type Options struct {
 	FileStoreOpts    stores.FileStoreOptions
 	MaxChannels      int
 	MaxMsgs          int    // Maximum number of messages per channel
-	MaxBytes         uint64 // Maximum number of bytes used by messages per channel
+	MaxBytes         int64  // Maximum number of bytes used by messages per channel
 	MaxSubscriptions int    // Maximum number of subscriptions per channel
 	Trace            bool   // Verbose trace
 	Debug            bool   // Debug trace
@@ -774,7 +774,11 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) *StanServer 
 	}
 
 	Noticef("STAN: Message store is %s", s.store.Name())
-	Noticef("STAN: Maximum of %d will be stored", limits.MaxNumMsgs)
+	if limits.MaxNumMsgs > 0 {
+		Noticef("STAN: Maximum of %d will be stored", limits.MaxNumMsgs)
+	} else {
+		Noticef("STAN: No limit in number of messages stored")
+	}
 
 	// Execute (in a go routine) redelivery of unacknowledged messages,
 	// and release newOnHold

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -4475,3 +4475,27 @@ func TestFileStoreDurableQueueSubRedeliveryOnRejoin(t *testing.T) {
 		t.Fatal("Did not get our message")
 	}
 }
+
+func TestIsValidSubject(t *testing.T) {
+	subject := ""
+	for i := 0; i < 100; i++ {
+		subject += "foo."
+	}
+	subject += "foo"
+	if !isValidSubject(subject) {
+		t.Fatalf("Subject %q should be valid", subject)
+	}
+	subjects := []string{
+		"foo.bar*",
+		"foo.bar>",
+		"foo.bar.*",
+		"foo.bar.>",
+		"foo*.bar",
+		"foo>.bar",
+	}
+	for _, s := range subjects {
+		if isValidSubject(s) {
+			t.Fatalf("Subject %q expected to be invalid", s)
+		}
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1264,7 +1264,7 @@ func TestMaxBytes(t *testing.T) {
 	msgSize := m.Size()
 	sOpts := GetDefaultOptions()
 	sOpts.ID = clusterName
-	sOpts.MaxBytes = uint64(msgSize * 10)
+	sOpts.MaxBytes = int64(msgSize * 10)
 	s := RunServerWithOpts(sOpts, nil)
 	defer s.Shutdown()
 
@@ -1285,7 +1285,7 @@ func TestMaxBytes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error getting state: %v", err)
 	}
-	if b != sOpts.MaxBytes {
+	if b != uint64(sOpts.MaxBytes) {
 		t.Fatalf("Expected msgs size to be %v, got %v", sOpts.MaxBytes, b)
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1260,9 +1260,11 @@ func TestMaxMsgs(t *testing.T) {
 
 func TestMaxBytes(t *testing.T) {
 	payload := []byte("hello")
+	m := pb.MsgProto{Data: payload, Subject: "foo", Sequence: 1, Timestamp: time.Now().UnixNano()}
+	msgSize := m.Size()
 	sOpts := GetDefaultOptions()
 	sOpts.ID = clusterName
-	sOpts.MaxBytes = uint64(len(payload) * 10)
+	sOpts.MaxBytes = uint64(msgSize * 10)
 	s := RunServerWithOpts(sOpts, nil)
 	defer s.Shutdown()
 

--- a/stores/bench_test.go
+++ b/stores/bench_test.go
@@ -34,11 +34,11 @@ func benchCreateDefaultFileStore(t *testing.B) *FileStore {
 }
 
 func benchStoreMsg(b *testing.B, ms MsgStore, data []byte) *pb.MsgProto {
-	m, err := ms.Store("", data)
+	seq, err := ms.Store(data)
 	if err != nil {
 		stackFatalf(b, "Error storing message: %v", err)
 	}
-	return m
+	return ms.Lookup(seq)
 }
 
 func BenchmarkRecoverMsgs(b *testing.B) {

--- a/stores/bench_test.go
+++ b/stores/bench_test.go
@@ -19,7 +19,7 @@ func benchCleanupDatastore(b *testing.B, dir string) {
 }
 
 func benchCreateDefaultFileStore(t *testing.B) *FileStore {
-	fs, state, err := NewFileStore(defaultDataStore, &testDefaultChannelLimits)
+	fs, state, err := NewFileStore(defaultDataStore, &testDefaultStoreLimits)
 	if err != nil {
 		stackFatalf(t, "Unable to create a FileStore instance: %v", err)
 	}
@@ -127,7 +127,7 @@ func BenchmarkRecoverSubs(b *testing.B) {
 	// Measure recovery
 	b.N = count * numSubs
 	b.StartTimer()
-	s, state, err := NewFileStore(defaultDataStore, &testDefaultChannelLimits)
+	s, state, err := NewFileStore(defaultDataStore, &testDefaultStoreLimits)
 	b.StopTimer()
 	if err != nil {
 		b.Fatalf("Unable to create a FileStore instance: %v", err)

--- a/stores/common.go
+++ b/stores/common.go
@@ -3,7 +3,6 @@
 package stores
 
 import (
-	"sort"
 	"sync"
 
 	"github.com/nats-io/go-nats-streaming/pb"
@@ -46,7 +45,6 @@ type genericMsgStore struct {
 	subject    string // Can't be wildcard
 	first      uint64
 	last       uint64
-	msgs       map[uint64]*pb.MsgProto
 	totalCount int
 	totalBytes uint64
 	hitLimit   bool // indicates if store had to drop messages due to limit
@@ -229,12 +227,6 @@ func (gs *genericStore) close() error {
 func (gms *genericMsgStore) init(subject string, limits ChannelLimits) {
 	gms.subject = subject
 	gms.limits = limits
-	// FIXME(ik) - Long term, msgs map should probably not be part of the
-	// generic store.
-	// We could use limits.MaxNumMsgs for the size of the map, but that
-	// may be too big if there is lots of channels with only few messages.
-	// The map will grow as needed.
-	gms.msgs = make(map[uint64]*pb.MsgProto, 64)
 }
 
 // State returns some statistics related to this store
@@ -271,26 +263,20 @@ func (gms *genericMsgStore) FirstAndLastSequence() (uint64, uint64) {
 
 // Lookup returns the stored message with given sequence number.
 func (gms *genericMsgStore) Lookup(seq uint64) *pb.MsgProto {
-	gms.RLock()
-	m := gms.msgs[seq]
-	gms.RUnlock()
-	return m
+	// no-op
+	return nil
 }
 
 // FirstMsg returns the first message stored.
 func (gms *genericMsgStore) FirstMsg() *pb.MsgProto {
-	gms.RLock()
-	m := gms.msgs[gms.first]
-	gms.RUnlock()
-	return m
+	// no-op
+	return nil
 }
 
 // LastMsg returns the last message stored.
 func (gms *genericMsgStore) LastMsg() *pb.MsgProto {
-	gms.RLock()
-	m := gms.msgs[gms.last]
-	gms.RUnlock()
-	return m
+	// no-op
+	return nil
 }
 
 func (gms *genericMsgStore) Flush() error {
@@ -301,18 +287,8 @@ func (gms *genericMsgStore) Flush() error {
 // GetSequenceFromTimestamp returns the sequence of the first message whose
 // timestamp is greater or equal to given timestamp.
 func (gms *genericMsgStore) GetSequenceFromTimestamp(timestamp int64) uint64 {
-	gms.RLock()
-	defer gms.RUnlock()
-
-	index := sort.Search(len(gms.msgs), func(i int) bool {
-		m := gms.msgs[uint64(i)+gms.first]
-		if m.Timestamp >= timestamp {
-			return true
-		}
-		return false
-	})
-
-	return uint64(index) + gms.first
+	// no-op
+	return 0
 }
 
 // Close closes this store.

--- a/stores/common.go
+++ b/stores/common.go
@@ -5,6 +5,7 @@ package stores
 import (
 	"sync"
 
+	"fmt"
 	"github.com/nats-io/go-nats-streaming/pb"
 	"github.com/nats-io/nats-streaming-server/spb"
 )
@@ -82,6 +83,13 @@ func (gs *genericStore) SetChannelLimits(limits ChannelLimits) {
 	gs.Lock()
 	gs.limits = limits
 	gs.Unlock()
+}
+
+// CreateChannel creates a ChannelStore for the given channel, and returns
+// `true` to indicate that the channel is new, false if it already exists.
+func (gs *genericStore) CreateChannel(channel string, userData interface{}) (*ChannelStore, bool, error) {
+	// no-op
+	return nil, false, fmt.Errorf("Generic store, feature not implemented")
 }
 
 // LookupChannel returns a ChannelStore for the given channel.

--- a/stores/common.go
+++ b/stores/common.go
@@ -61,10 +61,9 @@ type genericMsgStore struct {
 func (gs *genericStore) init(name string, limits *StoreLimits) {
 	gs.name = name
 	if limits == nil {
-		gs.limits = DefaultStoreLimits
-	} else {
-		gs.setLimits(limits)
+		limits = &DefaultStoreLimits
 	}
+	gs.setLimits(limits)
 	// Do not use limits values to create the map.
 	gs.channels = make(map[string]*ChannelStore)
 	gs.clients = make(map[string]*Client)
@@ -254,9 +253,9 @@ func (gs *genericStore) close() error {
 ////////////////////////////////////////////////////////////////////////////
 
 // init initializes this generic message store
-func (gms *genericMsgStore) init(subject string, limits MsgStoreLimits) {
+func (gms *genericMsgStore) init(subject string, limits *MsgStoreLimits) {
 	gms.subject = subject
-	gms.limits = limits
+	gms.limits = *limits
 }
 
 // State returns some statistics related to this store
@@ -331,9 +330,9 @@ func (gms *genericMsgStore) Close() error {
 ////////////////////////////////////////////////////////////////////////////
 
 // init initializes the structure of a generic sub store
-func (gss *genericSubStore) init(channel string, limits SubStoreLimits) {
+func (gss *genericSubStore) init(channel string, limits *SubStoreLimits) {
 	gss.subject = channel
-	gss.limits = limits
+	gss.limits = *limits
 }
 
 // CreateSub records a new subscription represented by SubState. On success,

--- a/stores/common.go
+++ b/stores/common.go
@@ -3,9 +3,9 @@
 package stores
 
 import (
+	"fmt"
 	"sync"
 
-	"fmt"
 	"github.com/nats-io/go-nats-streaming/pb"
 	"github.com/nats-io/nats-streaming-server/spb"
 )
@@ -140,7 +140,7 @@ func (gs *genericStore) MsgsState(channel string) (numMessages int, byteSize uin
 // canAddChannel returns true if the current number of channels is below the limit.
 // Store lock is assumed to be locked.
 func (gs *genericStore) canAddChannel() error {
-	if len(gs.channels) >= gs.limits.MaxChannels {
+	if gs.limits.MaxChannels > 0 && len(gs.channels) >= gs.limits.MaxChannels {
 		return ErrTooManyChannels
 	}
 	return nil
@@ -332,7 +332,7 @@ func (gss *genericSubStore) UpdateSub(sub *spb.SubState) error {
 // createSub is the unlocked version of CreateSub that can be used by
 // non-generic implementations.
 func (gss *genericSubStore) createSub(sub *spb.SubState) error {
-	if gss.subsCount >= gss.limits.MaxSubs {
+	if gss.limits.MaxSubs > 0 && gss.subsCount >= gss.limits.MaxSubs {
 		return ErrTooManySubs
 	}
 

--- a/stores/common_test.go
+++ b/stores/common_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nats-io/go-nats-streaming/pb"
 	"github.com/nats-io/nats-streaming-server/spb"
 	"github.com/nats-io/nuid"
+	"reflect"
 	"runtime"
 	"strings"
 )
@@ -265,11 +266,13 @@ func testBasicMsgStore(t *testing.T, s Store) {
 		t.Fatalf("Unexpected sequences: %v,%v", s1, s2)
 	}
 
-	if lm1 := ms.Lookup(m1.Sequence); lm1 != m1 {
+	lm1 := ms.Lookup(m1.Sequence)
+	if !reflect.DeepEqual(lm1, m1) {
 		t.Fatalf("Unexpected lookup result: %v instead of %v", lm1, m1)
 	}
 
-	if lm2 := ms.Lookup(m2.Sequence); lm2 != m2 {
+	lm2 := ms.Lookup(m2.Sequence)
+	if !reflect.DeepEqual(lm2, m2) {
 		t.Fatalf("Unexpected lookup result: %v instead of %v", lm2, m2)
 	}
 

--- a/stores/common_test.go
+++ b/stores/common_test.go
@@ -246,12 +246,12 @@ func testBasicMsgStore(t *testing.T, s Store) {
 		t.Fatalf("Unexpected payload: %v", string(m1.Data))
 	}
 
-	if ms.FirstMsg() != m1 {
+	if !reflect.DeepEqual(ms.FirstMsg(), m1) {
 		t.Fatalf("Unexpected first message: %v vs %v", ms.FirstMsg(), m1)
 	}
 
-	if ms.LastMsg() != m2 {
-		t.Fatalf("Unexpected first message: %v vs %v", ms.LastMsg(), m2)
+	if !reflect.DeepEqual(ms.LastMsg(), m2) {
+		t.Fatalf("Unexpected last message: %v vs %v", ms.LastMsg(), m2)
 	}
 
 	if ms.FirstSequence() != m1.Sequence {
@@ -283,6 +283,12 @@ func testBasicMsgStore(t *testing.T, s Store) {
 	expectedBytes := uint64(m1.Size() + m2.Size())
 	if count != 2 || bytes != expectedBytes {
 		t.Fatalf("Unexpected counts: %v, %v vs %v, %v", count, bytes, 2, expectedBytes)
+	}
+
+	// Store one more mesasge to check that LastMsg is correctly updated
+	m3 := storeMsg(t, s, "foo", []byte("last"))
+	if !reflect.DeepEqual(ms.LastMsg(), m3) {
+		t.Fatalf("Expected last message to be %v, got %v", m3, ms.LastMsg())
 	}
 }
 

--- a/stores/common_test.go
+++ b/stores/common_test.go
@@ -563,3 +563,32 @@ func testFlush(t *testing.T, s Store) {
 		t.Fatalf("Unexpected error on flush: %v", err)
 	}
 }
+
+func TestGSNoOps(t *testing.T) {
+	gs := &genericStore{}
+	defer gs.Close()
+	limits := DefaultChannelLimits
+	gs.init("test generic", &limits)
+	if _, _, err := gs.CreateChannel("foo", nil); err == nil {
+		t.Fatal("Expected to get an error since this should not be implemented for generic store")
+	}
+	if err := gs.Close(); err != nil {
+		t.Fatalf("Expected nil, got %v", err)
+	}
+
+	gms := &genericMsgStore{}
+	defer gms.Close()
+	gms.init("foo", limits)
+	if gms.Lookup(1) != nil || gms.FirstMsg() != nil || gms.LastMsg() != nil || gms.Flush() != nil ||
+		gms.GetSequenceFromTimestamp(0) != 0 || gms.Close() != nil {
+		t.Fatal("Expected no value since these should not be implemented for generic store")
+	}
+
+	gss := &genericSubStore{}
+	defer gss.Close()
+	gss.init("foo", limits)
+	if gss.AddSeqPending(1, 1) != nil || gss.AckSeqPending(1, 1) != nil || gss.Flush() != nil ||
+		gss.Close() != nil {
+		t.Fatal("Expected no value since these should not be implemented for generic store")
+	}
+}

--- a/stores/common_test.go
+++ b/stores/common_test.go
@@ -61,11 +61,11 @@ func storeMsg(t *testing.T, s Store, channel string, data []byte) *pb.MsgProto {
 		}
 	}
 	ms := cs.Msgs
-	m, err := ms.Store("", data)
+	seq, err := ms.Store(data)
 	if err != nil {
 		stackFatalf(t, "Error storing message into channel [%v]: %v", channel, err)
 	}
-	return m
+	return ms.Lookup(seq)
 }
 
 func storeSub(t *testing.T, s Store, channel string) uint64 {
@@ -616,7 +616,7 @@ func testFlush(t *testing.T, s Store) {
 	if err != nil {
 		t.Fatalf("Unexpected error creating channel: %v", err)
 	}
-	msg, err := cs.Msgs.Store("", []byte("hello"))
+	seq, err := cs.Msgs.Store([]byte("hello"))
 	if err != nil {
 		t.Fatalf("Unexpected error on store: %v", err)
 	}
@@ -627,7 +627,7 @@ func testFlush(t *testing.T, s Store) {
 	if err := cs.Subs.CreateSub(&sub); err != nil {
 		t.Fatalf("Unexpected error creating sub: %v", err)
 	}
-	if err := cs.Subs.AddSeqPending(sub.ID, msg.Sequence); err != nil {
+	if err := cs.Subs.AddSeqPending(sub.ID, seq); err != nil {
 		t.Fatalf("Unexpected error adding sequence to substore: %v", err)
 	}
 	if err := cs.Subs.Flush(); err != nil {

--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -1366,29 +1366,33 @@ func (ms *FileMsgStore) Store(reply string, data []byte) (*pb.MsgProto, error) {
 
 	fslice := ms.files[ms.currSliceIdx]
 
-	// Check if we need to move to next file slice
-	if (ms.currSliceIdx < numFiles-1) &&
-		((fslice.msgsCount >= ms.limits.MaxNumMsgs/(numFiles-1)) ||
-			(fslice.msgsSize >= ms.limits.MaxMsgBytes/(numFiles-1))) {
+	maxMsgs := ms.limits.MaxNumMsgs
+	maxBytes := ms.limits.MaxMsgBytes
+	if maxMsgs > 0 || maxBytes > 0 {
+		// Check if we need to move to next file slice
+		if (ms.currSliceIdx < numFiles-1) &&
+			((maxMsgs > 0 && fslice.msgsCount >= maxMsgs/(numFiles-1)) ||
+				(maxBytes > 0 && fslice.msgsSize >= uint64(maxBytes)/(numFiles-1))) {
 
-		// Don't change store variable until success...
-		nextSlice := ms.currSliceIdx + 1
+			// Don't change store variable until success...
+			nextSlice := ms.currSliceIdx + 1
 
-		// Close the file and open the next slice
-		if err := ms.closeDataAndIndexFiles(); err != nil {
-			return nil, err
+			// Close the file and open the next slice
+			if err := ms.closeDataAndIndexFiles(); err != nil {
+				return nil, err
+			}
+			// Open the new slice
+			if err := ms.openDataAndIndexFiles(
+				ms.files[nextSlice].fileName,
+				ms.files[nextSlice].idxFName); err != nil {
+				return nil, err
+			}
+			// Success, update the store's variables
+			ms.currSliceIdx = nextSlice
+			ms.wOffset = int64(4)
+
+			fslice = ms.files[ms.currSliceIdx]
 		}
-		// Open the new slice
-		if err := ms.openDataAndIndexFiles(
-			ms.files[nextSlice].fileName,
-			ms.files[nextSlice].idxFName); err != nil {
-			return nil, err
-		}
-		// Success, update the store's variables
-		ms.currSliceIdx = nextSlice
-		ms.wOffset = int64(4)
-
-		fslice = ms.files[ms.currSliceIdx]
 	}
 
 	seq := ms.last + 1
@@ -1473,9 +1477,11 @@ func (ms *FileMsgStore) Store(reply string, data []byte) (*pb.MsgProto, error) {
 	}
 	fslice.lastSeq = seq
 
-	// Enfore limits and update file slice if needed.
-	if err := ms.enforceLimits(); err != nil {
-		return nil, err
+	if maxMsgs > 0 || maxBytes > 0 {
+		// Enfore limits and update file slice if needed.
+		if err := ms.enforceLimits(); err != nil {
+			return nil, err
+		}
 	}
 	return m, nil
 }
@@ -1518,9 +1524,11 @@ func (ms *FileMsgStore) enforceLimits() error {
 	// Check if we need to remove any (but leave at least the last added).
 	// Note that we may have to remove more than one msg if we are here
 	// after a restart with smaller limits than originally set.
+	maxMsgs := ms.limits.MaxNumMsgs
+	maxBytes := ms.limits.MaxMsgBytes
 	for ms.totalCount > 1 &&
-		((ms.totalCount > ms.limits.MaxNumMsgs) ||
-			(ms.totalBytes > ms.limits.MaxMsgBytes)) {
+		((maxMsgs > 0 && ms.totalCount > maxMsgs) ||
+			(maxBytes > 0 && ms.totalBytes > uint64(maxBytes))) {
 
 		// slice we are inspecting, make sure the slice is not
 		// empty.

--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -549,15 +549,7 @@ func NewFileStore(rootDir string, limits *ChannelLimits, options ...FileStoreOpt
 				// Lookup messages, and if we find those, update the
 				// Pending map.
 				for seq := range sub.seqnos {
-					// Access directly 'msgs' here. If we have a
-					// different implementation where we don't
-					// keep messages around, we would still have
-					// a cache of messages per channel that will
-					// then be cleared after this loop when we
-					// are done restoring the subscriptions.
-					if m := msgStore.msgs[seq]; m != nil {
-						rss.Pending[seq] = m.msg
-					}
+					rss.Pending[seq] = struct{}{}
 				}
 			}
 			// Add to the array of recovered subscriptions

--- a/stores/filestore_test.go
+++ b/stores/filestore_test.go
@@ -378,9 +378,9 @@ func TestFSBasicRecovery(t *testing.T) {
 			if subID != sub1 {
 				t.Fatalf("Invalid subscription id. Expected %v, got %v", sub1, subID)
 			}
-			for _, m := range recSub.Pending {
-				if m.Sequence != foo2.Sequence {
-					t.Fatalf("Unexpected recovered pending seqno for sub1: %v", m.Sequence)
+			for seq := range recSub.Pending {
+				if seq != foo2.Sequence {
+					t.Fatalf("Unexpected recovered pending seqno for sub1: %v", seq)
 				}
 			}
 			break
@@ -388,9 +388,9 @@ func TestFSBasicRecovery(t *testing.T) {
 			if subID != sub2 {
 				t.Fatalf("Invalid subscription id. Expected %v, got %v", sub2, subID)
 			}
-			for _, m := range recSub.Pending {
-				if m.Sequence != bar1.Sequence && m.Sequence != bar2.Sequence && m.Sequence != bar3.Sequence {
-					t.Fatalf("Unexpected recovered pending seqno for sub2: %v", m.Sequence)
+			for seq := range recSub.Pending {
+				if seq != bar1.Sequence && seq != bar2.Sequence && seq != bar3.Sequence {
+					t.Fatalf("Unexpected recovered pending seqno for sub2: %v", seq)
 				}
 			}
 			break

--- a/stores/filestore_test.go
+++ b/stores/filestore_test.go
@@ -224,6 +224,7 @@ func TestFSOptions(t *testing.T) {
 		DoCRC:                false,
 		CRCPolynomial:        int64(crc32.Castagnoli),
 		DoSync:               false,
+		CacheMsgs:            false,
 	}
 	// Create the file with custom options
 	fs, _, err := NewFileStore(defaultDataStore, &testDefaultChannelLimits,
@@ -234,7 +235,8 @@ func TestFSOptions(t *testing.T) {
 		CompactMinFileSize(expected.CompactMinFileSize),
 		DoCRC(expected.DoCRC),
 		CRCPolynomial(expected.CRCPolynomial),
-		DoSync(expected.DoSync))
+		DoSync(expected.DoSync),
+		CacheMsgs(expected.CacheMsgs))
 	if err != nil {
 		t.Fatalf("Unexpected error on file store create: %v", err)
 	}

--- a/stores/filestore_test.go
+++ b/stores/filestore_test.go
@@ -3,6 +3,8 @@
 package stores
 
 import (
+	"bufio"
+	"flag"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -14,8 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"bufio"
-	"flag"
 	"github.com/nats-io/go-nats-streaming/pb"
 	"github.com/nats-io/nats-streaming-server/spb"
 	"github.com/nats-io/nats-streaming-server/util"
@@ -700,6 +700,13 @@ func TestFSMaxChannels(t *testing.T) {
 	fs.SetChannelLimits(limits)
 
 	testMaxChannels(t, fs, limitCount)
+
+	// Set the limit to 0
+	limits.MaxChannels = 0
+	fs.SetChannelLimits(limits)
+	// Now try to test the limit against
+	// any value, it should not fail
+	testMaxChannels(t, fs, 0)
 }
 
 func TestFSMaxSubs(t *testing.T) {
@@ -716,7 +723,14 @@ func TestFSMaxSubs(t *testing.T) {
 
 	fs.SetChannelLimits(limits)
 
-	testMaxSubs(t, fs, limitCount)
+	testMaxSubs(t, fs, "foo", limitCount)
+
+	// Set the limit to 0
+	limits.MaxSubs = 0
+	fs.SetChannelLimits(limits)
+	// Now try to test the limit against
+	// any value, it should not fail
+	testMaxSubs(t, fs, "bar", 0)
 }
 
 func TestFSBasicSubStore(t *testing.T) {

--- a/stores/limits.go
+++ b/stores/limits.go
@@ -1,0 +1,109 @@
+// Copyright 2016 Apcera Inc. All rights reserved.
+
+package stores
+
+import (
+	"fmt"
+)
+
+// AddPerChannel stores limits for the given channel `name` in the StoreLimits.
+// Inheritance (that is, specifying 0 for a limit means that the global limit
+// should be used) is not applied in this call. This is done in StoreLimits.Build
+// along with some validation.
+func (sl *StoreLimits) AddPerChannel(name string, cl *ChannelLimits) {
+	if sl.PerChannel == nil {
+		sl.PerChannel = make(map[string]*ChannelLimits)
+	}
+	sl.PerChannel[name] = cl
+}
+
+// Build sets the global limits into per-channel limits that are set
+// to zero. This call also validates the limits. An error is returned if:
+// * any limit is set to a negative value.
+// * the number of per-channel is higher than StoreLimits.MaxChannels.
+// * any per-channel limit is higher than the corresponding global limit.
+func (sl *StoreLimits) Build() error {
+	// Check that there is no negative value
+	if sl.MaxChannels < 0 {
+		return fmt.Errorf("Max channels limit cannot be negative")
+	}
+	if err := sl.checkChannelLimits(&sl.ChannelLimits, ""); err != nil {
+		return err
+	}
+	// If there is no per-channel, we are done.
+	if len(sl.PerChannel) == 0 {
+		return nil
+	}
+	if len(sl.PerChannel) > sl.MaxChannels {
+		return fmt.Errorf("Too many channels defined (%v). The max channels limit is set to %v",
+			len(sl.PerChannel), sl.MaxChannels)
+	}
+	for cn, cl := range sl.PerChannel {
+		if err := sl.checkChannelLimits(cl, cn); err != nil {
+			return err
+		}
+	}
+	// If we are here, it means that there was no error,
+	// so we now apply inheritance.
+	for _, cl := range sl.PerChannel {
+		if cl.MaxSubscriptions == 0 {
+			cl.MaxSubscriptions = sl.MaxSubscriptions
+		}
+		if cl.MaxMsgs == 0 {
+			cl.MaxMsgs = sl.MaxMsgs
+		}
+		if cl.MaxBytes == 0 {
+			cl.MaxBytes = sl.MaxBytes
+		}
+		if cl.MaxAge == 0 {
+			cl.MaxAge = sl.MaxAge
+		}
+	}
+	return nil
+}
+
+func (sl *StoreLimits) checkChannelLimits(cl *ChannelLimits, channelName string) error {
+	// Check that there is no per-channel unlimited limit if corresponding
+	// limit is not.
+	if err := verifyLimit("subscriptions", channelName,
+		int64(cl.MaxSubscriptions), int64(sl.MaxSubscriptions)); err != nil {
+		return err
+	}
+	if err := verifyLimit("messages", channelName,
+		int64(cl.MaxMsgs), int64(sl.MaxMsgs)); err != nil {
+		return err
+	}
+	if err := verifyLimit("bytes", channelName,
+		cl.MaxBytes, sl.MaxBytes); err != nil {
+		return err
+	}
+	if err := verifyLimit("age", channelName,
+		int64(cl.MaxAge), int64(sl.MaxAge)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func verifyLimit(errText, channelName string, limit, globalLimit int64) error {
+	// No limit can be negative. If channelName is "" we are
+	// verifying the global limit (in this case limit == globalLimit).
+	// Otherwise, we verify a given per-channel limit. Make
+	// sure that the value is not greater than the corresponding
+	// global limit.
+	if channelName == "" {
+		if limit < 0 {
+			return fmt.Errorf("Max %s for global limit cannot be negative", errText)
+		}
+		return nil
+	}
+	// Per-channel limit specific here.
+	if limit < 0 {
+		return fmt.Errorf("Max %s for channel %q cannot be negative. "+
+			"Set it to 0 to be equal to the global limit of %v", errText, channelName, globalLimit)
+	}
+	if limit > globalLimit {
+		return fmt.Errorf("Max %s for channel %q cannot be higher than global limit "+
+			"of %v", errText, channelName, globalLimit)
+	}
+	return nil
+}

--- a/stores/limits_test.go
+++ b/stores/limits_test.go
@@ -1,0 +1,186 @@
+// Copyright 2016 Apcera Inc. All rights reserved.
+
+package stores
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAddPerChannel(t *testing.T) {
+	sl := testDefaultStoreLimits
+	cl := &ChannelLimits{
+		MsgStoreLimits{
+			MaxMsgs:  10,
+			MaxBytes: 100,
+			MaxAge:   1000,
+		},
+		SubStoreLimits{
+			MaxSubscriptions: 10,
+		},
+	}
+	sl.AddPerChannel("foo", cl)
+	if len(sl.PerChannel) != 1 {
+		t.Fatalf("Expected 1 channel, got %v", len(sl.PerChannel))
+	}
+	addedCL := sl.PerChannel["foo"]
+	if addedCL == nil {
+		t.Fatal("ChannelLimits not found")
+	}
+	if !reflect.DeepEqual(*cl, *addedCL) {
+		t.Fatalf("Expected channel limits to be %v, got %v", *cl, *addedCL)
+	}
+}
+
+func TestBuildErrors(t *testing.T) {
+	sl := testDefaultStoreLimits
+
+	// This function calls Build(), expects and error and check
+	// that the error it gets starts with the given error text.
+	expectError := func(errTxt string) {
+		err := sl.Build()
+		if err == nil {
+			stackFatalf(t, "Expected error on build, did not get one")
+		}
+		if !strings.HasPrefix(err.Error(), errTxt) {
+			stackFatalf(t, "Expected error to be about %q, got %v", errTxt, err.Error())
+		}
+	}
+	// Check that we get an error for negative values.
+	sl.MaxChannels = -1
+	expectError("Max channels")
+
+	sl.MaxChannels = 1
+	sl.MaxSubscriptions = -1
+	expectError("Max subscriptions")
+
+	sl.MaxChannels = 1
+	sl.MaxSubscriptions = 1
+	sl.MaxMsgs = -1
+	expectError("Max messages")
+
+	sl.MaxChannels = 1
+	sl.MaxSubscriptions = 1
+	sl.MaxMsgs = 1
+	sl.MaxBytes = -1
+	expectError("Max bytes")
+
+	sl.MaxChannels = 1
+	sl.MaxSubscriptions = 1
+	sl.MaxMsgs = 1
+	sl.MaxBytes = 1
+	sl.MaxAge = -1
+	expectError("Max age")
+
+	// Reset sl
+	sl.MaxChannels = 1
+	sl.MaxSubscriptions = 1
+	sl.MaxMsgs = 1
+	sl.MaxBytes = 1
+	sl.MaxAge = 1
+
+	// Check per-channel negative values
+	cl := &ChannelLimits{}
+	cl.MaxSubscriptions = -1
+	sl.AddPerChannel("foo", cl)
+	expectError("Max subscriptions")
+
+	cl = &ChannelLimits{}
+	cl.MaxMsgs = -1
+	sl.AddPerChannel("foo", cl)
+	expectError("Max messages")
+
+	cl = &ChannelLimits{}
+	cl.MaxAge = -1
+	sl.AddPerChannel("foo", cl)
+	expectError("Max age")
+
+	sl.MaxChannels = 1
+	// Adding a second channel should cause build failures, AddPerChannel itself
+	// does not fail.
+	cl = &ChannelLimits{}
+	cl.MaxMsgs = 10
+	cl.MaxAge = 2 * time.Hour
+	sl.AddPerChannel("foo", cl)
+	sl.AddPerChannel("bar", cl)
+	expectError("Too many channels")
+
+	// Check per-channel values are below global limits.
+	sl.MaxChannels = 2
+	sl.MaxMsgs = 10
+	sl.MaxBytes = 20
+	sl.MaxSubscriptions = 30
+	sl.MaxAge = time.Second
+
+	cl = &ChannelLimits{}
+	cl.MaxMsgs = 5
+	sl.AddPerChannel("foo", cl)
+	cl2 := *cl
+	cl2.MaxMsgs = 12
+	sl.AddPerChannel("bar", &cl2)
+	expectError("Max messages for channel \"bar\"")
+
+	cl = &ChannelLimits{}
+	cl.MaxBytes = 25
+	cl2 = *cl
+	cl2.MaxBytes = 18
+	sl.AddPerChannel("foo", cl)
+	sl.AddPerChannel("bar", &cl2)
+	expectError("Max bytes for channel \"foo\"")
+
+	cl = &ChannelLimits{}
+	cl.MaxAge = time.Second
+	cl2 = *cl
+	cl2.MaxAge = time.Hour
+	sl.AddPerChannel("foo", cl)
+	sl.AddPerChannel("bar", &cl2)
+	expectError("Max age for channel \"bar\"")
+
+	cl = &ChannelLimits{}
+	cl.MaxSubscriptions = 35
+	cl2 = *cl
+	cl2.MaxSubscriptions = 10
+	sl.AddPerChannel("foo", cl)
+	sl.AddPerChannel("bar", &cl2)
+	expectError("Max subscriptions for channel \"foo\"")
+}
+
+func TestAppliedInheritance(t *testing.T) {
+	sl := testDefaultStoreLimits
+	sl.MaxMsgs = 11
+	sl.MaxBytes = 12
+	sl.MaxAge = 13
+	sl.MaxSubscriptions = 14
+
+	checkPerChannel := func(maxMsgs int, maxBytes, maxAge int64, maxSubs int) {
+		cl := &ChannelLimits{}
+		cl.MaxMsgs = maxMsgs
+		cl.MaxBytes = maxBytes
+		cl.MaxAge = time.Duration(maxAge)
+		cl.MaxSubscriptions = maxSubs
+		sl.AddPerChannel("foo", cl)
+		if err := sl.Build(); err != nil {
+			stackFatalf(t, "Unexpected error on build: %v", err)
+		}
+		builtCl := sl.PerChannel["foo"]
+		// Make sure that values from global are used for limits that were specified as 0.
+		if maxMsgs == 0 && builtCl.MaxMsgs != sl.MaxMsgs {
+			t.Fatalf("Max messages from global limit not inherited: %v", builtCl)
+		}
+		if maxBytes == 0 && builtCl.MaxBytes != sl.MaxBytes {
+			t.Fatalf("Max bytes from global limit not inherited: %v", builtCl)
+		}
+		if maxAge == 0 && builtCl.MaxAge != sl.MaxAge {
+			t.Fatalf("Max age from global limit not inherited: %v", builtCl)
+		}
+		if maxSubs == 0 && builtCl.MaxSubscriptions != sl.MaxSubscriptions {
+			t.Fatalf("Max messages from global limit not inherited: %v", builtCl)
+		}
+	}
+	checkPerChannel(10, 0, 0, 0)
+	checkPerChannel(0, 10, 0, 0)
+	checkPerChannel(0, 0, 10, 0)
+	checkPerChannel(0, 0, 0, 10)
+}

--- a/stores/memstore.go
+++ b/stores/memstore.go
@@ -91,13 +91,13 @@ func (ms *MemoryMsgStore) Store(reply string, data []byte) (*pb.MsgProto, error)
 	}
 	ms.msgs[ms.last] = m
 	ms.totalCount++
-	ms.totalBytes += uint64(len(data))
+	ms.totalBytes += uint64(m.Size())
 
 	// Check if we need to remove any (but leave at least the last added)
 	for ms.totalCount > ms.limits.MaxNumMsgs ||
 		((ms.totalCount > 1) && (ms.totalBytes > ms.limits.MaxMsgBytes)) {
 		firstMsg := ms.msgs[ms.first]
-		ms.totalBytes -= uint64(len(firstMsg.Data))
+		ms.totalBytes -= uint64(firstMsg.Size())
 		ms.totalCount--
 		if !ms.hitLimit {
 			ms.hitLimit = true

--- a/stores/memstore.go
+++ b/stores/memstore.go
@@ -74,7 +74,7 @@ func (ms *MemoryStore) CreateChannel(channel string, userData interface{}) (*Cha
 ////////////////////////////////////////////////////////////////////////////
 
 // Store a given message.
-func (ms *MemoryMsgStore) Store(reply string, data []byte) (*pb.MsgProto, error) {
+func (ms *MemoryMsgStore) Store(data []byte) (uint64, error) {
 	ms.Lock()
 	defer ms.Unlock()
 
@@ -85,7 +85,6 @@ func (ms *MemoryMsgStore) Store(reply string, data []byte) (*pb.MsgProto, error)
 	m := &pb.MsgProto{
 		Sequence:  ms.last,
 		Subject:   ms.subject,
-		Reply:     reply,
 		Data:      data,
 		Timestamp: time.Now().UnixNano(),
 	}
@@ -112,7 +111,7 @@ func (ms *MemoryMsgStore) Store(reply string, data []byte) (*pb.MsgProto, error)
 		}
 	}
 
-	return m, nil
+	return ms.last, nil
 }
 
 // Lookup returns the stored message with given sequence number.

--- a/stores/memstore_test.go
+++ b/stores/memstore_test.go
@@ -150,6 +150,24 @@ func TestMSMaxSubs(t *testing.T) {
 	testMaxSubs(t, ms, "bar", 0)
 }
 
+func TestMSMaxAge(t *testing.T) {
+	ms := createDefaultMemStore(t)
+	defer ms.Close()
+
+	testMaxAge(t, ms)
+
+	// Store a message
+	storeMsg(t, ms, "foo", []byte("msg"))
+	// Verify timer is set
+	ms.RLock()
+	cs := ms.LookupChannel("foo")
+	timerSet := cs.Msgs.(*MemoryMsgStore).ageTimer != nil
+	ms.RUnlock()
+	if !timerSet {
+		t.Fatal("Timer should have been set")
+	}
+}
+
 func TestMSBasicSubStore(t *testing.T) {
 	ms := createDefaultMemStore(t)
 	defer ms.Close()

--- a/stores/memstore_test.go
+++ b/stores/memstore_test.go
@@ -111,6 +111,13 @@ func TestMSMaxChannels(t *testing.T) {
 	ms.SetChannelLimits(limits)
 
 	testMaxChannels(t, ms, limitCount)
+
+	// Set the limit to 0
+	limits.MaxChannels = 0
+	ms.SetChannelLimits(limits)
+	// Now try to test the limit against
+	// any value, it should not fail
+	testMaxChannels(t, ms, 0)
 }
 
 func TestMSMaxSubs(t *testing.T) {
@@ -124,7 +131,14 @@ func TestMSMaxSubs(t *testing.T) {
 
 	ms.SetChannelLimits(limits)
 
-	testMaxSubs(t, ms, limitCount)
+	testMaxSubs(t, ms, "foo", limitCount)
+
+	// Set the limit to 0
+	limits.MaxSubs = 0
+	ms.SetChannelLimits(limits)
+	// Now try to test the limit against
+	// any value, it should not fail
+	testMaxSubs(t, ms, "bar", 0)
 }
 
 func TestMSBasicSubStore(t *testing.T) {

--- a/stores/store.go
+++ b/stores/store.go
@@ -75,9 +75,8 @@ type Client struct {
 // RecoveredSubscriptions is a map of recovered subscriptions, keyed by channel name.
 type RecoveredSubscriptions map[string][]*RecoveredSubState
 
-// PendingAcks is a map of messages waiting to be acknowledged, keyed by
-// message sequence number.
-type PendingAcks map[uint64]*pb.MsgProto
+// PendingAcks is a set of message sequences waiting to be acknowledged.
+type PendingAcks map[uint64]struct{}
 
 // RecoveredSubState represents a recovered Subscription with a map
 // of pending messages.

--- a/stores/store.go
+++ b/stores/store.go
@@ -189,8 +189,8 @@ type MsgStore interface {
 	// State returns some statistics related to this store.
 	State() (numMessages int, byteSize uint64, err error)
 
-	// Store stores a message.
-	Store(reply string, data []byte) (*pb.MsgProto, error)
+	// Store stores a message and returns the message sequence.
+	Store(data []byte) (uint64, error)
 
 	// Lookup returns the stored message with given sequence number.
 	Lookup(seq uint64) *pb.MsgProto

--- a/stores/store.go
+++ b/stores/store.go
@@ -41,7 +41,7 @@ type ChannelLimits struct {
 	// How many messages per channel are allowed.
 	MaxNumMsgs int
 	// How many bytes (messages payloads) per channel are allowed.
-	MaxMsgBytes uint64
+	MaxMsgBytes int64
 	// How old messages on a channel can be before being removed.
 	MaxMsgAge time.Duration
 	// How many subscriptions per channel are allowed.

--- a/stores/store.go
+++ b/stores/store.go
@@ -34,28 +34,59 @@ func Noticef(format string, v ...interface{}) {
 	server.Noticef(format, v...)
 }
 
-// ChannelLimits defines some limits on the store interface
-type ChannelLimits struct {
+// StoreLimits define limits for a store.
+type StoreLimits struct {
 	// How many channels are allowed.
 	MaxChannels int
-	// How many messages per channel are allowed.
-	MaxNumMsgs int
-	// How many bytes (messages payloads) per channel are allowed.
-	MaxMsgBytes int64
-	// How old messages on a channel can be before being removed.
-	MaxMsgAge time.Duration
-	// How many subscriptions per channel are allowed.
-	MaxSubs int
+	// Global limits. Any 0 value means that the limit is ignored (unlimited).
+	ChannelLimits
+	// Per-channel limits. If a limit for a channel in this map is 0,
+	// the corresponding global limit (specified above) is used.
+	PerChannel map[string]*ChannelLimits
 }
 
-// DefaultChannelLimits are the channel limits that a Store must
+// ChannelLimits defines limits for a given channel
+type ChannelLimits struct {
+	// Limits for message stores
+	MsgStoreLimits
+	// Limits for subscriptions stores
+	SubStoreLimits
+}
+
+// MsgStoreLimits defines limits for a MsgStore.
+// For global limits, a value of 0 means "unlimited".
+// For per-channel limits, it means that the corresponding global
+// limit is used.
+type MsgStoreLimits struct {
+	// How many messages are allowed.
+	MaxMsgs int
+	// How many bytes are allowed.
+	MaxBytes int64
+	// How long messages are kept in the log (unit is seconds)
+	MaxAge time.Duration
+}
+
+// SubStoreLimits defines limits for a SubStore
+type SubStoreLimits struct {
+	// How many subscriptions are allowed.
+	MaxSubscriptions int
+}
+
+// DefaultStoreLimits are the limits that a Store must
 // use when none are specified to the Store constructor.
-// Store limits can be changed with the Store.SetChannelLimits() method.
-var DefaultChannelLimits = ChannelLimits{
-	MaxChannels: 100,
-	MaxNumMsgs:  1000000,
-	MaxMsgBytes: 1000000 * 1024,
-	MaxSubs:     1000,
+// Store limits can be changed with the Store.SetLimits() method.
+var DefaultStoreLimits = StoreLimits{
+	100,
+	ChannelLimits{
+		MsgStoreLimits{
+			MaxMsgs:  1000000,
+			MaxBytes: 1000000 * 1024,
+		},
+		SubStoreLimits{
+			MaxSubscriptions: 1000,
+		},
+	},
+	nil,
 }
 
 // RecoveredState allows the server to reconstruct its state after a restart.
@@ -95,9 +126,9 @@ type ChannelStore struct {
 	Msgs MsgStore
 }
 
-// Store is the storage interface for STAN servers.
+// Store is the storage interface for NATS Streaming servers.
 //
-// If an implementation has a Store constructor with ChannelLimits, it should be
+// If an implementation has a Store constructor with StoreLimits, it should be
 // noted that the limits don't apply to any state being recovered, for Store
 // implementations supporting recovery.
 //
@@ -108,12 +139,17 @@ type Store interface {
 	// Name returns the name type of this store (e.g: MEMORY, FILESTORE, etc...).
 	Name() string
 
-	// SetChannelLimits sets limits per channel. The action is not expected
+	// SetLimits sets limits for this store. The action is not expected
 	// to be retroactive.
-	SetChannelLimits(limits ChannelLimits)
+	// The store implementation should make a deep copy as to not change
+	// the content of the structure passed by the caller.
+	// This call may return an error due to limits validation errors.
+	SetLimits(limits *StoreLimits) error
 
 	// CreateChannel creates a ChannelStore for the given channel, and returns
 	// `true` to indicate that the channel is new, false if it already exists.
+	// Limits defined for this channel in StoreLimits.PeChannel map, if present,
+	// will apply. Otherwise, the global limits in StoreLimits will apply.
 	CreateChannel(channel string, userData interface{}) (*ChannelStore, bool, error)
 
 	// LookupChannel returns a ChannelStore for the given channel, nil if channel

--- a/test/configs/test_parse.conf
+++ b/test/configs/test_parse.conf
@@ -1,0 +1,49 @@
+id: "me"
+discover_prefix: "discover"
+store: "file"
+dir: "/path/to/datastore"
+sd: true
+sv: true
+ns: "nats://localhost:4222"
+secure: true
+
+store_limits: {
+    max_channels: 11
+    max_msgs: 12
+    max_bytes: 13
+    max_age: "14s"
+    max_subs: 15
+    
+    channels: {
+      "foo": {
+        max_msgs: 1
+        max_bytes: 2
+        max_age: "3s"
+        max_subs: 4
+      }
+      "bar": {
+        max_msgs: 5
+        max_bytes: 6
+        max_age: "7s"
+        max_subs: 8      
+      }
+    }
+}
+
+tls: {
+    client_cert: "/path/to/client/cert_file"
+    client_key: "/path/to/client/key_file"
+    client_ca: "/path/to/client/ca_file"
+}
+
+file: {
+    compact: true
+    compact_frag: 1
+    compact_interval: 2
+    compact_min_size: 3
+    buffer_size: 4
+    crc: true
+    crc_poly: 5
+    sync: true
+    cache: true
+}


### PR DESCRIPTION
Many commits that mainly:

- Add FileStore indexing so that messages are recovered from an index file (avoiding need to recover whole messages)
- Ability to disable caching for file stores
- Buffered writers for SubStore and MsgStore can now shrink to reduce memory need
- Allow MaxMsgs/MaxBytes to be set to 0 to mean "no limit"
- Some improvements (reduced number of memory allocations in processing incoming messages)