### PR TITLE
[ADDED] Support for Subscription.Close()

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -344,6 +344,12 @@ func TestInvalidRequests(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
+	// Send a dummy message on the STAN subscription close subject
+	if err := checkServerResponse(nc, s.info.SubClose, ErrInvalidUnsubReq,
+		&pb.SubscriptionResponse{}); err != nil {
+		t.Fatalf("%v", err)
+	}
+
 	// Send a dummy message on the STAN close subject
 	if err := checkServerResponse(nc, s.info.Close, ErrInvalidCloseReq,
 		&pb.CloseResponse{}); err != nil {
@@ -4986,5 +4992,128 @@ func TestProtocolOrder(t *testing.T) {
 			t.Fatalf("Unexpected error on unsubscribe: %v", err)
 		}
 		sc2.Close()
+	}
+}
+
+func TestDurableClosedNotUnsubscribed(t *testing.T) {
+	closeSubscriber(t, "sub")
+	closeSubscriber(t, "queue")
+}
+
+func closeSubscriber(t *testing.T, subType string) {
+	s := RunServer(clusterName)
+	defer s.Shutdown()
+
+	sc := NewDefaultConnection(t)
+	defer sc.Close()
+
+	if err := sc.Publish("foo", []byte("msg")); err != nil {
+		stackFatalf(t, "Unexpected error on publish: %v", err)
+	}
+	// Create a durable
+	durName := "dur"
+	groupName := "group"
+	durKey := fmt.Sprintf("%s-%s-%s", clientName, "foo", durName)
+	if subType == "queue" {
+		durKey = fmt.Sprintf("%s:%s", durName, groupName)
+	}
+	ch := make(chan bool)
+	errCh := make(chan bool)
+	count := 0
+	cb := func(m *stan.Msg) {
+		count++
+		if m.Sequence != uint64(count) {
+			errCh <- true
+			return
+		}
+		ch <- true
+	}
+	var sub stan.Subscription
+	var err error
+	if subType == "sub" {
+		sub, err = sc.Subscribe("foo", cb,
+			stan.DeliverAllAvailable(),
+			stan.DurableName(durName))
+	} else {
+		sub, err = sc.QueueSubscribe("foo", groupName, cb,
+			stan.DeliverAllAvailable(),
+			stan.DurableName(durName))
+	}
+	if err != nil {
+		stackFatalf(t, "Unexpected error on subscribe: %v", err)
+	}
+	wait := func() {
+		select {
+		case <-errCh:
+			stackFatalf(t, "Unexpected message received")
+		case <-ch:
+		case <-time.After(5 * time.Second):
+			stackFatalf(t, "Did not get our message")
+		}
+	}
+	wait()
+
+	s.RLock()
+	cs := s.store.LookupChannel("foo")
+	ss := cs.UserData.(*subStore)
+	var dur *subState
+	if subType == "sub" {
+		dur = ss.durables[durKey]
+	} else {
+		dur = ss.qsubs[durKey].subs[0]
+	}
+	s.RUnlock()
+	if dur == nil {
+		stackFatalf(t, "Durable should have been found")
+	}
+	// Make sure ACKs are processed before closing to avoid redelivery
+	waitForAcks(t, s, clientName, dur.ID, 0)
+	// Close durable, don't unsubscribe it
+	if err := sub.Close(); err != nil {
+		stackFatalf(t, "Error on subscriber close: %v", err)
+	}
+	// Durable should still be present
+	ss.RLock()
+	var there bool
+	if subType == "sub" {
+		_, there = ss.durables[durKey]
+	} else {
+		_, there = ss.qsubs[durKey]
+	}
+	ss.RUnlock()
+	if !there {
+		stackFatalf(t, "Durable should still be present")
+	}
+	// Send second message
+	if err := sc.Publish("foo", []byte("msg")); err != nil {
+		stackFatalf(t, "Unexpected error on publish: %v", err)
+	}
+	// Restart the durable
+	if subType == "sub" {
+		sub, err = sc.Subscribe("foo", cb,
+			stan.DeliverAllAvailable(),
+			stan.DurableName(durName))
+	} else {
+		sub, err = sc.QueueSubscribe("foo", groupName, cb,
+			stan.DeliverAllAvailable(),
+			stan.DurableName(durName))
+	}
+	wait()
+	// Unsubscribe for good
+	if err := sub.Unsubscribe(); err != nil {
+		stackFatalf(t, "Unexpected error on unsubscribe")
+	}
+	// Wait for unsub to be fully processed
+	waitForNumSubs(t, s, clientName, 0)
+	// Should have been removed
+	ss.RLock()
+	if subType == "sub" {
+		_, there = ss.durables[durKey]
+	} else {
+		_, there = ss.qsubs[durKey]
+	}
+	ss.RUnlock()
+	if there {
+		stackFatalf(t, "Durable should not be present")
 	}
 }

