### PR TITLE
Change coverage/cross compile trigger for travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ script:
 - go test -race -v -p=1 $EXCLUDE_VENDOR
 - staticcheck -ignore "$(cat staticcheck.ignore)" $EXCLUDE_VENDOR
 after_success:
-- if [ "$TRAVIS_GO_VERSION" \> "1.7." ]; then ./scripts/cov.sh TRAVIS; fi
-- if [ "$TRAVIS_GO_VERSION" \> "1.7." ] && [ "$TRAVIS_TAG" != "" ]; then ./scripts/cross_compile.sh $TRAVIS_TAG; ghr --owner nats-io --token $GITHUB_TOKEN --draft --replace $TRAVIS_TAG pkg/; fi
+- if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]]; then ./scripts/cov.sh TRAVIS; fi
+- if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]] && [ "$TRAVIS_TAG" != "" ]; then ./scripts/cross_compile.sh $TRAVIS_TAG; ghr --owner nats-io --token $GITHUB_TOKEN --draft --replace $TRAVIS_TAG pkg/; fi


### PR DESCRIPTION
If we were to introduce 1.8 in the matrix, the coverage/cross
compile would be triggered for both 1.7 and 1.8.
Changing the trigger to only 1.7.x Go version for now.