### PR TITLE
Allow forcing embedded server even when a NATS url is specified.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,9 @@ _testmain.go
 .project
 .settings/
 
+# IntelliJ
+.idea/
+*.iml
+
 # MS Visual Code
 .vscode/

--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -31,6 +31,7 @@ Streaming Server Options:
     -ma,  --max_age <seconds>        Max duration a message can be stored ("0s" for unlimited)
     -ns,  --nats_server <url>        Connect to this external NATS Server (embedded otherwise)
     -sc,  --stan_config <file>       Streaming server configuration file
+    --embed													 Force embedded NATS server, even if --ns is specified
 
 Streaming Server File Store Options:
     --file_compact_enabled           Enable file compaction
@@ -82,7 +83,7 @@ TLS Options:
         --tls                        Enable TLS, do not verify clients (default: false)
         --tlscert <file>             Server certificate file
         --tlskey <file>              Private key for server certificate
-        --tlsverify                  Enable TLS, very client certificates
+        --tlsverify                  Enable TLS, verify client certificates
         --tlscacert <file>           Client certificate CA for verification
 
 NATS Clustering Options:
@@ -159,6 +160,7 @@ func parseFlags() (*stand.Options, *natsd.Options) {
 	flag.String("tls_client_cacert", "", "ClientCA")
 	flag.String("nats_server", "", "NATSServerURL")
 	flag.String("ns", "", "NATSServerURL")
+	flag.Bool("embed", false, "ForceEmbedded")
 	flag.StringVar(&stanConfigFile, "sc", "", "")
 	flag.StringVar(&stanConfigFile, "stan_config", "", "")
 	flag.Bool("file_compact_enabled", stores.DefaultFileStoreOptions.CompactEnabled, "FileStoreOpts.CompactEnabled")

--- a/server/server.go
+++ b/server/server.go
@@ -495,6 +495,7 @@ type Options struct {
 	ClientCA           string // Client CAs for TLS
 	IOBatchSize        int    // Number of messages we collect from clients before processing them.
 	IOSleepTime        int64  // Duration (in micro-seconds) the server waits for more message to fill up a batch.
+	ForceEmbedded      bool   // Force Embedded NATS Server, even if if there's a NATSServerURL
 	NATSServerURL      string // URL for external NATS Server to connect to. If empty, NATS Server is embedded.
 }
 
@@ -507,6 +508,7 @@ var defaultOptions = Options{
 	IOBatchSize:    DefaultIOBatchSize,
 	IOSleepTime:    DefaultIOSleepTime,
 	NATSServerURL:  "",
+	ForceEmbedded:  false,
 }
 
 // GetDefaultOptions returns default options for the STAN server
@@ -768,7 +770,7 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) *StanServer 
 	}
 
 	// If no NATS server url is provided, it means that we embed the NATS Server
-	if sOpts.NATSServerURL == "" {
+	if sOpts.NATSServerURL == "" || sOpts.ForceEmbedded {
 		s.startNATSServer(nOpts)
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -255,6 +255,15 @@ func TestRunServer(t *testing.T) {
 	defer s.Shutdown()
 }
 
+func TestForceRunEmbeddedServer(t *testing.T) {
+	opts := GetDefaultOptions()
+	opts.ForceEmbedded = true
+	opts.NATSServerURL = "nats://127.0.0.1:4222"
+
+	s := RunServerWithOpts(opts, nil)
+	defer s.Shutdown()
+}
+
 func TestDefaultOptions(t *testing.T) {
 
 	opts := GetDefaultOptions()


### PR DESCRIPTION
~~This looks to work with most basic cases, but I'm getting a TLS error when forcing verify clients. It might be something in my cert setup, so need to do a bit more debugging there.~~

Works fine. I had initially not set the allowed uses for client_auth on the client cert.

This is a pretty straightforward change that simply starts the server if ForceEmbedded is set to true (defaults to false, so no changes for existing users). 

This does risk someone embedding a server, but not actually connecting to it.

To reiterate, the goal of this change is to be able to run an embedded nats server with TLS required.