### PR TITLE
[CHANGED] RunServer() and RunServerWithOpts() APIs to return error

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -116,7 +116,11 @@ func main() {
 	// override the NoSigs for NATS since we have our own signal handler below
 	nOpts.NoSigs = true
 	stand.ConfigureLogger(sOpts, nOpts)
-	s := stand.RunServerWithOpts(sOpts, nOpts)
+	s, err := stand.RunServerWithOpts(sOpts, nOpts)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	go func() {

--- a/server/bench_test.go
+++ b/server/bench_test.go
@@ -29,7 +29,10 @@ func benchRunServer(b *testing.B) *StanServer {
 	if storeType == stores.TypeFile {
 		opts.FilestoreDir = defaultDataStore
 	}
-	s := RunServerWithOpts(opts, nil)
+	s, err := RunServerWithOpts(opts, nil)
+	if err != nil {
+		b.Fatalf("Unable to start server: %v", err)
+	}
 	return s
 }
 

--- a/server/log_test.go
+++ b/server/log_test.go
@@ -219,17 +219,13 @@ func TestRunServerFailureLogsCause(t *testing.T) {
 	stanLog.Unlock()
 
 	// We expect the server to fail to start
-	var s *StanServer
-	defer func() {
-		if s != nil {
-			t.Fatal("Expected no server to be returned")
-		}
-		if r := recover(); r != nil {
-			// We should get a trace in the log_
-			if !strings.Contains(d.msg, "Can't connect to NATS") {
-				t.Fatalf("Expected to get a cause as invalid connection, got: %v", d.msg)
-			}
-		}
-	}()
-	s = RunServerWithOpts(sOpts, nil)
+	s, err := RunServerWithOpts(sOpts, nil)
+	if err == nil {
+		s.Shutdown()
+		t.Fatal("Expected error, got none")
+	}
+	// We should get a trace in the log_
+	if !strings.Contains(d.msg, "available for connection") {
+		t.Fatalf("Expected to get a cause as invalid connection, got: %v", d.msg)
+	}
 }

--- a/test/test.go
+++ b/test/test.go
@@ -3,12 +3,26 @@
 package test
 
 import (
+	gnatsd "github.com/nats-io/gnatsd/server"
 	"github.com/nats-io/nats-streaming-server/server"
 )
 
 // RunServer launches a server with the specified ID and default options.
 func RunServer(ID string) *server.StanServer {
-	return server.RunServer(ID)
+	s, err := server.RunServer(ID)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// RunServerWithOpts launches a server with the specified options.
+func RunServerWithOpts(stanOpts *server.Options, natsOpts *gnatsd.Options) *server.StanServer {
+	s, err := server.RunServerWithOpts(stanOpts, natsOpts)
+	if err != nil {
+		panic(err)
+	}
+	return s
 }
 
 // RunServerWithDebugTrace is a helper to assist debugging
@@ -27,5 +41,9 @@ func RunServerWithDebugTrace(ID string, enableSTANDebug, enableSTANTrace, enable
 	// enable logging
 	server.ConfigureLogger(sOpts, &nOpts)
 
-	return server.RunServerWithOpts(sOpts, &nOpts)
+	s, err := server.RunServerWithOpts(sOpts, &nOpts)
+	if err != nil {
+		panic(err)
+	}
+	return s
 }


### PR DESCRIPTION
Those APIs used to only return an instance of StanServer. If there
was any issue on startup, the call would panic. The purpose of this
change is to instead return an error. The executable will also
display the error as a fatal error and exit (without the panic).

This would require a change in the Go client tests and for users
running the streaming server programmatically.