### PR TITLE
Use the send connection to send protocol responses

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1467,7 +1467,7 @@ func (s *StanServer) processClientPublish(m *nats.Msg) {
 func (s *StanServer) sendPublishErr(subj, guid string, err error) {
 	badMsgAck := &pb.PubAck{Guid: guid, Error: err.Error()}
 	if b, err := badMsgAck.Marshal(); err == nil {
-		s.nc.Publish(subj, b)
+		s.ncs.Publish(subj, b)
 	}
 }
 
@@ -2071,13 +2071,13 @@ func (s *StanServer) processUnSubscribeRequest(m *nats.Msg) {
 	// Create a non-error response
 	resp := &pb.SubscriptionResponse{AckInbox: req.Inbox}
 	b, _ := resp.Marshal()
-	s.nc.Publish(m.Reply, b)
+	s.ncs.Publish(m.Reply, b)
 }
 
 func (s *StanServer) sendSubscriptionResponseErr(reply string, err error) {
 	resp := &pb.SubscriptionResponse{Error: err.Error()}
 	b, _ := resp.Marshal()
-	s.nc.Publish(reply, b)
+	s.ncs.Publish(reply, b)
 }
 
 // Check for valid subjects
@@ -2437,7 +2437,7 @@ func (s *StanServer) processSubscriptionRequest(m *nats.Msg) {
 	// Create a non-error response
 	resp := &pb.SubscriptionResponse{AckInbox: ackInbox}
 	b, _ := resp.Marshal()
-	s.nc.Publish(m.Reply, b)
+	s.ncs.Publish(m.Reply, b)
 
 	// If we are a durable (queue or not) and have state
 	if isDurable {


### PR DESCRIPTION
Using two connections can theoretically introduce a protocol ordering issue, particularly when subscription responses are published on a different connection than the messages sent to subscribers.

Imagine the following case where a client makes a subscription request.  The NATS streaming server receives this request, and sends a response on the "general" connection, then starts streaming messages on the "send" connection to a subscriber.  The NATS server happens to service the "send" connection first and sends a `MsgProto` to the subscribing client before the `SubscriptionResponse`.  This violates the protocol and results in undefined behavior at the client.

To mitigate this, send any subscription responses on the "send" connection.  It makes sense to be congruent and do the same with publish errors alongside publish acknowledgements.

Performance remains unaffected.  This is nearly impossible to replicate consistently, so there is no test.

This bug may be related to what was seen in #188.