### PR TITLE
Add the possibility to disallow unknown channels to avoid DoS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: go
 sudo: false
 go:
-- 1.6.4
-- 1.7.4
+- 1.7.5
+- 1.8
 install:
 - go get -t ./...
 - go get github.com/nats-io/gnatsd
 - go get github.com/mattn/goveralls
 - go get github.com/wadey/gocovmerge
-- go get honnef.co/go/tools/cmd/staticcheck
-- go get honnef.co/go/tools/cmd/gosimple
+- go get -u honnef.co/go/tools/cmd/staticcheck
+- go get -u honnef.co/go/tools/cmd/gosimple
 before_script:
 - EXCLUDE_VENDOR=$(go list ./... | grep -v "/vendor/")
 - go build

--- a/server/conf.go
+++ b/server/conf.go
@@ -176,6 +176,11 @@ func parseStoreLimits(itf interface{}, opts *Options) error {
 			if err := parsePerChannelLimits(v, opts); err != nil {
 				return err
 			}
+		case "unknown_channels_disallowed":
+			if err := checkType(k, reflect.Bool, v); err != nil {
+				return err
+			}
+			opts.UnknownChannelsDisallowed = v.(bool)
 		default:
 			// Check for the global limits (MaxMsgs, MaxBytes, etc..)
 			if err := parseChannelLimits(&opts.ChannelLimits, k, name, v); err != nil {

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -258,6 +258,7 @@ func TestParseWrongTypes(t *testing.T) {
 	expectFailureFor(t, "store_limits:{max_age:false}", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{max_age:\"foo\"}", wrongTimeErr)
 	expectFailureFor(t, "store_limits:{max_subs:false}", wrongTypeErr)
+	expectFailureFor(t, "store_limits:{unknown_channels_disallowed:1}", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_msgs:false}}}", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_bytes:false}}}", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_age:\"1h:0m\"}}}", wrongTimeErr)

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -113,6 +113,9 @@ func TestParseConfig(t *testing.T) {
 	if opts.MaxSubscriptions != 15 {
 		t.Fatalf("Expected MaxSubscriptions to be 15, got %v", opts.MaxSubscriptions)
 	}
+	if !opts.UnknownChannelsDisallowed {
+		t.Fatalf("Expected UnknownChannelsDisallowed to be true, got false")
+	}
 	if len(opts.PerChannel) != 2 {
 		t.Fatalf("Expected PerChannel map to have 2 elements, got %v", len(opts.PerChannel))
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -292,7 +292,7 @@ func (s *StanServer) lookupOrCreateChannel(channel string) (*stores.ChannelStore
 	if cs := s.store.LookupChannel(channel); cs != nil {
 		return cs, nil
 	}
-	if s.opts.UnknownChannelsDisallowed {
+	if s.opts.UnknownChannelsDisallowed && !s.store.IsPredeclaredChannel(channel) {
 		return nil, ErrUnknownChannel
 	}
 	// It's possible that more than one go routine comes here at the same

--- a/server/server.go
+++ b/server/server.go
@@ -114,6 +114,7 @@ var (
 	ErrDupDurable         = errors.New("stan: duplicate durable registration")
 	ErrInvalidDurName     = errors.New("stan: durable name of a durable queue subscriber can't contain the character ':'")
 	ErrUnknownClient      = errors.New("stan: unknown clientID")
+	ErrUnknownChannel     = errors.New("stan: unknown channel")
 )
 
 // Shared regular expression to check clientID validity.
@@ -290,6 +291,9 @@ type subState struct {
 func (s *StanServer) lookupOrCreateChannel(channel string) (*stores.ChannelStore, error) {
 	if cs := s.store.LookupChannel(channel); cs != nil {
 		return cs, nil
+	}
+	if s.opts.UnknownChannelsDisallowed {
+		return nil, ErrUnknownChannel
 	}
 	// It's possible that more than one go routine comes here at the same
 	// time. `ss` will then be simply gc'ed.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5712,8 +5712,8 @@ func TestDontSendEmptyMsgProto(t *testing.T) {
 	sub := subs[0]
 
 	defer func() {
-		if r := recover(); r != nil {
-			// Ok!
+		if r := recover(); r == nil {
+			t.Fatal("Server should have panic'ed")
 		}
 	}()
 
@@ -5721,8 +5721,6 @@ func TestDontSendEmptyMsgProto(t *testing.T) {
 	sub.Lock()
 	s.sendMsgToSub(sub, m, false)
 	sub.Unlock()
-
-	t.Fatal("Server should have panic'ed")
 }
 
 func TestMsgsNotSentToSubBeforeSubReqResponse(t *testing.T) {

--- a/stores/common.go
+++ b/stores/common.go
@@ -123,6 +123,15 @@ func (gs *genericStore) LookupChannel(channel string) *ChannelStore {
 	return cs
 }
 
+// IsPredeclaredChannel returns true if this store has
+// pre-declared this channel in store_limits.channels hash.
+func (gs *genericStore) IsPredeclaredChannel(channel string) (ok bool) {
+	gs.RLock()
+	_, ok = gs.limits.PerChannel[channel]
+	gs.RUnlock()
+	return
+}
+
 // HasChannel returns true if this store has any channel
 func (gs *genericStore) HasChannel() bool {
 	gs.RLock()

--- a/stores/common_test.go
+++ b/stores/common_test.go
@@ -818,7 +818,15 @@ func testPerChannelLimits(t *testing.T, s Store) {
 		t.Fatalf("Unexpected error setting limits: %v", err)
 	}
 
-	checkLimitsForChannel := func(channelName string, maxMsgs, maxSubs int) {
+	checkLimitsForChannel := func(channelName string, declared bool, maxMsgs, maxSubs int) {
+		if s.IsPredeclaredChannel(channelName) != declared {
+			if declared {
+				stackFatalf(t, "Channel %s expected pre-declared, got no", channelName)
+			} else {
+				stackFatalf(t, "Channel %s expected NOT pre-declared, got yes", channelName)
+			}
+		}
+
 		cs, _, err := s.CreateChannel(channelName, nil)
 		if err != nil {
 			stackFatalf(t, "Unexpected error on create channel: %v", err)
@@ -844,12 +852,12 @@ func testPerChannelLimits(t *testing.T, s Store) {
 			}
 		}
 	}
-	checkLimitsForChannel("foo", fooLimits.MaxMsgs, fooLimits.MaxSubscriptions)
-	checkLimitsForChannel("bar", barLimits.MaxMsgs, barLimits.MaxSubscriptions)
-	checkLimitsForChannel("baz", noSubsOverrideLimits.MaxMsgs, storeLimits.MaxSubscriptions)
-	checkLimitsForChannel("abc", storeLimits.MaxMsgs, storeLimits.MaxSubscriptions)
-	checkLimitsForChannel("def", noMaxBytesOverrideLimits.MaxMsgs, storeLimits.MaxSubscriptions)
-	checkLimitsForChannel("global", storeLimits.MaxMsgs, storeLimits.MaxSubscriptions)
+	checkLimitsForChannel("foo", true, fooLimits.MaxMsgs, fooLimits.MaxSubscriptions)
+	checkLimitsForChannel("bar", true, barLimits.MaxMsgs, barLimits.MaxSubscriptions)
+	checkLimitsForChannel("baz", true, noSubsOverrideLimits.MaxMsgs, storeLimits.MaxSubscriptions)
+	checkLimitsForChannel("abc", true, storeLimits.MaxMsgs, storeLimits.MaxSubscriptions)
+	checkLimitsForChannel("def", true, noMaxBytesOverrideLimits.MaxMsgs, storeLimits.MaxSubscriptions)
+	checkLimitsForChannel("global", false, storeLimits.MaxMsgs, storeLimits.MaxSubscriptions)
 }
 
 func testIncrementalTimestamp(t *testing.T, s Store) {

--- a/stores/common_test.go
+++ b/stores/common_test.go
@@ -26,6 +26,7 @@ var testDefaultStoreLimits = StoreLimits{
 			MaxSubscriptions: 1000,
 		},
 	},
+	false,
 	nil,
 }
 

--- a/stores/filestore_test.go
+++ b/stores/filestore_test.go
@@ -725,7 +725,6 @@ func TestFSBasicRecovery(t *testing.T) {
 					t.Fatalf("Unexpected recovered pending seqno for sub1: %v", seq)
 				}
 			}
-			break
 		case "bar":
 			if subID != sub2 {
 				t.Fatalf("Invalid subscription id. Expected %v, got %v", sub2, subID)
@@ -735,7 +734,6 @@ func TestFSBasicRecovery(t *testing.T) {
 					t.Fatalf("Unexpected recovered pending seqno for sub2: %v", seq)
 				}
 			}
-			break
 		default:
 			t.Fatalf("Recovered unknown channel: %v", channel)
 		}

--- a/stores/store.go
+++ b/stores/store.go
@@ -159,6 +159,10 @@ type Store interface {
 	// does not exist.
 	LookupChannel(channel string) *ChannelStore
 
+	// IsPredeclaredChannel returns true if this store has
+	// predeclared this channel in store_limits.channels hash.
+	IsPredeclaredChannel(channel string) bool
+
 	// HasChannel returns true if this store has any channel.
 	HasChannel() bool
 

--- a/stores/store.go
+++ b/stores/store.go
@@ -40,6 +40,8 @@ type StoreLimits struct {
 	MaxChannels int
 	// Global limits. Any 0 value means that the limit is ignored (unlimited).
 	ChannelLimits
+	// Channels not referenced in PerChannel cannot be subscribed.
+	UnknownChannelsDisallowed bool
 	// Per-channel limits. If a limit for a channel in this map is 0,
 	// the corresponding global limit (specified above) is used.
 	PerChannel map[string]*ChannelLimits
@@ -86,6 +88,7 @@ var DefaultStoreLimits = StoreLimits{
 			MaxSubscriptions: 1000,
 		},
 	},
+	false,
 	nil,
 }
 

--- a/test/configs/test_parse.conf
+++ b/test/configs/test_parse.conf
@@ -17,7 +17,8 @@ store_limits: {
     max_bytes: 13
     max_age: "14s"
     max_subs: 15
-    
+    unknown_channels_disallowed: true
+
     channels: {
       "foo": {
         max_msgs: 1


### PR DESCRIPTION
Until an authorization framework comes up for limiting subscribing (à
la nats), add a store_limits parameter: unknown_channels_disallowed.
When set to true, only channels listed in store_limits.channels hash
are allowed to be subscribed.