### PR TITLE
Update vendor due to removal of GetListenEndpoint()

### DIFF
--- a/vendor/github.com/nats-io/gnatsd/server/route.go
+++ b/vendor/github.com/nats-io/gnatsd/server/route.go
@@ -598,13 +598,13 @@ func (s *Server) routeAcceptLoop(ch chan struct{}) {
 		return
 	}
 
-	// Let them know we are up
-	close(ch)
-
 	// Setup state that can enable shutdown
 	s.mu.Lock()
 	s.routeListener = l
 	s.mu.Unlock()
+
+	// Let them know we are up
+	close(ch)
 
 	tmpDelay := ACCEPT_MIN_SLEEP
 

--- a/vendor/github.com/nats-io/gnatsd/test/test.go
+++ b/vendor/github.com/nats-io/gnatsd/test/test.go
@@ -97,28 +97,11 @@ func RunServerWithAuth(opts *server.Options, auth server.Auth) *server.Server {
 	// Run server in Go routine.
 	go s.Start()
 
-	end := time.Now().Add(10 * time.Second)
-	for time.Now().Before(end) {
-		addr := s.GetListenEndpoint()
-		if addr == "" {
-			time.Sleep(50 * time.Millisecond)
-			// Retry. We might take a little while to open a connection.
-			continue
-		}
-		conn, err := net.Dial("tcp", addr)
-		if err != nil {
-			// Retry after 50ms
-			time.Sleep(50 * time.Millisecond)
-			continue
-		}
-		conn.Close()
-		// Wait a bit to give a chance to the server to remove this
-		// "client" from its state, which may otherwise interfere with
-		// some tests.
-		time.Sleep(25 * time.Millisecond)
-		return s
+	// Wait for accept loop(s) to be started
+	if !s.ReadyForConnections(10 * time.Second) {
+		panic("Unable to start NATS Server in Go Routine")
 	}
-	panic("Unable to start NATS Server in Go Routine")
+	return s
 }
 
 func stackFatalf(t tLogger, f string, args ...interface{}) {

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -41,7 +41,7 @@
 			"importpath": "github.com/nats-io/gnatsd",
 			"repository": "https://github.com/nats-io/gnatsd",
 			"vcs": "git",
-			"revision": "ee93345fde06252e4b4bb0ffe8976502ccd073ca",
+			"revision": "c39204b478b87f294d7b9149065bf5de0e1d685a",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
The NATS Server's "RunServer" functions no longer use GetListenEndpoint().
This function has been removed. When server is embedded, since we
know it is local, use 127.0.0.1 or ::1 if NATS server's host
is 0.0.0.0 or :: respectively.