### PR TITLE
[FIXED] Prevent unrecognized sub commands in command line

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -252,6 +252,18 @@ func parseFlags() (*stand.Options, *natsd.Options) {
 		natsd.PrintTLSHelpAndDie()
 	}
 
+	// Process args looking for non-flag options,
+	// 'version' and 'help' only for now
+	showVersion, showHelp, err := natsd.ProcessCommandLineArgs(flag.CommandLine)
+	if err != nil {
+		natsd.PrintAndDie(err.Error() + usageStr)
+	} else if showVersion {
+		fmt.Printf("nats-streaming-server version %s, ", stand.VERSION)
+		natsd.PrintServerAndExit()
+	} else if showHelp {
+		usage()
+	}
+
 	// Parse NATS Streaming configuration file, updating stanOpts with
 	// what is found in the file, possibly overriding the defaults.
 	if stanConfigFile != "" {

--- a/stores/filestore_test.go
+++ b/stores/filestore_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -3092,9 +3093,7 @@ func TestFSFirstEmptySliceRemovedOnCreateNewSlice(t *testing.T) {
 	timeout = time.Now().Add(5 * time.Second)
 	ok = false
 	for time.Now().Before(timeout) {
-		ms.RLock()
-		timeTick := ms.timeTick
-		ms.RUnlock()
+		timeTick := atomic.LoadInt64(&ms.timeTick)
 
 		if timeTick-firstWrite > int64(time.Second) {
 			ok = true
@@ -3996,7 +3995,7 @@ func TestFSMsgCache(t *testing.T) {
 		}
 	}
 	// Wait for a bit.
-	time.Sleep(bkgTasksSleepDuration + time.Duration(cacheTTL) + 100*time.Millisecond)
+	time.Sleep(bkgTasksSleepDuration + time.Duration(cacheTTL) + 500*time.Millisecond)
 	// Now a lookup should return nil because message
 	// should have been evicted and file is closed
 	lm = ms.Lookup(msg.Sequence)


### PR DESCRIPTION
This is a port of PR for NATS Server: https://github.com/nats-io/gnatsd/pull/393
Also fixed some data race and flapping tests.