--- a/spb/protocol.pb.go
+++ b/spb/protocol.pb.go
@@ -75,6 +75,7 @@ type ServerInfo struct {
 	Subscribe   string `protobuf:"bytes,4,opt,name=Subscribe,proto3" json:"Subscribe,omitempty"`
 	Unsubscribe string `protobuf:"bytes,5,opt,name=Unsubscribe,proto3" json:"Unsubscribe,omitempty"`
 	Close       string `protobuf:"bytes,6,opt,name=Close,proto3" json:"Close,omitempty"`
+	SubClose    string `protobuf:"bytes,7,opt,name=SubClose,proto3" json:"SubClose,omitempty"`
 }
 
 func (m *ServerInfo) Reset()         { *m = ServerInfo{} }
@@ -287,6 +288,12 @@ func (m *ServerInfo) MarshalTo(data []byte) (int, error) {
 		i = encodeVarintProtocol(data, i, uint64(len(m.Close)))
 		i += copy(data[i:], m.Close)
 	}
+	if len(m.SubClose) > 0 {
+		data[i] = 0x3a
+		i++
+		i = encodeVarintProtocol(data, i, uint64(len(m.SubClose)))
+		i += copy(data[i:], m.SubClose)
+	}
 	return i, nil
 }
 
@@ -457,6 +464,10 @@ func (m *ServerInfo) Size() (n int) {
 		n += 1 + l + sovProtocol(uint64(l))
 	}
 	l = len(m.Close)
+	if l > 0 {
+		n += 1 + l + sovProtocol(uint64(l))
+	}
+	l = len(m.SubClose)
 	if l > 0 {
 		n += 1 + l + sovProtocol(uint64(l))
 	}
@@ -1150,6 +1161,35 @@ func (m *ServerInfo) Unmarshal(data []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Close = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SubClose", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowProtocol
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthProtocol
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SubClose = string(data[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/spb/protocol.proto
+++ b/spb/protocol.proto
@@ -41,11 +41,12 @@ message SubStateUpdate {
 // ServerInfo contains basic information regarding the Server
 message ServerInfo {
   string ClusterID   = 1; // Cluster ID
-	string Discovery   = 2; // Subject server receives connect requests on.
-	string Publish     = 3; // Subject prefix server receives published messages on.
-	string Subscribe   = 4; // Subject server receives subscription requests on.
-	string Unsubscribe = 5; // Subject server receives unsubscribe requests on.
-	string Close       = 6; // Subject server receives close requests on.
+  string Discovery   = 2; // Subject server receives connect requests on.
+  string Publish     = 3; // Subject prefix server receives published messages on.
+  string Subscribe   = 4; // Subject server receives subscription requests on.
+  string Unsubscribe = 5; // Subject server receives unsubscribe requests on.
+  string Close       = 6; // Subject server receives close requests on.
+  string SubClose    = 7; // Subject server receives subscription close requests on.
 }
 
 // ClientInfo contains information related to a Client


### PR DESCRIPTION
Client can now close a subscription without calling Unsubscribe()
which was a problem for durable subscriptions. Clients were forced
to close the connection if they wanted to stop consuming but not
delete the subscription.

Resolves #182