### PR TITLE
Fixed server panic when channel is created without any message

### DIFF
--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -2491,10 +2491,12 @@ func (ms *FileMsgStore) backgroundTasks() {
 		// Shrink the buffer if applicable
 		if hasBuffer && time.Duration(timeTick-lastBufShrink) >= bufShrinkInterval {
 			ms.Lock()
-			file := ms.writeSlice.file
-			if ms.fm.lockFileIfOpened(file) {
-				ms.writer, _ = ms.bw.tryShrinkBuffer(file.handle)
-				ms.fm.unlockFile(file)
+			if ms.writeSlice != nil {
+				file := ms.writeSlice.file
+				if ms.fm.lockFileIfOpened(file) {
+					ms.writer, _ = ms.bw.tryShrinkBuffer(file.handle)
+					ms.fm.unlockFile(file)
+				}
 			}
 			ms.Unlock()
 			lastBufShrink = timeTick

--- a/stores/filestore_test.go
+++ b/stores/filestore_test.go
@@ -4324,3 +4324,22 @@ func TestFSMsgCache(t *testing.T) {
 		t.Fatal("Cache should be empty")
 	}
 }
+
+func TestFSMsgStoreBackgroundTaskCrash(t *testing.T) {
+	cleanupDatastore(t, defaultDataStore)
+	defer cleanupDatastore(t, defaultDataStore)
+
+	// For this test, reduce the buffer shrink interval
+	bufShrinkInterval = time.Second
+	defer func() {
+		bufShrinkInterval = defaultBufShrinkInterval
+	}()
+
+	fs := createDefaultFileStore(t)
+	defer fs.Close()
+
+	fs.CreateChannel("foo", nil)
+	// Wait for background task to execute
+	time.Sleep(1500 * time.Millisecond)
+	// It should not have crashed.
+}


### PR DESCRIPTION
Issue introduced by d9fb4180a20ee8ad93853425f3109ac79867156b.
If a channel is created without message (for instance creating a
subscription on a new channel), the server will panic at the next
background task execution (around 1 second).

Resolves #259