### PR TITLE
Reduce memory usage for FileMsgStore

### DIFF
--- a/stores/filestore_test.go
+++ b/stores/filestore_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Apcera Inc. All rights reserved.
+// Copyright 2016-2017 Apcera Inc. All rights reserved.
 
 package stores
 
@@ -2857,7 +2857,11 @@ func TestFSFileSlicesClosed(t *testing.T) {
 	for i, s := range ms.files {
 		if s.file != nil {
 			ms.RUnlock()
-			t.Fatalf("File slice %v should be closed", i)
+			t.Fatalf("File slice %v should be closed (data file)", i)
+		}
+		if s.idxFile != nil {
+			ms.RUnlock()
+			t.Fatalf("File slice %v should be closed (index file)", i)
 		}
 	}
 	ms.RUnlock()

--- a/util/util.go
+++ b/util/util.go
@@ -1,10 +1,11 @@
-// Copyright 2016 Apcera Inc. All rights reserved.
+// Copyright 2016-2017 Apcera Inc. All rights reserved.
 
 package util
 
 import (
 	"encoding/binary"
 	"io"
+	"os"
 )
 
 // ByteOrder specifies how to convert byte sequences into 16-, 32-, or 64-bit
@@ -50,4 +51,13 @@ func ReadInt(r io.Reader) (int, error) {
 		return 0, err
 	}
 	return int(ByteOrder.Uint32(bs)), nil
+}
+
+// CloseFile closes the given file and report the possible error only
+// if the given error `err` is not already set.
+func CloseFile(err error, f *os.File) error {
+	if lerr := f.Close(); lerr != nil && err == nil {
+		err = lerr
+	}
+	return err
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,8 +1,9 @@
-// Copyright 2016 Apcera Inc. All rights reserved.
+// Copyright 2016-2017 Apcera Inc. All rights reserved.
 
 package util
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
@@ -56,5 +57,32 @@ func TestReadInt(t *testing.T) {
 	}
 	if v, err := ReadInt(file); err != nil || v != 123 {
 		t.Fatalf("Expected to read 123, got: %v (err=%v)", v, err)
+	}
+}
+
+func TestCloseFile(t *testing.T) {
+	fileName := "test.dat"
+	file, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer os.Remove(fileName)
+
+	err = nil
+	cferr := CloseFile(err, file)
+	if cferr != nil {
+		t.Fatalf("Unexpected error: %v", cferr)
+	}
+
+	err = fmt.Errorf("Previous error")
+	cferr = CloseFile(err, file)
+	if cferr != err {
+		t.Fatalf("Expected original error to be untouched")
+	}
+
+	err = nil
+	cferr = CloseFile(err, file)
+	if cferr == err {
+		t.Fatalf("Expected returned error to be different")
 	}
 }


### PR DESCRIPTION
By not keeping `msgIndex` (which contains message's offset on
data file, timestamp and message size), the memory footprint
is now reduced and actually does not increase for a given
message store, regardless of the number of messages stored.

This causes however to access the index file - to retrieve
the message offset - in order to lookup a message, during
message expiration, or enforcing limits.

The `FileMsgStore` still uses a small message cache which
contains messages that have been just written or looked-up.