### PR TITLE
[ADDED] Option to configure a pool of ACK subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Streaming Server Options:
     -hbi, --hb_interval <duration>   Interval at which server sends heartbeat to a client
     -hbt, --hb_timeout <duration>    How long server waits for a heartbeat response
     -hbf, --hb_fail_count <number>   Number of failed heartbeats before server closes the client connection
+          --ack_subs <number>        Number of internal subscriptions handling incoming ACKs (0 means one per client's subscription)
 
 Streaming Server File Store Options:
     --file_compact_enabled           Enable file compaction
@@ -197,6 +198,14 @@ hb_timeout: "10s"
 # The actual total wait is: (fail count + 1) * (hb interval + hb timeout).
 # Can be hbf, hb_fail_count, server_to_client_hb_fail_count
 hb_fail_count: 2
+
+# Normally, when a client creates a subscription, the server creates
+# an internal subscription to receive its ACKs.
+# If lots of subscriptions are created, the number of internal
+# subscriptions in the server could be very high. To curb this growth,
+# use this parameter to configure a pool of internal ACKs subscriptions.
+# Can be ack_subs_pool_size, ack_subscriptions_pool_size
+ack_subs_pool_size: 10
 
 # Define store limits.
 # Can be limits, store_limits or StoreLimits.

--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -34,6 +34,7 @@ Streaming Server Options:
     -hbi, --hb_interval <duration>   Interval at which server sends heartbeat to a client
     -hbt, --hb_timeout <duration>    How long server waits for a heartbeat response
     -hbf, --hb_fail_count <number>   Number of failed heartbeats before server closes the client connection
+          --ack_subs <number>        Number of internal subscriptions handling incoming ACKs (0 means one per client's subscription)
 
 Streaming Server File Store Options:
     --file_compact_enabled           Enable file compaction
@@ -173,6 +174,7 @@ func parseFlags() (*stand.Options, *natsd.Options) {
 	flag.String("ns", "", "NATSServerURL")
 	flag.StringVar(&stanConfigFile, "sc", "", "")
 	flag.StringVar(&stanConfigFile, "stan_config", "", "")
+	flag.Int("ack_subs", 0, "AckSubsPoolSize")
 	flag.Bool("file_compact_enabled", stores.DefaultFileStoreOptions.CompactEnabled, "FileStoreOpts.CompactEnabled")
 	flag.Int("file_compact_frag", stores.DefaultFileStoreOptions.CompactFragmentation, "FileStoreOpts.CompactFragmentation")
 	flag.Int("file_compact_interval", stores.DefaultFileStoreOptions.CompactInterval, "FileStoreOpts.CompactInterval")

--- a/server/conf.go
+++ b/server/conf.go
@@ -109,6 +109,11 @@ func ProcessConfigFile(configFile string, opts *Options) error {
 				return err
 			}
 			opts.ClientHBFailCount = int(v.(int64))
+		case "ack_subs_pool_size", "ack_subscriptions_pool_size":
+			if err := checkType(k, reflect.Int64, v); err != nil {
+				return err
+			}
+			opts.AckSubsPoolSize = int(v.(int64))
 		}
 	}
 	return nil

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -154,6 +154,9 @@ func TestParseConfig(t *testing.T) {
 	if opts.ClientHBFailCount != 2 {
 		t.Fatalf("Expected ClientHBFailCount to be 2, got %v", opts.ClientHBFailCount)
 	}
+	if opts.AckSubsPoolSize != 3 {
+		t.Fatalf("Expected AckSubscriptions to be 3, got %v", opts.AckSubsPoolSize)
+	}
 }
 
 func TestParsePermError(t *testing.T) {
@@ -242,6 +245,7 @@ func TestParseWrongTypes(t *testing.T) {
 	expectFailureFor(t, "hb_timeout: 123", wrongTypeErr)
 	expectFailureFor(t, "hb_timeout: \"foo\"", wrongTimeErr)
 	expectFailureFor(t, "hb_fail_count: false", wrongTypeErr)
+	expectFailureFor(t, "ack_subs_pool_size: false", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{max_channels:false}", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{max_msgs:false}", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{max_bytes:false}", wrongTypeErr)

--- a/test/configs/test_parse.conf
+++ b/test/configs/test_parse.conf
@@ -9,6 +9,7 @@ secure: true
 hb_interval: "10s"
 hb_timeout: "1s"
 hb_fail_count: 2
+ack_subs_pool_size: 3
 
 store_limits: {
     max_channels: 11


### PR DESCRIPTION
The server normally creates an ACK subscription per user subscription.
This could lead to a very high number of go-routines if the number
of user subscriptions increases.
The added option limit this number by creating a pool of internal
subscriptions.