### PR TITLE
Protocol ordering v2

### DIFF
--- a/server/bench_test.go
+++ b/server/bench_test.go
@@ -23,6 +23,8 @@ func benchCleanupDatastore(b *testing.B, dir string) {
 
 func benchRunServer(b *testing.B) *StanServer {
 	opts := GetDefaultOptions()
+	opts.Debug = false
+	opts.Trace = false
 	opts.StoreType = storeType
 	if storeType == stores.TypeFile {
 		opts.FilestoreDir = defaultDataStore

--- a/server/log_test.go
+++ b/server/log_test.go
@@ -14,6 +14,9 @@ import (
 func TestConfigureLogger(t *testing.T) {
 
 	defer RemoveLogger()
+	defer setDebugAndTraceToDefaultOptions(true)
+
+	setDebugAndTraceToDefaultOptions(false)
 
 	checkDebugTraceOff := func() {
 		if debug != 0 || trace != 0 {
@@ -65,6 +68,9 @@ func TestConfigureLogger(t *testing.T) {
 func TestLogging(t *testing.T) {
 
 	defer RemoveLogger()
+	defer setDebugAndTraceToDefaultOptions(true)
+
+	setDebugAndTraceToDefaultOptions(false)
 
 	// test without a logger
 	Noticef("noop")
@@ -130,6 +136,9 @@ func (d *dummyLogger) Reset() {
 
 func TestLogOutput(t *testing.T) {
 	defer RemoveLogger()
+	defer setDebugAndTraceToDefaultOptions(true)
+
+	setDebugAndTraceToDefaultOptions(false)
 
 	// dummy to override the configured logger.
 	d := &dummyLogger{}
@@ -190,6 +199,9 @@ func TestLogOutput(t *testing.T) {
 
 func TestRunServerFailureLogsCause(t *testing.T) {
 	defer RemoveLogger()
+	defer setDebugAndTraceToDefaultOptions(true)
+
+	setDebugAndTraceToDefaultOptions(false)
 
 	// dummy to override the configured logger.
 	d := &dummyLogger{}

--- a/server/server.go
+++ b/server/server.go
@@ -106,107 +106,18 @@ func init() {
 	}
 }
 
-// ioPendingMsg is a record that embeds the PubMsg and PubAck
-// structures so we reduce the number of memory allocations
-// to 1 when processing a message from producer.
+// ioPendingMsg is a record that embeds the pointer to the incoming
+// NATS Message, the PubMsg and PubAck structures so we reduce the
+// number of memory allocations to 1 when processing a message from
+// producer.
 type ioPendingMsg struct {
+	m  *nats.Msg
 	pm pb.PubMsg
 	pa pb.PubAck
 }
 
 // Constant that defines the size of the channel that feeds the IO thread.
 const ioChannelSize = 64 * 1024
-
-// ioProto is a structure that includes the incoming NATS protocol message.
-// Those protocols are chained and processed in the ioLoop. This structure
-// includes a pointer to a ioPendingMsg for (the majority of) cases where
-// the protocol is a published message.
-type ioProto struct {
-	m      *nats.Msg
-	pubmsg *ioPendingMsg
-	next   *ioProto
-}
-
-// ioProtoList is a list of ioProto records.
-type ioProtoList struct {
-	sync.RWMutex
-	head  *ioProto
-	tail  *ioProto
-	count int
-}
-
-// append adds a protocol to the end of the list.
-// This call is not thread-safe.
-func (l *ioProtoList) append(proto *ioProto) {
-	if l.tail == nil {
-		l.head = proto
-	} else {
-		l.tail.next = proto
-	}
-	l.tail = proto
-	l.count++
-}
-
-// protectedAppend is similar to ioProtoList.append except that it is thread-safe.
-func (l *ioProtoList) protectedAppend(proto *ioProto) {
-	l.Lock()
-	l.append(proto)
-	l.Unlock()
-}
-
-// popHead removes the head of the list and returns it, or nil if the list is
-// empty.
-// This call is not thread-safe.
-func (l *ioProtoList) popHead() *ioProto {
-	proto := l.head
-	if l.head != nil {
-		l.head = proto.next
-		l.count--
-		if l.count == 0 {
-			l.tail = nil
-		}
-		proto.next = nil
-	}
-	return proto
-}
-
-// getCount returns the number of elements in the list.
-// This call is not thread-safe.
-func (l *ioProtoList) getCount() int {
-	return l.count
-}
-
-// protectedGetCount is similar to ioProtoList.getCount except that it is thread-safe.
-func (l *ioProtoList) protectedGetCount() int {
-	l.RLock()
-	count := l.count
-	l.RUnlock()
-	return count
-}
-
-// isEmpty returns true if the list is empty, false otherwise.
-// This call is not thread-safe.
-func (l *ioProtoList) isEmpty() bool {
-	return l.count == 0
-}
-
-// protectedTransferTo transfers meta data of list `l` into `dst` and
-// clears `l` under lock.
-func (l *ioProtoList) protectedTransferTo(dst *ioProtoList) {
-	l.Lock()
-	dst.head = l.head
-	dst.tail = l.tail
-	dst.count = l.count
-	l.head, l.tail, l.count = nil, nil, 0
-	l.Unlock()
-}
-
-// ioProtoPool is a sync.Pool for ioProto objects.
-var ioProtoPool = sync.Pool{
-	New: func() interface{} {
-		return &ioProto{}
-	},
-}
 
 // StanServer structure represents the STAN server
 type StanServer struct {
@@ -251,19 +162,9 @@ type StanServer struct {
 	store stores.Store
 
 	// IO Channel
-	ioChannel     chan *nats.Msg
+	ioChannel     chan *ioPendingMsg
 	ioChannelQuit chan struct{}
 	ioChannelWG   sync.WaitGroup
-	ioSignal      chan struct{}
-	ioList        *ioProtoList
-
-	// Channel subscribers (to identify which subjects message belongs to)
-	connSub     *nats.Subscription
-	pubSub      *nats.Subscription
-	subSub      *nats.Subscription
-	unsubSub    *nats.Subscription
-	subCloseSub *nats.Subscription
-	closeSub    *nats.Subscription
 
 	// Use these flags for Debug/Trace in places where speed matters.
 	// Normally, Debugf and Tracef will check an atomic variable to
@@ -615,6 +516,12 @@ var DefaultNatsServerOptions = server.Options{
 	NoSigs: true,
 }
 
+// Used only by tests
+func setDebugAndTraceToDefaultOptions(val bool) {
+	defaultOptions.Trace = val
+	defaultOptions.Debug = val
+}
+
 func stanDisconnectedHandler(nc *nats.Conn) {
 	if nc.LastError() != nil {
 		Errorf("STAN: connection %q has been disconnected: %v",
@@ -775,9 +682,7 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) *StanServer 
 		dupCIDMap:         make(map[string]struct{}),
 		dupMaxCIDRoutines: defaultMaxDupCIDRoutines,
 		dupCIDTimeout:     defaultCheckDupCIDTimeout,
-		ioList:            &ioProtoList{},
-		ioSignal:          make(chan struct{}, 1),
-		ioChannelQuit:     make(chan struct{}, 2),
+		ioChannelQuit:     make(chan struct{}, 1),
 		trace:             sOpts.Trace,
 		debug:             sOpts.Debug,
 	}
@@ -1201,11 +1106,12 @@ func (s *StanServer) postRecoveryProcessing(recoveredClients []*stores.Client, r
 		// been created (may happen with durables that may reconnect maybe?)
 		if sub.ackSub == nil {
 			// Subscribe to acks
-			sub.ackSub, err = s.nc.ChanSubscribe(sub.AckInbox, s.ioChannel)
+			sub.ackSub, err = s.nc.Subscribe(sub.AckInbox, s.processAckMsg)
 			if err != nil {
 				sub.Unlock()
 				return err
 			}
+			sub.ackSub.SetPendingLimits(-1, -1)
 		}
 		sub.Unlock()
 	}
@@ -1278,38 +1184,34 @@ func (s *StanServer) initSubscriptions() {
 
 	s.startIOLoop()
 
-	var err error
-	// We use ChanSubscribe and specify the same channel for all subscriptions.
-	// This gives us connection level ordering.
-
 	// Listen for connection requests.
-	s.connSub, err = s.nc.ChanSubscribe(s.info.Discovery, s.ioChannel)
+	_, err := s.nc.Subscribe(s.info.Discovery, s.connectCB)
 	if err != nil {
 		panic(fmt.Sprintf("Could not subscribe to discover subject, %v\n", err))
 	}
 	// Receive published messages from clients.
 	pubSubject := fmt.Sprintf("%s.>", s.info.Publish)
-	s.pubSub, err = s.nc.ChanSubscribe(pubSubject, s.ioChannel)
+	_, err = s.nc.Subscribe(pubSubject, s.processClientPublish)
 	if err != nil {
 		panic(fmt.Sprintf("Could not subscribe to publish subject, %v\n", err))
 	}
 	// Receive subscription requests from clients.
-	s.subSub, err = s.nc.ChanSubscribe(s.info.Subscribe, s.ioChannel)
+	_, err = s.nc.Subscribe(s.info.Subscribe, s.processSubscriptionRequest)
 	if err != nil {
 		panic(fmt.Sprintf("Could not subscribe to subscribe request subject, %v\n", err))
 	}
 	// Receive unsubscribe requests from clients.
-	s.unsubSub, err = s.nc.ChanSubscribe(s.info.Unsubscribe, s.ioChannel)
+	_, err = s.nc.Subscribe(s.info.Unsubscribe, s.processUnSubscribeRequest)
 	if err != nil {
 		panic(fmt.Sprintf("Could not subscribe to unsubscribe request subject, %v\n", err))
 	}
 	// Receive subscription close requests from clients.
-	s.subCloseSub, err = s.nc.ChanSubscribe(s.info.SubClose, s.ioChannel)
+	_, err = s.nc.Subscribe(s.info.SubClose, s.processSubCloseRequest)
 	if err != nil {
 		panic(fmt.Sprintf("Could not subscribe to subscription close request subject, %v\n", err))
 	}
 	// Receive close requests from clients.
-	s.closeSub, err = s.nc.ChanSubscribe(s.info.Close, s.ioChannel)
+	_, err = s.nc.Subscribe(s.info.Close, s.processCloseRequest)
 	if err != nil {
 		panic(fmt.Sprintf("Could not subscribe to close request subject, %v\n", err))
 	}
@@ -1572,8 +1474,8 @@ func (s *StanServer) sendCloseErr(subj, err string) {
 }
 
 // processClientPublish process inbound messages from clients.
-func (s *StanServer) processClientPublish(m *nats.Msg) (*ioPendingMsg, *stores.ChannelStore) {
-	iopm := &ioPendingMsg{}
+func (s *StanServer) processClientPublish(m *nats.Msg) {
+	iopm := &ioPendingMsg{m: m}
 	pm := &iopm.pm
 	pm.Unmarshal(m.Data)
 
@@ -1581,16 +1483,10 @@ func (s *StanServer) processClientPublish(m *nats.Msg) (*ioPendingMsg, *stores.C
 	if pm.Guid == "" || !s.clients.IsValid(pm.ClientID) || !isValidSubject(pm.Subject) {
 		Errorf("STAN: Received invalid client publish message %v", pm)
 		s.sendPublishErr(m.Reply, pm.Guid, ErrInvalidPubReq)
-		return nil, nil
+		return
 	}
 
-	cs, err := s.assignAndStore(&iopm.pm)
-	if err != nil {
-		Errorf("STAN: [Client:%s] Error processing message for subject %q: %v", pm.ClientID, m.Subject, err)
-		s.sendPublishErr(m.Reply, pm.Guid, err)
-		return nil, nil
-	}
-	return iopm, cs
+	s.ioChannel <- iopm
 }
 
 func (s *StanServer) sendPublishErr(subj, guid string, err error) {
@@ -1950,37 +1846,15 @@ func (s *StanServer) setupAckTimer(sub *subState, d time.Duration) {
 }
 
 func (s *StanServer) startIOLoop() {
-	s.ioChannelWG.Add(2)
-	s.ioChannel = make(chan *nats.Msg, ioChannelSize)
-	// Use wait group to ensure that those loops are as ready as
+	s.ioChannelWG.Add(1)
+	s.ioChannel = make(chan *ioPendingMsg, ioChannelSize)
+	// Use wait group to ensure that the loop is as ready as
 	// possible before we setup the subscriptions and open the door
 	// to incoming NATS messages.
 	ready := &sync.WaitGroup{}
-	ready.Add(2)
-	go s.buildProtocolsList(ready)
+	ready.Add(1)
 	go s.ioLoop(ready)
 	ready.Wait()
-}
-
-func (s *StanServer) buildProtocolsList(ready *sync.WaitGroup) {
-	defer s.ioChannelWG.Done()
-
-	ready.Done()
-	for {
-		select {
-		case m := <-s.ioChannel:
-			iop := ioProtoPool.Get().(*ioProto)
-			iop.m = m
-			iop.pubmsg = nil
-			iop.next = nil
-			s.ioList.protectedAppend(iop)
-			if len(s.ioSignal) == 0 {
-				s.ioSignal <- struct{}{}
-			}
-		case <-s.ioChannelQuit:
-			return
-		}
-	}
 }
 
 func (s *StanServer) ioLoop(ready *sync.WaitGroup) {
@@ -1998,126 +1872,97 @@ func (s *StanServer) ioLoop(ready *sync.WaitGroup) {
 	////////////////////////////////////////////////////////////////////////////
 	storesToFlush := make(map[*stores.ChannelStore]struct{}, 64)
 
+	var _pendingMsgs [ioChannelSize]*ioPendingMsg
+	var pendingMsgs = _pendingMsgs[:0]
+
+	storeIOPendingMsg := func(iopm *ioPendingMsg) {
+		cs, err := s.assignAndStore(&iopm.pm)
+		if err != nil {
+			Errorf("STAN: [Client:%s] Error processing message for subject %q: %v", iopm.pm.ClientID, iopm.m.Subject, err)
+			s.sendPublishErr(iopm.m.Reply, iopm.pm.Guid, err)
+		} else {
+			pendingMsgs = append(pendingMsgs, iopm)
+			storesToFlush[cs] = struct{}{}
+		}
+	}
+
 	batchSize := s.opts.IOBatchSize
 	sleepTime := s.opts.IOSleepTime
 	sleepDur := time.Duration(sleepTime) * time.Microsecond
 	max := 0
-	pubMsgs := &ioProtoList{}
-	list := &ioProtoList{}
 
 	ready.Done()
 	for {
 		select {
-		case <-s.ioSignal:
-			// If allowed to sleep, to try gather more
-			if sleepTime > 0 {
-				count := s.ioList.protectedGetCount()
-				if count > 0 && count < batchSize {
-					time.Sleep(sleepDur)
-				}
-			}
-			// Transfer the global list meta data into this local list,
-			// and clear the global list at the same time.
-			s.ioList.protectedTransferTo(list)
+		case iopm := <-s.ioChannel:
+			// store the one we just pulled
+			storeIOPendingMsg(iopm)
 
-			// It is possible that current signal was processed by
-			// previous iteration. So if count is 0, we are done.
-			count := list.getCount()
-			if count == 0 {
-				continue
-			}
+			remaining := batchSize - 1
+			// fill the pending messages slice with at most our batch size,
+			// unless the channel is empty.
+			for remaining > 0 {
+				ioChanLen := len(s.ioChannel)
 
-			// Note that the count may be higher than batchSize, so we
-			// will limit processing up to batchSize and repeat until
-			// list is empty.
-			for count > 0 {
-				if batchSize > 0 && count > batchSize {
-					count = batchSize
-				}
-				// Keep track of max number of messages in a batch
-				if count > max {
-					max = count
-					atomic.StoreInt64(&(s.ioChannelStatsMaxBatchSize), int64(max))
-				}
-				for i := 0; i < count; i++ {
-					proto := list.popHead()
-
-					// Process client published messages and add them to the
-					// pubMsgs list.
-					if proto.m.Sub == s.pubSub {
-						iopm, cs := s.processClientPublish(proto.m)
-						if iopm != nil {
-							proto.pubmsg = iopm
-							storesToFlush[cs] = struct{}{}
-							pubMsgs.append(proto)
+				// if we are empty, wait, check again, and break if nothing.
+				// While this adds some latency, it optimizes batching.
+				if ioChanLen == 0 {
+					if sleepTime > 0 {
+						time.Sleep(sleepDur)
+						ioChanLen = len(s.ioChannel)
+						if ioChanLen == 0 {
+							break
 						}
 					} else {
-						// Process any pubMsg that we got up to that point.
-						if !pubMsgs.isEmpty() {
-							s.processPubMsgs(pubMsgs, storesToFlush)
-						}
-						switch proto.m.Sub {
-						case s.connSub:
-							s.connectCB(proto.m)
-						case s.subSub:
-							s.processSubscriptionRequest(proto.m)
-						case s.unsubSub:
-							s.processUnSubscribeRequest(proto.m)
-						case s.subCloseSub:
-							s.processSubscriptionCloseRequest(proto.m)
-						case s.closeSub:
-							s.processCloseRequest(proto.m)
-						default:
-							// assume this is an ACK
-							ack := &pb.Ack{}
-							if err := ack.Unmarshal(proto.m.Data); err != nil {
-								if s.debug {
-									Debugf("Unknown subject: %q", proto.m.Subject)
-								}
-							} else {
-								s.processAckMsg(ack, proto.m)
-							}
-						}
-						// Put back into pool
-						ioProtoPool.Put(proto)
+						break
 					}
 				}
-				// If there are pubMsgs, process them now.
-				if !pubMsgs.isEmpty() {
-					s.processPubMsgs(pubMsgs, storesToFlush)
+
+				// stick to our buffer size
+				if ioChanLen > remaining {
+					ioChanLen = remaining
 				}
-				// Refresh count
-				count = list.getCount()
+
+				for i := 0; i < ioChanLen; i++ {
+					storeIOPendingMsg(<-s.ioChannel)
+				}
+				// Keep track of max number of messages in a batch
+				if ioChanLen > max {
+					max = ioChanLen
+					atomic.StoreInt64(&(s.ioChannelStatsMaxBatchSize), int64(max))
+				}
+				remaining -= ioChanLen
 			}
+
+			// flush all the stores with messages written to them...
+			for cs := range storesToFlush {
+				if err := cs.Msgs.Flush(); err != nil {
+					// TODO: Attempt recovery, notify publishers of error.
+					panic(fmt.Errorf("Unable to flush msg store: %v", err))
+				}
+				// Call this here, so messages are sent to subscribers,
+				// which means that msg seq is added to subscription file
+				s.processMsg(cs)
+				if err := cs.Subs.Flush(); err != nil {
+					panic(fmt.Errorf("Unable to flush sub store: %v", err))
+				}
+				// Remove entry from map (this is safe in Go)
+				delete(storesToFlush, cs)
+			}
+
+			// Ack our messages back to the publisher
+			for i := range pendingMsgs {
+				iopm := pendingMsgs[i]
+				s.ackPublisher(iopm)
+				pendingMsgs[i] = nil
+			}
+
+			// clear out pending messages
+			pendingMsgs = pendingMsgs[:0]
+
 		case <-s.ioChannelQuit:
 			return
 		}
-	}
-}
-
-func (s *StanServer) processPubMsgs(list *ioProtoList, storesToFlush map[*stores.ChannelStore]struct{}) {
-	// flush all the stores with messages written to them...
-	for cs := range storesToFlush {
-		if err := cs.Msgs.Flush(); err != nil {
-			// TODO: Attempt recovery, notify publishers of error.
-			panic(fmt.Errorf("Unable to flush msg store: %v", err))
-		}
-		// Call this here, so messages are sent to subscribers,
-		// which means that msg seq is added to subscription file
-		s.processMsg(cs)
-		if err := cs.Subs.Flush(); err != nil {
-			panic(fmt.Errorf("Unable to flush sub store: %v", err))
-		}
-		// Remove entry from map (this is safe in Go)
-		delete(storesToFlush, cs)
-	}
-
-	// Ack our messages back to the publisher
-	for !list.isEmpty() {
-		proto := list.popHead()
-		s.ackPublisher(proto.m, proto.pubmsg)
-		// Put back into pool
-		ioProtoPool.Put(proto)
 	}
 }
 
@@ -2134,7 +1979,7 @@ func (s *StanServer) assignAndStore(pm *pb.PubMsg) (*stores.ChannelStore, error)
 }
 
 // ackPublisher sends the ack for a message.
-func (s *StanServer) ackPublisher(m *nats.Msg, iopm *ioPendingMsg) {
+func (s *StanServer) ackPublisher(iopm *ioPendingMsg) {
 	msgAck := &iopm.pa
 	msgAck.Guid = iopm.pm.Guid
 	var buf [32]byte
@@ -2144,7 +1989,7 @@ func (s *StanServer) ackPublisher(m *nats.Msg, iopm *ioPendingMsg) {
 		pm := &iopm.pm
 		Tracef("STAN: [Client:%s] Acking Publisher subj=%s guid=%s", pm.ClientID, pm.Subject, pm.Guid)
 	}
-	s.ncs.Publish(m.Reply, b[:n])
+	s.ncs.Publish(iopm.m.Reply, b[:n])
 }
 
 // Delete a sub from a given list.
@@ -2212,11 +2057,11 @@ func (s *StanServer) processUnSubscribeRequest(m *nats.Msg) {
 }
 
 // processSubCloseRequest will process a subscription close request.
-func (s *StanServer) processSubscriptionCloseRequest(m *nats.Msg) {
+func (s *StanServer) processSubCloseRequest(m *nats.Msg) {
 	req := &pb.UnsubscribeRequest{}
 	err := req.Unmarshal(m.Data)
 	if err != nil {
-		Errorf("STAN: Invalid unsub request from %s.", m.Subject)
+		Errorf("STAN: Invalid sub close request from %s.", m.Subject)
 		s.sendSubscriptionResponseErr(m.Reply, ErrInvalidUnsubReq)
 		return
 	}
@@ -2590,11 +2435,12 @@ func (s *StanServer) processSubscriptionRequest(m *nats.Msg) {
 	// Subscribe to acks.
 	// We MUST use the same connection than all other chan subscribers
 	// if we want to receive messages in order from NATS server.
-	sub.ackSub, err = s.nc.ChanSubscribe(ackInbox, s.ioChannel)
+	sub.ackSub, err = s.nc.Subscribe(ackInbox, s.processAckMsg)
 	if err != nil {
 		sub.Unlock()
 		panic(fmt.Sprintf("Could not subscribe to ack subject, %v\n", err))
 	}
+	sub.ackSub.SetPendingLimits(-1, -1)
 	sub.Unlock()
 	// However, we need to flush to ensure that NATS server processes
 	// this subscription request before we return OK and start sending
@@ -2625,7 +2471,9 @@ func (s *StanServer) processSubscriptionRequest(m *nats.Msg) {
 }
 
 // processAckMsg processes inbound acks from clients for delivered messages.
-func (s *StanServer) processAckMsg(ack *pb.Ack, m *nats.Msg) {
+func (s *StanServer) processAckMsg(m *nats.Msg) {
+	ack := &pb.Ack{}
+	ack.Unmarshal(m.Data)
 	cs := s.store.LookupChannel(ack.Subject)
 	if cs == nil {
 		Errorf("STAN: [Client:?] Ack received, invalid channel (%s)", ack.Subject)
@@ -2846,8 +2694,6 @@ func (s *StanServer) Shutdown() {
 
 	if s.ioChannel != nil {
 		// Notify the IO channel that we are shutting down
-		s.ioChannelQuit <- struct{}{}
-		// There is also the loop that gets messages from NATS
 		s.ioChannelQuit <- struct{}{}
 	} else {
 		waitForIOStoreLoop = false

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -44,6 +44,8 @@ func init() {
 		panic(fmt.Errorf("Error removing temp directory: %v", err))
 	}
 	defaultDataStore = tmpDir
+	// Set debug and trace for this file.
+	setDebugAndTraceToDefaultOptions(true)
 }
 
 func stackFatalf(t tLogger, f string, args ...interface{}) {
@@ -4886,6 +4888,7 @@ func TestPerChannelLimits(t *testing.T) {
 }
 
 func TestProtocolOrder(t *testing.T) {
+	t.SkipNow()
 	s := RunServer(clusterName)
 	defer s.Shutdown()
 
@@ -4899,6 +4902,16 @@ func TestProtocolOrder(t *testing.T) {
 			t.Fatalf("Unexpected error on subscribe: %v", err)
 		}
 		if err := sub.Unsubscribe(); err != nil {
+			t.Fatalf("Unexpected error on unsubscribe: %v", err)
+		}
+	}
+	// Subscription close should not be processed before Subscribe
+	for i := 0; i < 100; i++ {
+		sub, err := sc.Subscribe("foo", nil)
+		if err != nil {
+			t.Fatalf("Unexpected error on subscribe: %v", err)
+		}
+		if err := sub.Close(); err != nil {
 			t.Fatalf("Unexpected error on unsubscribe: %v", err)
 		}
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -4888,37 +4888,163 @@ func TestPerChannelLimits(t *testing.T) {
 }
 
 func TestProtocolOrder(t *testing.T) {
-	t.SkipNow()
 	s := RunServer(clusterName)
 	defer s.Shutdown()
 
 	sc := NewDefaultConnection(t)
 	defer sc.Close()
 
-	// Unsubscribe should not be processed before Subscribe
-	for i := 0; i < 100; i++ {
-		sub, err := sc.Subscribe("foo", nil)
-		if err != nil {
-			t.Fatalf("Unexpected error on subscribe: %v", err)
-		}
-		if err := sub.Unsubscribe(); err != nil {
-			t.Fatalf("Unexpected error on unsubscribe: %v", err)
+	for i := 0; i < 10; i++ {
+		if err := sc.Publish("bar", []byte("hello")); err != nil {
+			t.Fatalf("Unexpected error on publish: %v", err)
 		}
 	}
-	// Subscription close should not be processed before Subscribe
-	for i := 0; i < 100; i++ {
-		sub, err := sc.Subscribe("foo", nil)
-		if err != nil {
+
+	ch := make(chan bool)
+	errCh := make(chan error)
+
+	recv := int32(0)
+	mode := 0
+	var sc2 stan.Conn
+	cb := func(m *stan.Msg) {
+		count := atomic.AddInt32(&recv, 1)
+		if err := m.Ack(); err != nil {
+			errCh <- err
+			return
+		}
+		if count == 10 {
+			var err error
+			switch mode {
+			case 1:
+				err = m.Sub.Unsubscribe()
+			case 2:
+				err = m.Sub.Close()
+			case 3:
+				err = sc2.Close()
+			case 4:
+				err = m.Sub.Unsubscribe()
+				if err == nil {
+					err = sc2.Close()
+				}
+			case 5:
+				err = m.Sub.Close()
+				if err == nil {
+					err = sc2.Close()
+				}
+			}
+			if err != nil {
+				errCh <- err
+			} else {
+				ch <- true
+			}
+		}
+	}
+
+	total := 50
+	// Unsubscribe should not be processed before last processed Ack
+	mode = 1
+	for i := 0; i < total; i++ {
+		atomic.StoreInt32(&recv, 0)
+		if _, err := sc.Subscribe("bar", cb,
+			stan.SetManualAckMode(), stan.DeliverAllAvailable()); err != nil {
 			t.Fatalf("Unexpected error on subscribe: %v", err)
 		}
-		if err := sub.Close(); err != nil {
-			t.Fatalf("Unexpected error on unsubscribe: %v", err)
+		// Wait confirmation of received message
+		select {
+		case <-ch:
+		case e := <-errCh:
+			t.Fatal(e)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timed-out waiting for messages")
+		}
+	}
+	// Subscription close should not be processed before last processed Ack
+	mode = 2
+	for i := 0; i < total; i++ {
+		atomic.StoreInt32(&recv, 0)
+		if _, err := sc.Subscribe("bar", cb,
+			stan.SetManualAckMode(), stan.DeliverAllAvailable()); err != nil {
+			t.Fatalf("Unexpected error on subscribe: %v", err)
+		}
+		// Wait confirmation of received message
+		select {
+		case <-ch:
+		case e := <-errCh:
+			t.Fatal(e)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timed-out waiting for messages")
+		}
+	}
+	// Connection close should not be processed before last processed Ack
+	mode = 3
+	for i := 0; i < total; i++ {
+		atomic.StoreInt32(&recv, 0)
+		conn, err := stan.Connect(clusterName, "otherclient")
+		if err != nil {
+			t.Fatalf("Expected to connect correctly, got err %v", err)
+		}
+		sc2 = conn
+		if _, err := sc2.Subscribe("bar", cb,
+			stan.SetManualAckMode(), stan.DeliverAllAvailable()); err != nil {
+			t.Fatalf("Unexpected error on subscribe: %v", err)
+		}
+		// Wait confirmation of received message
+		select {
+		case <-ch:
+		case e := <-errCh:
+			t.Fatal(e)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timed-out waiting for messages")
+		}
+	}
+	// Connection close should not be processed before unsubscribe and last processed Ack
+	mode = 4
+	for i := 0; i < total; i++ {
+		atomic.StoreInt32(&recv, 0)
+		conn, err := stan.Connect(clusterName, "otherclient")
+		if err != nil {
+			t.Fatalf("Expected to connect correctly, got err %v", err)
+		}
+		sc2 = conn
+		if _, err := sc2.Subscribe("bar", cb,
+			stan.SetManualAckMode(), stan.DeliverAllAvailable()); err != nil {
+			t.Fatalf("Unexpected error on subscribe: %v", err)
+		}
+		// Wait confirmation of received message
+		select {
+		case <-ch:
+		case e := <-errCh:
+			t.Fatal(e)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timed-out waiting for messages")
+		}
+	}
+	// Connection close should not be processed before sub close and last processed Ack
+	mode = 5
+	for i := 0; i < total; i++ {
+		atomic.StoreInt32(&recv, 0)
+		conn, err := stan.Connect(clusterName, "otherclient")
+		if err != nil {
+			t.Fatalf("Expected to connect correctly, got err %v", err)
+		}
+		sc2 = conn
+		if _, err := sc2.Subscribe("bar", cb,
+			stan.SetManualAckMode(), stan.DeliverAllAvailable()); err != nil {
+			t.Fatalf("Unexpected error on subscribe: %v", err)
+		}
+		// Wait confirmation of received message
+		select {
+		case <-ch:
+		case e := <-errCh:
+			t.Fatal(e)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timed-out waiting for messages")
 		}
 	}
 
 	// Mix pub and subscribe calls
-	ch := make(chan bool)
-	errCh := make(chan error)
+	ch = make(chan bool)
+	errCh = make(chan error)
 	startSubAt := 50
 	var sub stan.Subscription
 	var err error
@@ -4950,7 +5076,7 @@ func TestProtocolOrder(t *testing.T) {
 	sub.Unsubscribe()
 
 	// Acks should be processed before Connection close
-	for i := 0; i < 100; i++ {
+	for i := 0; i < total; i++ {
 		rcv := int32(0)
 		sc2, err := stan.Connect(clusterName, "otherclient")
 		if err != nil {

--- a/spb/protocol.pb.go
+++ b/spb/protocol.pb.go
@@ -15,6 +15,7 @@
 		ServerInfo
 		ClientInfo
 		ClientDelete
+		CtrlMsg
 */
 package spb
 
@@ -29,6 +30,29 @@ import io "io"
 var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
+
+type CtrlMsg_Type int32
+
+const (
+	CtrlMsg_SubUnsubscribe CtrlMsg_Type = 0
+	CtrlMsg_SubClose       CtrlMsg_Type = 1
+	CtrlMsg_ConnClose      CtrlMsg_Type = 2
+)
+
+var CtrlMsg_Type_name = map[int32]string{
+	0: "SubUnsubscribe",
+	1: "SubClose",
+	2: "ConnClose",
+}
+var CtrlMsg_Type_value = map[string]int32{
+	"SubUnsubscribe": 0,
+	"SubClose":       1,
+	"ConnClose":      2,
+}
+
+func (x CtrlMsg_Type) String() string {
+	return proto.EnumName(CtrlMsg_Type_name, int32(x))
+}
 
 // SubState represents the state of a Subscription
 type SubState struct {
@@ -100,6 +124,16 @@ func (m *ClientDelete) Reset()         { *m = ClientDelete{} }
 func (m *ClientDelete) String() string { return proto.CompactTextString(m) }
 func (*ClientDelete) ProtoMessage()    {}
 
+type CtrlMsg struct {
+	MsgType  CtrlMsg_Type `protobuf:"varint,1,opt,name=MsgType,proto3,enum=spb.CtrlMsg_Type" json:"MsgType,omitempty"`
+	ServerID string       `protobuf:"bytes,2,opt,name=ServerID,proto3" json:"ServerID,omitempty"`
+	Data     []byte       `protobuf:"bytes,3,opt,name=Data,proto3" json:"Data,omitempty"`
+}
+
+func (m *CtrlMsg) Reset()         { *m = CtrlMsg{} }
+func (m *CtrlMsg) String() string { return proto.CompactTextString(m) }
+func (*CtrlMsg) ProtoMessage()    {}
+
 func init() {
 	proto.RegisterType((*SubState)(nil), "spb.SubState")
 	proto.RegisterType((*SubStateDelete)(nil), "spb.SubStateDelete")
@@ -107,6 +141,8 @@ func init() {
 	proto.RegisterType((*ServerInfo)(nil), "spb.ServerInfo")
 	proto.RegisterType((*ClientInfo)(nil), "spb.ClientInfo")
 	proto.RegisterType((*ClientDelete)(nil), "spb.ClientDelete")
+	proto.RegisterType((*CtrlMsg)(nil), "spb.CtrlMsg")
+	proto.RegisterEnum("spb.CtrlMsg_Type", CtrlMsg_Type_name, CtrlMsg_Type_value)
 }
 func (m *SubState) Marshal() (data []byte, err error) {
 	size := m.Size()
@@ -351,6 +387,43 @@ func (m *ClientDelete) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
+func (m *CtrlMsg) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *CtrlMsg) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.MsgType != 0 {
+		data[i] = 0x8
+		i++
+		i = encodeVarintProtocol(data, i, uint64(m.MsgType))
+	}
+	if len(m.ServerID) > 0 {
+		data[i] = 0x12
+		i++
+		i = encodeVarintProtocol(data, i, uint64(len(m.ServerID)))
+		i += copy(data[i:], m.ServerID)
+	}
+	if m.Data != nil {
+		if len(m.Data) > 0 {
+			data[i] = 0x1a
+			i++
+			i = encodeVarintProtocol(data, i, uint64(len(m.Data)))
+			i += copy(data[i:], m.Data)
+		}
+	}
+	return i, nil
+}
+
 func encodeFixed64Protocol(data []byte, offset int, v uint64) int {
 	data[offset] = uint8(v)
 	data[offset+1] = uint8(v >> 8)
@@ -494,6 +567,25 @@ func (m *ClientDelete) Size() (n int) {
 	l = len(m.ID)
 	if l > 0 {
 		n += 1 + l + sovProtocol(uint64(l))
+	}
+	return n
+}
+
+func (m *CtrlMsg) Size() (n int) {
+	var l int
+	_ = l
+	if m.MsgType != 0 {
+		n += 1 + sovProtocol(uint64(m.MsgType))
+	}
+	l = len(m.ServerID)
+	if l > 0 {
+		n += 1 + l + sovProtocol(uint64(l))
+	}
+	if m.Data != nil {
+		l = len(m.Data)
+		if l > 0 {
+			n += 1 + l + sovProtocol(uint64(l))
+		}
 	}
 	return n
 }
@@ -1377,6 +1469,135 @@ func (m *ClientDelete) Unmarshal(data []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.ID = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipProtocol(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthProtocol
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CtrlMsg) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowProtocol
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CtrlMsg: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CtrlMsg: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MsgType", wireType)
+			}
+			m.MsgType = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowProtocol
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.MsgType |= (CtrlMsg_Type(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ServerID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowProtocol
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthProtocol
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ServerID = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Data", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowProtocol
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthProtocol
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Data = append(m.Data[:0], data[iNdEx:postIndex]...)
+			if m.Data == nil {
+				m.Data = []byte{}
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/spb/protocol.proto
+++ b/spb/protocol.proto
@@ -58,3 +58,14 @@ message ClientInfo {
 message ClientDelete {
   string ID = 1; // ID of the client being unregistered
 }
+
+message CtrlMsg {
+  enum Type {
+    SubUnsubscribe = 0; // Subscription Unsubscribe request.
+    SubClose       = 1; // Subscription Close request.
+    ConnClose      = 2; // Connection Close request.
+  }
+  Type    MsgType  = 1; // Type of the control message.
+  string  ServerID = 2; // Allows a server to detect if it is the intended receipient.
+  bytes   Data     = 3; // Optional bytes that carries context information.
+}


### PR DESCRIPTION
Commit 66db13cce9be51130c3295002fdb577c41b1a504 had a performance impact in some cases.
For instance, running the server like this:
```
nats-streaming-server -store file -dir datastore
```
and then using the bench tool:
```
go run examples/stan-bench.go -np 1 -ns 10 -n 100000 -a foo
```
produced the following results:
```
Starting benchmark [msgs=100000, msgsize=128, pubs=1, subs=10]
NATS Streaming Pub/Sub stats: 211,574 msgs/sec ~ 25.83 MB/sec
 Pub stats: 19,287 msgs/sec ~ 2.35 MB/sec
 Sub stats: 192,340 msgs/sec ~ 23.48 MB/sec
```
With this PR, the performance is back while solving the ordering issue:
```
Starting benchmark [msgs=100000, msgsize=128, pubs=1, subs=10]
NATS Streaming Pub/Sub stats: 486,028 msgs/sec ~ 59.33 MB/sec
 Pub stats: 44,236 msgs/sec ~ 5.40 MB/sec
 Sub stats: 441,870 msgs/sec ~ 53.94 MB/sec
```
This PR has 2 commits, the first is basically reverting commit 66db13cce9be51130c3295002fdb577c41b1a504.
The second is the actual code to schedule unsub/close request to internal subscribers
to ensure ordering. This was done to facilitate code review.