### PR TITLE
[ADDED] File slices configuration, including script for archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,22 +256,22 @@ file: {
     # Can be cache, do_cache, cache_msgs
     cache: true
 
-    # Define the file slice maximum number of messages. If a channel limit
-    # is set, the lowest of "channel limit max messages / 4" and this value
-    # will be used.
+    # Define the file slice maximum number of messages. If set to 0 and a
+    # channel count limit is set, then the server will set a slice count
+    # limit automatically.
     # Can be slice_max_msgs, slice_max_count, slice_msgs, slice_count
     slice_max_msgs: 10000
 
     # Define the file slice maximum size (including the size of index file).
-    # If a channel limit is set, the lowest of "channel limit max bytes / 4"
-    # and this value will be used.
+    # If set to 0 and a channel size limit is set, then the server will
+    # set a slice bytes limit automatically.
     # Expressed in bytes.
     # Can be slice_max_bytes, slice_max_size, slice_bytes, slice_size
     slice_max_bytes: 67108864
 
     # Define the period of time covered by a file slice, starting at when
-    # the first message is stored. If a channel limit is set, the lowest
-    # of "channel limit max age / 4" and this value will be used.
+    # the first message is stored. If set to 0 and a channel age limit
+    # is set, then the server will set a slice age limit automatically.
     # Expressed as a duration, such as "24h", etc..
     # Can be  slice_max_age, slice_age, slice_max_time, slice_time_limit
     slice_max_age: "24h"
@@ -468,13 +468,8 @@ those slices by number of messages it can contain (`--file_slice_max_msgs`), the
 (`--file_slice_max_bytes`), or the period of time that a file slice should cover - starting at the time the first message is stored in
 that slice (`--file_slice_max_age`). The default file store options are defined such that only the slice size is configured to 64MB.
 
-If you set channel limits, and if those limits are smaller than the slice configuration, then appropriate values will
-be selected by the server.<br>
-For instance, the default channel limits set 1,000,000 as the maximum number of messages per channel.
-The server picks a slice limit to `max_msgs/4` which is `1,000,000/4 = 250,000` messages per slice.<br>
-If messages are small, it is possible that the server will move to a new slice before the combined size of the data
-and index file reaches 64MB. This is because the file slice will have reached the number of messages (250,000) before
-reaching the size limit of 64MB.
+Note: If you don't configure any slice limit but you do configure channel limits, then the server will automatically
+set some limits for file slices.
 
 When messages accumulate in a channel, and limits are reached, older messages are removed. When the first file slice
 becomes empty, the server removes this file slice (and corresponding index file).

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Streaming Server File Store Options:
     --file_crc_poly <int>            Polynomial used to make the table used for CRC-32 checksum
     --file_sync                      Enable File.Sync on Flush
     --file_cache                     Enable messages caching
+    --file_slice_max_msgs            Maximum number of messages per file slice (subject to channel limits)
+    --file_slice_max_bytes           Maximum file slice size - including index file (subject to channel limits)
+    --file_slice_max_age             Maximum file slice duration starting when the first message is stored (subject to channel limits)
+    --file_slice_archive_script      Path to script to use if you want to archive a file slice being removed
 
 Streaming Server TLS Options:
     -secure                          Use a TLS connection to the NATS server without
@@ -251,6 +255,34 @@ file: {
     # on disk reads (improved performance at the expense of memory).
     # Can be cache, do_cache, cache_msgs
     cache: true
+
+    # Define the file slice maximum number of messages. If a channel limit
+    # is set, the lowest of "channel limit max messages / 4" and this value
+    # will be used.
+    # Can be slice_max_msgs, slice_max_count, slice_msgs, slice_count
+    slice_max_msgs: 10000
+
+    # Define the file slice maximum size (including the size of index file).
+    # If a channel limit is set, the lowest of "channel limit max bytes / 4"
+    # and this value will be used.
+    # Expressed in bytes.
+    # Can be slice_max_bytes, slice_max_size, slice_bytes, slice_size
+    slice_max_bytes: 67108864
+
+    # Define the period of time covered by a file slice, starting at when
+    # the first message is stored. If a channel limit is set, the lowest
+    # of "channel limit max age / 4" and this value will be used.
+    # Expressed as a duration, such as "24h", etc..
+    # Can be  slice_max_age, slice_age, slice_max_time, slice_time_limit
+    slice_max_age: "24h"
+
+    # Define the location and name of a script to be invoked when the
+    # server discards a file slice due to limits. The script is invoked
+    # with the name of the channel, the name of data and index files.
+    # It is the responsability of the script to then remove the unused
+    # files.
+    # Can be slice_archive_script, slice_archive, slice_script
+    slice_archive_script: "/home/nats-streaming/archive/script.sh"
 }
 ```
 
@@ -426,6 +458,42 @@ The number of sub-directories, which again correspond to channels, can be limite
 On a given channel, the number of subscriptions can also be limited with the configuration parameter `-max_subs`. A client that tries to create a subscription on a given channel (subject) for which the limit is reached will receive an error.
 
 Finally, the number of stored messages for a given channel can also be limited with the parameter `-max_msgs` and/or `-max_bytes`. However, for messages, the client does not get an error when the limit is reached. The oldest messages are discarded to make room for the new messages.
+
+#### File Store Options
+
+As described in the [Configuring](#Configuring) section, there are several options that you can use to configure a file store.
+
+Regardless of channel limits, you can configure message logs to be split in individual files (called file slices). You can configure
+those slices by number of messages it can contain (`--file_slice_max_msgs`), the size of the file - including the corresponding index file
+(`--file_slice_max_bytes`), or the period of time that a file slice should cover - starting at the time the first message is stored in
+that slice (`--file_slice_max_age`). The default file store options are defined such that only the slice size is configured to 64MB.
+
+If you set channel limits, and if those limits are smaller than the slice configuration, then appropriate values will
+be selected by the server.<br>
+For instance, the default channel limits set 1,000,000 as the maximum number of messages per channel.
+The server picks a slice limit to `max_msgs/4` which is `1,000,000/4 = 250,000` messages per slice.<br>
+If messages are small, it is possible that the server will move to a new slice before the combined size of the data
+and index file reaches 64MB. This is because the file slice will have reached the number of messages (250,000) before
+reaching the size limit of 64MB.
+
+When messages accumulate in a channel, and limits are reached, older messages are removed. When the first file slice
+becomes empty, the server removes this file slice (and corresponding index file).
+
+However, if you specify a script (`--file_slice_archive_script`), then the server will rename the slice files (data and index)
+with a `.bak` extension and invoke the script with the channel name, data and index file names.<br>
+The files are left in the channel's directory and therefore it is the script responsibility to delete those files when done.
+At any rate, those files will not be recovered on a server restart, but having lots of unused files in the directory may slow
+down the server restart.
+
+For instance, suppose the server is about to delete file slice `datastore/foo/msgs.1.dat` (and `datastore/foo/msgs.1.idx`),
+and you have configured the script `/home/nats-streaming/archive_script.sh`. The server will invoke:
+
+``` bash
+/home/nats-streaming/archive_script.sh foo datastore/foo/msgs.1.dat.bak datastore/foo/msgs.2.idx.bak
+```
+Notice how the files have been renamed with the `.bak` extension so that they are not going to be recovered if
+the script leave those files in place.
+
 
 ### Store Interface
 

--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -42,6 +42,10 @@ Streaming Server File Store Options:
     --file_crc_poly <int>            Polynomial used to make the table used for CRC-32 checksum
     --file_sync                      Enable File.Sync on Flush
     --file_cache                     Enable messages caching
+    --file_slice_max_msgs            Maximum number of messages per file slice (subject to channel limits)
+    --file_slice_max_bytes           Maximum file slice size - including index file (subject to channel limits)
+    --file_slice_max_age             Maximum file slice duration starting when the first message is stored (subject to channel limits)
+    --file_slice_archive_script      Path to script to use if you want to archive a file slice being removed
 
 Streaming Server TLS Options:
     -secure                          Use a TLS connection to the NATS server without
@@ -170,6 +174,10 @@ func parseFlags() (*stand.Options, *natsd.Options) {
 	flag.Int64("file_crc_poly", stores.DefaultFileStoreOptions.CRCPolynomial, "FileStoreOpts.CRCPolynomial")
 	flag.Bool("file_sync", stores.DefaultFileStoreOptions.DoSync, "FileStoreOpts.DoSync")
 	flag.Bool("file_cache", stores.DefaultFileStoreOptions.CacheMsgs, "FileStoreOpts.CacheMsgs")
+	flag.Int("file_slice_max_msgs", stores.DefaultFileStoreOptions.SliceMaxMsgs, "FileStoreOpts.SliceMaxMsgs")
+	flag.Int64("file_slice_max_bytes", stores.DefaultFileStoreOptions.SliceMaxBytes, "FileStoreOpts.SliceMaxBytes")
+	flag.String("file_slice_max_age", "0s", "FileStoreOpts.SliceMaxAge")
+	flag.String("file_slice_archive_script", "", "FileStoreOpts.SliceArchiveScript")
 	flag.Int("io_batch_size", stand.DefaultIOBatchSize, "IOBatchSize")
 	flag.Int64("io_sleep_time", stand.DefaultIOSleepTime, "IOSleepTime")
 

--- a/server/conf.go
+++ b/server/conf.go
@@ -266,6 +266,30 @@ func parseFileOptions(itf interface{}, opts *Options) error {
 				return err
 			}
 			opts.FileStoreOpts.CacheMsgs = v.(bool)
+		case "slice_max_msgs", "slice_max_count", "slice_msgs", "slice_count":
+			if err := checkType(k, reflect.Int64, v); err != nil {
+				return err
+			}
+			opts.FileStoreOpts.SliceMaxMsgs = int(v.(int64))
+		case "slice_max_bytes", "slice_max_size", "slice_bytes", "slice_size":
+			if err := checkType(k, reflect.Int64, v); err != nil {
+				return err
+			}
+			opts.FileStoreOpts.SliceMaxBytes = v.(int64)
+		case "slice_max_age", "slice_age", "slice_max_time", "slice_time_limit":
+			if err := checkType(k, reflect.String, v); err != nil {
+				return err
+			}
+			dur, err := time.ParseDuration(v.(string))
+			if err != nil {
+				return err
+			}
+			opts.FileStoreOpts.SliceMaxAge = dur
+		case "slice_archive_script", "slice_archive", "slice_script":
+			if err := checkType(k, reflect.String, v); err != nil {
+				return err
+			}
+			opts.FileStoreOpts.SliceArchiveScript = v.(string)
 		}
 	}
 	return nil

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -86,6 +86,18 @@ func TestParseConfig(t *testing.T) {
 	if opts.FileStoreOpts.CRCPolynomial != 5 {
 		t.Fatalf("Expected CRCPolynomial to be 5, got %v", opts.FileStoreOpts.CRCPolynomial)
 	}
+	if opts.FileStoreOpts.SliceMaxMsgs != 6 {
+		t.Fatalf("Expected SliceMaxMsgs to be 6, got %v", opts.FileStoreOpts.SliceMaxMsgs)
+	}
+	if opts.FileStoreOpts.SliceMaxBytes != 7 {
+		t.Fatalf("Expected SliceMaxBytes to be 7, got %v", opts.FileStoreOpts.SliceMaxBytes)
+	}
+	if opts.FileStoreOpts.SliceMaxAge != 8*time.Second {
+		t.Fatalf("Expected SliceMaxMsgs to be 8s, got %v", opts.FileStoreOpts.SliceMaxAge)
+	}
+	if opts.FileStoreOpts.SliceArchiveScript != "myArchiveScript" {
+		t.Fatalf("Expected SliceArchiveScript to be myArchiveScript, got %v", opts.FileStoreOpts.SliceArchiveScript)
+	}
 	if opts.MaxChannels != 11 {
 		t.Fatalf("Expected MaxChannels to be 11, got %v", opts.MaxChannels)
 	}
@@ -239,6 +251,11 @@ func TestParseWrongTypes(t *testing.T) {
 	expectFailureFor(t, "file:{crc_poly:false}", wrongTypeErr)
 	expectFailureFor(t, "file:{sync:123}", wrongTypeErr)
 	expectFailureFor(t, "file:{cache:123}", wrongTypeErr)
+	expectFailureFor(t, "file:{slice_max_msgs:true}", wrongTypeErr)
+	expectFailureFor(t, "file:{slice_max_bytes:false}", wrongTypeErr)
+	expectFailureFor(t, "file:{slice_max_age:123}", wrongTypeErr)
+	expectFailureFor(t, "file:{slice_max_age:\"1h:0m\"}", wrongTimeErr)
+	expectFailureFor(t, "file:{slice_archive_script:123}", wrongTypeErr)
 }
 
 func expectFailureFor(t *testing.T, content, errorMatch string) {

--- a/server/server.go
+++ b/server/server.go
@@ -711,6 +711,7 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) *StanServer 
 	var err error
 	var recoveredState *stores.RecoveredState
 	var recoveredSubs []*subState
+	var store stores.Store
 
 	// Ensure store type option is in upper-case
 	sOpts.StoreType = strings.ToUpper(sOpts.StoreType)
@@ -723,16 +724,25 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) *StanServer 
 			err = fmt.Errorf("for %v stores, root directory must be specified", stores.TypeFile)
 			break
 		}
-		s.store, recoveredState, err = stores.NewFileStore(sOpts.FilestoreDir, limits,
+		store, recoveredState, err = stores.NewFileStore(sOpts.FilestoreDir, limits,
 			stores.AllOptions(&sOpts.FileStoreOpts))
 	case stores.TypeMemory:
-		s.store, err = stores.NewMemoryStore(limits)
+		store, err = stores.NewMemoryStore(limits)
 	default:
 		err = fmt.Errorf("unsupported store type: %v", sOpts.StoreType)
 	}
 	if err != nil {
-		panic(fmt.Sprintf("%v", err))
+		panic(err)
 	}
+	// StanServer.store (s.store here) is of type stores.Store, which is an
+	// interace. If we assign s.store in the call of the constructor and there
+	// is an error, although the call returns "nil" for the store, we can no
+	// longer have a test such as "if s.store != nil" (as we do in shutdown).
+	// This is because the constructors return a store implementention.
+	// We would need to use reflection such as reflect.ValueOf(s.store).IsNil().
+	// So to not do that, we simply delay the setting of s.store when we know
+	// that it was successful.
+	s.store = store
 
 	// Create clientStore
 	s.clients = &clientStore{store: s.store}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -611,7 +611,7 @@ func TestInvalidUnsubRequest(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Check that sub's has been removed.
-	subs = checkSubs(t, s, clientName, 0)
+	checkSubs(t, s, clientName, 0)
 }
 
 func TestDuplicateClientIDs(t *testing.T) {

--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -1635,6 +1635,10 @@ func (ms *FileMsgStore) Store(data []byte) (uint64, error) {
 	if ms.first == 0 {
 		ms.first = 1
 		ms.firstMsg = m
+	} else if ms.first == seq {
+		// Happens after all messages expired and this is the
+		// first new message.
+		ms.firstMsg = m
 	}
 	ms.last = seq
 	ms.lastMsg = m
@@ -1785,6 +1789,10 @@ func (ms *FileMsgStore) removeFirstMsg() {
 	ms.first++
 	// Invalidate ms.firstMsg, it will be looked-up on demand.
 	ms.firstMsg = nil
+	// Invalidate ms.lastMsg if it was the last message being removed.
+	if ms.first > ms.last {
+		ms.lastMsg = nil
+	}
 	// Is file slice is "empty" and not the last one
 	if slice.msgsCount == slice.rmCount && len(ms.files) > 1 {
 		ms.removeFirstSlice()

--- a/test/configs/test_parse.conf
+++ b/test/configs/test_parse.conf
@@ -46,4 +46,8 @@ file: {
     crc_poly: 5
     sync: true
     cache: true
+    slice_max_msgs: 6
+    slice_max_bytes: 7
+    slice_max_age: "8s"
+    slice_archive_script: "myArchiveScript"
 }


### PR DESCRIPTION
You can now configure file slices to be of a certain size. The channel
limits may still override the size of the slices.
When a file slice is supposed to be removed, if a script has been
defined, the script is invoked with the renamed file slice. The
script can then move those files for archiving.

Related to #192