### PR TITLE
[FIXED] Ensure message timestamp increases monotonically

### DIFF
--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -1609,12 +1609,7 @@ func (ms *FileMsgStore) Store(data []byte) (uint64, error) {
 	}
 
 	seq := ms.last + 1
-	m := &pb.MsgProto{
-		Sequence:  seq,
-		Subject:   ms.subject,
-		Data:      data,
-		Timestamp: time.Now().UnixNano(),
-	}
+	m := ms.genericMsgStore.createMsg(seq, data)
 
 	msgInBuffer := false
 
@@ -1755,6 +1750,8 @@ func (ms *FileMsgStore) expireMsgs(now, maxAge int64) int64 {
 		elapsed := now - m.timestamp
 		if elapsed >= maxAge {
 			ms.removeFirstMsg()
+		} else if elapsed < 0 {
+			ms.expiration = m.timestamp + maxAge
 		} else {
 			ms.expiration = now + (maxAge - elapsed)
 			break

--- a/stores/memstore_test.go
+++ b/stores/memstore_test.go
@@ -3,10 +3,12 @@
 package stores
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
 	"github.com/nats-io/nats-streaming-server/spb"
+	"github.com/nats-io/nats-streaming-server/util"
 )
 
 func createDefaultMemStore(t *testing.T) *MemoryStore {
@@ -201,4 +203,18 @@ func TestMSPerChannelLimits(t *testing.T) {
 	defer ms.Close()
 
 	testPerChannelLimits(t, ms)
+}
+
+func TestMSIncrementalTimestamp(t *testing.T) {
+	// This test need to run without race and may take some time, so
+	// excluding from Travis. Check presence of a known TRAVIS env
+	// variable to detect that we run on Travis so we can skip this
+	// test.
+	if util.RaceEnabled || os.Getenv("TRAVIS_GO_VERSION") != "" {
+		t.SkipNow()
+	}
+	ms := createDefaultMemStore(t)
+	defer ms.Close()
+
+	testIncrementalTimestamp(t, ms)
 }

--- a/util/no_race.go
+++ b/util/no_race.go
@@ -1,0 +1,10 @@
+// Copyright 2016 Apcera Inc. All rights reserved.
+
+// +build !race
+
+package util
+
+// RaceEnabled indicates that program/tests are running with race detection
+// enabled or not. Some tests may chose to skip execution when race
+// detection is on.
+const RaceEnabled = false

--- a/util/race.go
+++ b/util/race.go
@@ -1,0 +1,10 @@
+// Copyright 2016 Apcera Inc. All rights reserved.
+
+// +build race
+
+package util
+
+// RaceEnabled indicates that program/tests are running with race detection
+// enabled or not. Some tests may chose to skip execution when race
+// detection is on.
+const RaceEnabled = true


### PR DESCRIPTION
Since we use `time.Now()` and this is returning the "wall clock",
it is subject to jump both forward or backwards, either due to
user changing the time, NTP, or leap second.
There is no much we can do, but at least we ensure that the messages
in a given log have their timestamp increasing monotonically.
That is, if M1 is stored before M2, then:
```
   M1.Sequence<M2.Sequence && M1.Timestamp <= M2.Timestamp
```
The expiration code also now accounts for possible negative delta
between "now" and a given message timestamp.

In part addresses: #231