### PR TITLE
[FIXED] Expiration timer runaway when some but not all messages expire

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -30,7 +30,7 @@ import (
 // Server defaults.
 const (
 	// VERSION is the current version for the NATS Streaming server.
-	VERSION = "0.3.1"
+	VERSION = "0.3.3"
 
 	DefaultClusterID      = "test-cluster"
 	DefaultDiscoverPrefix = "_STAN.discover"

--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -1734,11 +1734,11 @@ func (ms *FileMsgStore) expireMsgs() {
 			ms.allDone.Done()
 			return
 		}
-		diff := now - m.timestamp
-		if diff >= maxAge {
+		elapsed := now - m.timestamp
+		if elapsed >= maxAge {
 			ms.removeFirstMsg()
 		} else {
-			ms.ageTimer.Reset(time.Duration(maxAge - now))
+			ms.ageTimer.Reset(time.Duration(maxAge - elapsed))
 			return
 		}
 	}

--- a/stores/memstore.go
+++ b/stores/memstore.go
@@ -190,11 +190,11 @@ func (ms *MemoryMsgStore) expireMsgs() {
 			ms.wg.Done()
 			return
 		}
-		diff := now - m.Timestamp
-		if diff >= maxAge {
+		elapsed := now - m.Timestamp
+		if elapsed >= maxAge {
 			ms.removeFirstMsg()
 		} else {
-			ms.ageTimer.Reset(time.Duration(maxAge - now))
+			ms.ageTimer.Reset(time.Duration(maxAge - elapsed))
 			return
 		}
 	}


### PR DESCRIPTION
When the expiration timer fires, messages that have expired are
removed. The timer is then reset to the first message yet to expire
based on the message’s time left to reach the target expiration
time. A bug was reseting the timer to a negative value, which Go
would translate to setting the timer to a nano-second.