### PR TITLE
[ADDED] Shared Storage Fault Tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ NATS Streaming provides the following high-level feature set.
 - [Important Changes](#important-changes)
 - [Concepts](#concepts)
     * [Relation to NATS](#relation-to-nats)
-    * [Clients Connections](#clients-connections)
+    * [Client Connections](#client-connections)
     * [Channels](#channels)
         * [Message Log](#message-log)
         * [Subscriptions](#subscriptions)
@@ -76,14 +76,14 @@ connection, the server knows if a client is connected based on heartbeats.
 ***It is therefore strongly recommended for clients to close their connection when the application exit, otherwise the server
 will consider these clients connected (sending data, etc...) until it detects missing hearbeats.***
 
-The streaming server creates internal subscriptions on specific subjects to communicate withs its clients and/or other servers.
+The streaming server creates internal subscriptions on specific subjects to communicate with its clients and/or other servers.
 
 Note that NATS clients and NATS Streaming clients cannot exchange data between each other. That is, if a streaming client
 publishes on `foo`, a NATS client subscribing on that same subject will not receive the messages. Streaming messages are NATS
 messages made of a protobuf. The streaming server is expected to send ACKs back to producers and receive ACKs from consumers.
 If messages were freely exchanged with the NATS clients, this would cause problems.
 
-## Clients Connections
+## Client Connections
 
 As described, clients are not directly connected to the streaming server. Instead, they send connection requests. The request
 includes a `client ID` which is used by the server to uniquely identify, and restrict, a given client. That is, no two
@@ -151,7 +151,7 @@ given by the client when creating the durable subscription.
 
 #### Queue Group
 
-When consumers want to consume from the same channel but each receive a different message - as opposed to all receiving the same messages -,
+When consumers want to consume from the same channel but each receive a different message, as opposed to all receiving the same messages,
 they need to create a queue subscription. When a queue group name is specified, the server will send each messages from the log to a single
 consumer in the group. The distribution of these messages is not specified, therefore applications should not rely on an expected delivery
 scheme.
@@ -227,7 +227,7 @@ different FT groups for servers with the same cluster ID. For now, use it to sim
 
 ### Active Server
 
-There is a single Active server in the group. This server is elected and ensures that it can get an exclusive lock for the storage.
+There is a single Active server in the group. This server was the first to obtain the exclusive lock for storage.
 For the `FileStore` implementation, it means trying to get an advisory lock for a file located in the shared datastore. If the
 elected server fails to grab this lock because it is already locked, it will go back to standby.
 
@@ -322,8 +322,6 @@ Streaming Server Options:
     -hbf, --hb_fail_count <number>   Number of failed heartbeats before server closes the client connection
           --ack_subs <number>        Number of internal subscriptions handling incoming ACKs (0 means one per client's subscription)
           --ft_group <string>        Name of the FT Group. A group can be 2 or more servers with a single active server and all sharing the same datastore.
-          --ft_quorum <number>       Number of servers needed in order to elect a leader.
-          --ft_logfile <string>      FT logfile of this member (used for leader election). This file must not be shared by members.
 
 Streaming Server File Store Options:
     --file_compact_enabled           Enable file compaction

--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -35,6 +35,7 @@ Streaming Server Options:
     -hbt, --hb_timeout <duration>    How long server waits for a heartbeat response
     -hbf, --hb_fail_count <number>   Number of failed heartbeats before server closes the client connection
           --ack_subs <number>        Number of internal subscriptions handling incoming ACKs (0 means one per client's subscription)
+          --ft_group <string>        Name of the FT Group. A group can be 2 or more servers with a single active server and all sharing the same datastore.
 
 Streaming Server File Store Options:
     --file_compact_enabled           Enable file compaction
@@ -195,6 +196,7 @@ func parseFlags() (*stand.Options, *natsd.Options) {
 	flag.Int64("file_fds_limit", stores.DefaultFileStoreOptions.FileDescriptorsLimit, "FileStoreOpts.FileDescriptorsLimit")
 	flag.Int("io_batch_size", stand.DefaultIOBatchSize, "IOBatchSize")
 	flag.Int64("io_sleep_time", stand.DefaultIOSleepTime, "IOSleepTime")
+	flag.String("ft_group", "", "FTGroupName")
 
 	// NATS options
 	var showVersion bool

--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -4,6 +4,8 @@
 rm -rf ./cov
 mkdir cov
 go test -v -covermode=count -coverprofile=./cov/server.out ./server
+# repeat these server FT tests but focus on stores package
+go test -v -covermode=count -coverprofile=./cov/ft_stores.out -run=TestFTPartition -coverpkg=./stores ./server
 go test -v -covermode=count -coverprofile=./cov/stores.out ./stores
 go test -v -covermode=count -coverprofile=./cov/stores_no_buffer.out -run=TestFS ./stores -no_buffer
 go test -v -covermode=count -coverprofile=./cov/stores_fds_limit.out -run=TestFS ./stores -set_fds_limit

--- a/server/conf.go
+++ b/server/conf.go
@@ -114,6 +114,11 @@ func ProcessConfigFile(configFile string, opts *Options) error {
 				return err
 			}
 			opts.AckSubsPoolSize = int(v.(int64))
+		case "ft_group", "ft_group_name":
+			if err := checkType(k, reflect.String, v); err != nil {
+				return err
+			}
+			opts.FTGroupName = v.(string)
 		}
 	}
 	return nil

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -160,6 +160,9 @@ func TestParseConfig(t *testing.T) {
 	if opts.AckSubsPoolSize != 3 {
 		t.Fatalf("Expected AckSubscriptions to be 3, got %v", opts.AckSubsPoolSize)
 	}
+	if opts.FTGroupName != "ft" {
+		t.Fatalf("Expected FTGroupName to be %q, got %q", "ft", opts.FTGroupName)
+	}
 }
 
 func TestParsePermError(t *testing.T) {
@@ -249,6 +252,7 @@ func TestParseWrongTypes(t *testing.T) {
 	expectFailureFor(t, "hb_timeout: \"foo\"", wrongTimeErr)
 	expectFailureFor(t, "hb_fail_count: false", wrongTypeErr)
 	expectFailureFor(t, "ack_subs_pool_size: false", wrongTypeErr)
+	expectFailureFor(t, "ft_group: 123", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{max_channels:false}", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{max_msgs:false}", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{max_bytes:false}", wrongTypeErr)

--- a/server/ft.go
+++ b/server/ft.go
@@ -1,0 +1,214 @@
+// Copyright 2017 Apcera Inc. All rights reserved.
+
+package server
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats-streaming-server/spb"
+	"github.com/nats-io/nats-streaming-server/stores"
+	"github.com/nats-io/nats-streaming-server/util"
+)
+
+// FT constants
+const (
+	ftDefaultHBInterval       = time.Second
+	ftDefaultHBMissedInterval = 1250 * time.Millisecond
+)
+
+var (
+	// Some go-routine will panic, which we can't recover in test.
+	// So the tests will set this to true to be able to test the
+	// correct behavior.
+	ftNoPanic bool
+	// For tests purposes, we may want to pause for the first
+	// attempt at getting the store lock so that test can
+	// switch store with a mocked one.
+	ftPauseBeforeFirstAttempt bool
+	ftPauseCh                 = make(chan struct{})
+	// This can be changed for tests purposes.
+	ftHBInterval       = ftDefaultHBInterval
+	ftHBMissedInterval = ftDefaultHBMissedInterval
+)
+
+func ftReleasePause() {
+	ftPauseCh <- struct{}{}
+}
+
+// ftStart will return only when this server has become active
+// and was able to get the store's exclusive lock.
+// This is running in a separate go-routine so if server state
+// changes, take care of using the server's lock.
+func (s *StanServer) ftStart() (retErr error) {
+	Noticef("STAN: Starting in standby mode")
+	// For tests purposes
+	if ftPauseBeforeFirstAttempt {
+		<-ftPauseCh
+	}
+	print, _ := util.NewBackoffTimeCheck(time.Second, 2, time.Minute)
+	for {
+		select {
+		case <-s.ftQuit:
+			// we are done
+			return nil
+		case <-s.ftHBCh:
+			// go back to the beginning of the for loop
+			continue
+		case <-time.After(ftHBMissedInterval):
+			// try to lock the store
+		}
+		locked, err := s.ftGetStoreLock()
+		if err != nil {
+			// TODO: This means that we got an error not related to locking.
+			// Since we are in standby, should just keep trying? It could
+			// be that the storage is temporarily unavailable. Right now,
+			// we return an error which means that process will exit.
+			return err
+		} else if locked {
+			break
+		}
+		// Here, we did not get the lock, print and go back to standby.
+		// Use some backoff for the printing to not fill up the log
+		if print.Ok() {
+			Noticef("STAN: ft: unable to get store lock at this time, going back to standby")
+		}
+	}
+	// Capture the time this server activated. It will be used in case several
+	// servers claim to be active. Not bulletproof since there could be clock
+	// differences, etc... but when more than one server has acquired the store
+	// lock it means we are already in trouble, so just trying to minimize the
+	// possible store corruption...
+	activationTime := time.Now()
+	Noticef("STAN: Server is active")
+	s.startGoRoutine(func() {
+		s.ftSendHBLoop(activationTime)
+	})
+	// Start the recovery process, etc..
+	return s.start(FTActive)
+}
+
+// ftGetStoreLock returns true if the server was able to get the
+// exclusive store lock, false othewise, or if there was a fatal error doing so.
+func (s *StanServer) ftGetStoreLock() (bool, error) {
+	// Normally, the store would be set early and is immutable, but some
+	// FT tests do set a mock store after the server is created, so use
+	// locking here to avoid race reports.
+	s.mu.Lock()
+	store := s.store
+	s.mu.Unlock()
+	if ok, err := store.GetExclusiveLock(); !ok || err != nil {
+		// We got an error not related to locking (could be not supported,
+		// permissions error, file not reachable, etc..)
+		if err != nil {
+			return false, fmt.Errorf("ft: error getting the store lock: %v", err)
+		}
+		// If ok is false, it means that we did not get the lock.
+		return false, nil
+	}
+	return true, nil
+}
+
+// ftSendHBLoop is used by an active server to send HB to the FT subject.
+// Standby servers receiving those HBs do not attempt to lock the store.
+// When they miss HBs, they will.
+func (s *StanServer) ftSendHBLoop(activationTime time.Time) {
+	// Release the wait group on exit
+	defer s.wg.Done()
+
+	timeAsBytes, _ := activationTime.MarshalBinary()
+	ftHB := &spb.CtrlMsg{
+		MsgType:  spb.CtrlMsg_FTHeartbeat,
+		ServerID: s.serverID,
+		Data:     timeAsBytes,
+	}
+	ftHBBytes, _ := ftHB.Marshal()
+	print, _ := util.NewBackoffTimeCheck(time.Second, 2, time.Minute)
+	for {
+		if err := s.ftnc.Publish(s.ftSubject, ftHBBytes); err != nil {
+			if print.Ok() {
+				Errorf("STAN: Unable to send FT heartbeat: %v", err)
+			}
+		}
+	startSelect:
+		select {
+		case m := <-s.ftHBCh:
+			hb := spb.CtrlMsg{}
+			if err := hb.Unmarshal(m.Data); err != nil {
+				goto startSelect
+			}
+			// Ignore our own message
+			if hb.MsgType != spb.CtrlMsg_FTHeartbeat || hb.ServerID == s.serverID {
+				goto startSelect
+			}
+			// Another server claims to be active
+			peerActivationTime := time.Time{}
+			if err := peerActivationTime.UnmarshalBinary(hb.Data); err != nil {
+				Errorf("STAN: Error decoding activation time: %v", err)
+			} else {
+				// Step down if the peer's activation time is earlier than ours.
+				err := fmt.Errorf("ft: serverID %q claims to be active", hb.ServerID)
+				if peerActivationTime.Before(activationTime) {
+					err = fmt.Errorf("%s, aborting", err)
+					Fatalf("STAN: %v", err)
+					if ftNoPanic {
+						s.ftSetError(err)
+						return
+					}
+					panic(err)
+				} else {
+					Errorf(err.Error())
+				}
+			}
+		case <-time.After(ftHBInterval):
+		// We'll send the ping at the top of the for loop
+		case <-s.ftQuit:
+			return
+		}
+	}
+}
+
+// ftSetError is used in FT mode when a server fails for some reasons.
+// The state is set to FTFailed unless the server was already shutdown.
+func (s *StanServer) ftSetError(err error) {
+	s.mu.Lock()
+	s.ftError = err
+	// Don't override the state if server was shutdown before it got
+	// the FT failure.
+	if s.state != Shutdown {
+		s.state = FTFailed
+	}
+	s.mu.Unlock()
+}
+
+// ftSetup checks that all required FT parameters have been specified and
+// create the channel required for shutdown.
+// Note that FTGroupName has to be set before server invokes this function,
+// so this parameter is not checked here.
+func (s *StanServer) ftSetup() error {
+	// Check that store type is ok. So far only support for FileStore
+	if s.opts.StoreType != stores.TypeFile {
+		return fmt.Errorf("ft: only %v stores supported in FT mode", stores.TypeFile)
+	}
+	s.ftSubject = "_STAN.ft." + s.opts.ID + "." + s.opts.FTGroupName
+	s.ftHBCh = make(chan *nats.Msg)
+	sub, err := s.ftnc.Subscribe(s.ftSubject, func(m *nats.Msg) {
+		// Dropping incoming FT HBs is not crucial, we will then check for
+		// store lock.
+		select {
+		case s.ftHBCh <- m:
+		default:
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("ft: unable to subscribe on ft subject: %v", err)
+	}
+	// We don't want to cause possible slow consumer error
+	sub.SetPendingLimits(-1, -1)
+	// Create channel to notify FT go routine to quit.
+	s.ftQuit = make(chan struct{}, 1)
+	// Set the state as standby initially
+	s.state = FTStandby
+	return nil
+}

--- a/server/ft.go
+++ b/server/ft.go
@@ -149,9 +149,8 @@ func (s *StanServer) ftSendHBLoop(activationTime time.Time) {
 				err := fmt.Errorf("ft: serverID %q claims to be active", hb.ServerID)
 				if peerActivationTime.Before(activationTime) {
 					err = fmt.Errorf("%s, aborting", err)
-					Fatalf("STAN: %v", err)
 					if ftNoPanic {
-						s.ftSetError(err)
+						s.setLastError(err)
 						return
 					}
 					panic(err)
@@ -165,19 +164,6 @@ func (s *StanServer) ftSendHBLoop(activationTime time.Time) {
 			return
 		}
 	}
-}
-
-// ftSetError is used in FT mode when a server fails for some reasons.
-// The state is set to FTFailed unless the server was already shutdown.
-func (s *StanServer) ftSetError(err error) {
-	s.mu.Lock()
-	s.ftError = err
-	// Don't override the state if server was shutdown before it got
-	// the FT failure.
-	if s.state != Shutdown {
-		s.state = FTFailed
-	}
-	s.mu.Unlock()
 }
 
 // ftSetup checks that all required FT parameters have been specified and

--- a/server/ft.go
+++ b/server/ft.go
@@ -65,7 +65,10 @@ func (s *StanServer) ftStart() (retErr error) {
 			// Since we are in standby, should just keep trying? It could
 			// be that the storage is temporarily unavailable. Right now,
 			// we return an error which means that process will exit.
-			return err
+			if print.Ok() {
+				Errorf("STAN: ft: error getting store lock, going back to standby (err=%v)", err)
+			}
+			continue
 		} else if locked {
 			break
 		}

--- a/server/ft_test.go
+++ b/server/ft_test.go
@@ -1,0 +1,657 @@
+// Copyright 2017 Apcera Inc. All rights reserved.
+
+package server
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	natsdTest "github.com/nats-io/gnatsd/test"
+	"github.com/nats-io/go-nats"
+	"github.com/nats-io/go-nats-streaming"
+	"github.com/nats-io/nats-streaming-server/spb"
+	"github.com/nats-io/nats-streaming-server/stores"
+	"sync/atomic"
+)
+
+// A mock store that we use to override GetExclusiveLock() behavior.
+type ftMockStore struct {
+	// We need to embed the stores' MockStore.
+	stores.DelegateStore
+	sync.Mutex
+	result bool
+	err    error
+}
+
+func (ms *ftMockStore) GetExclusiveLock() (bool, error) {
+	ms.Lock()
+	defer ms.Unlock()
+	return ms.result, ms.err
+}
+
+func replaceWithMockedStore(s *StanServer, result bool, err error) {
+	s.mu.Lock()
+	ms := &ftMockStore{
+		DelegateStore: stores.DelegateStore{S: s.store},
+		result:        result,
+		err:           err,
+	}
+	s.store = ms
+	s.mu.Unlock()
+}
+
+func setMockedStoreVals(s *StanServer, result bool, err error) {
+	s.mu.Lock()
+	ms := s.store.(*ftMockStore)
+	s.mu.Unlock()
+	ms.Lock()
+	ms.result = result
+	ms.err = err
+	ms.Unlock()
+}
+
+func setFTTestsHBInterval() {
+	ftHBInterval = 50 * time.Millisecond
+	ftHBMissedInterval = 75 * time.Millisecond
+}
+
+func getTestFTDefaultOptions() *Options {
+	opts := getTestDefaultOptsForFileStore()
+	opts.FTGroupName = "ft"
+	return opts
+}
+
+func delayFirstLockAttempt() {
+	ftPauseBeforeFirstAttempt = true
+}
+
+func cancelFirstLockAttemptDelay() {
+	ftPauseBeforeFirstAttempt = false
+}
+
+func TestFTConfig(t *testing.T) {
+	cleanupDatastore(t, defaultDataStore)
+	defer cleanupDatastore(t, defaultDataStore)
+
+	opts := GetDefaultOptions()
+	opts.FTGroupName = "ft"
+	s, err := RunServerWithOpts(opts, nil)
+	if s != nil || err == nil {
+		s.Shutdown()
+		t.Fatal("Server should have failed to start with FT mode and MemStore")
+	}
+}
+
+func getFTActiveServer(t *testing.T, servers ...*StanServer) *StanServer {
+	var active *StanServer
+	for l := 0; l < 5; l++ {
+		for i := 0; i < len(servers); i++ {
+			s := servers[i]
+			if s.State() == FTActive {
+				if active != nil {
+					stackFatalf(t, "Found more than one active servers")
+				}
+				active = s
+			}
+		}
+		if active != nil {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	if active == nil {
+		stackFatalf(t, "Unable to find the active server")
+	}
+	return active
+}
+
+func TestFTBasic(t *testing.T) {
+	cleanupDatastore(t, defaultDataStore)
+	defer cleanupDatastore(t, defaultDataStore)
+
+	// For this test, use a central NATS server
+	ns := natsdTest.RunDefaultServer()
+	defer ns.Shutdown()
+
+	delayFirstLockAttempt()
+	defer cancelFirstLockAttemptDelay()
+
+	// Configure first server
+	s1sOpts := getTestFTDefaultOptions()
+	s1sOpts.NATSServerURL = "nats://localhost:4222"
+	s1, err := RunServerWithOpts(s1sOpts, nil)
+	if err != nil {
+		t.Fatalf("Error starting server: %v", err)
+	}
+	ftReleasePause()
+	defer s1.Shutdown()
+
+	// Configure second server
+	s2sOpts := getTestFTDefaultOptions()
+	s2sOpts.NATSServerURL = "nats://localhost:4222"
+	s2, err := RunServerWithOpts(s2sOpts, nil)
+	if err != nil {
+		t.Fatalf("Error starting server: %v", err)
+	}
+	replaceWithMockedStore(s2, false, nil)
+	ftReleasePause()
+	defer s2.Shutdown()
+
+	s := getFTActiveServer(t, s1, s2)
+
+	// Create a client connection
+	sc := NewDefaultConnection(t)
+	defer sc.Close()
+	// Create a subscription and notify the go channel when we get the message
+	ch := make(chan bool)
+	if _, err := sc.Subscribe("foo", func(_ *stan.Msg) { ch <- true },
+		stan.DeliverAllAvailable()); err != nil {
+		t.Fatalf("Unexpected error on subscribe: %v", err)
+	}
+	// For test, make sure subscriber is registered.
+	waitForNumSubs(t, s, clientName, 1)
+	// Now shutdown the active
+	s.Shutdown()
+	setMockedStoreVals(s2, true, nil)
+	// Get the reference to the new active server
+	s = getFTActiveServer(t, s1, s2)
+	// Publish a message
+	if err := sc.Publish("foo", []byte("hello")); err != nil {
+		t.Fatalf("Unexpected error on publish: %v", err)
+	}
+	// Check that we have received our message
+	if err := Wait(ch); err != nil {
+		t.Fatal("Did not get our message")
+	}
+	// Done!
+	sc.Close()
+	s.Shutdown()
+}
+
+func checkState(t *testing.T, s *StanServer, expectedState State) {
+	if state := s.State(); state != expectedState {
+		stackFatalf(t, "Expected server state to be %v, got %v (ft error=%v)",
+			expectedState.String(), state.String(), s.FTError())
+	}
+	// Repeat test with String() too...
+	if stateStr := s.State().String(); stateStr != expectedState.String() {
+		stackFatalf(t, "Expected server state to be %v, got %v (ft error=%v)",
+			expectedState.String(), stateStr, s.FTError())
+	}
+}
+
+func waitForGetLockAttempt() {
+	time.Sleep(ftHBMissedInterval + 25*time.Millisecond)
+}
+
+func TestFTCanStopFTStandby(t *testing.T) {
+	cleanupDatastore(t, defaultDataStore)
+	defer cleanupDatastore(t, defaultDataStore)
+
+	delayFirstLockAttempt()
+	defer cancelFirstLockAttemptDelay()
+
+	opts := getTestFTDefaultOptions()
+	s := runServerWithOpts(t, opts, nil)
+	defer s.Shutdown()
+	replaceWithMockedStore(s, false, nil)
+	ftReleasePause()
+
+	// Make sure that it did not become active, even after more than the
+	// attempt to get the store lock.
+	waitForGetLockAttempt()
+	checkState(t, s, FTStandby)
+	// Make sure we can shut it down
+	err := make(chan error, 1)
+	ok := make(chan struct{}, 1)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		select {
+		case <-ok:
+			ok <- struct{}{}
+		case <-time.After(5 * time.Second):
+			err <- fmt.Errorf("Failed to shutdown")
+		}
+	}()
+	go func() {
+		s.Shutdown()
+		ok <- struct{}{}
+	}()
+	select {
+	case <-ok:
+		ok <- struct{}{}
+	case e := <-err:
+		t.Fatal(e)
+	}
+	wg.Wait()
+	// Check state, should be shutdown
+	checkState(t, s, Shutdown)
+	// Since server did not try to activate, there should not be any FT startup error
+	if err := s.FTError(); err != nil {
+		t.Fatalf("FT startup error should be nil, got: %v", err)
+	}
+}
+
+var ftPartitionDB = flag.String("ft_partition", "", "")
+
+func TestFTPartition(t *testing.T) {
+	ds := *ftPartitionDB
+	parentProcess := ds == ""
+	nOpts := natsdTest.DefaultTestOptions
+	var natsURL string
+	if parentProcess {
+		ds = defaultDataStore
+		cleanupDatastore(t, ds)
+		defer cleanupDatastore(t, ds)
+
+		nOpts.Cluster.ListenStr = "nats://localhost:6222"
+		nOpts.RoutesStr = "nats://localhost:6223"
+		natsURL = "nats://localhost:4222"
+	} else {
+		nOpts.Port = 4223
+		nOpts.Cluster.ListenStr = "nats://localhost:6223"
+		nOpts.RoutesStr = "nats://localhost:6222"
+		natsURL = "nats://localhost:4223"
+	}
+
+	// Start NATS server independently
+	ns := natsdTest.RunServer(&nOpts)
+	defer shutdownRestartedNATSServerOnTestExit(&ns)
+
+	sOpts := getTestFTDefaultOptions()
+	sOpts.NATSServerURL = natsURL
+	sOpts.FilestoreDir = ds
+	s := runServerWithOpts(t, sOpts, nil)
+	defer s.Shutdown()
+
+	// Wait for election and check state
+	waitForGetLockAttempt()
+
+	if parentProcess {
+		// We should be the active server
+		checkState(t, s, FTActive)
+
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		errCh := make(chan error, 1)
+		go func() {
+			defer wg.Done()
+			// Start a process that will be the standby
+			out, err := exec.Command(os.Args[0], "-ft_partition", ds,
+				"-test.v", "-test.run=TestFTPartition$").CombinedOutput()
+			if err != nil {
+				errCh <- fmt.Errorf("Standby error: %v - %v", err, string(out))
+			}
+		}()
+
+		// Give a bit of chance for child process to start and be the standby
+		waitForGetLockAttempt()
+		// Kill our NATS server, the standby should try to become active but
+		// fail due to file lock
+		ns.Shutdown()
+		waitForGetLockAttempt()
+		ns = natsdTest.RunServer(&nOpts)
+		waitForGetLockAttempt()
+		checkState(t, s, FTActive)
+		wg.Wait()
+		select {
+		case e := <-errCh:
+			t.Fatal(e)
+		default:
+		}
+	} else {
+		// Wait this process to be the standby server
+		checkState(t, s, FTStandby)
+		// The active server's NATS server will be killed in the parent
+		// process. The standby is going to try to become active, but should
+		// fail.
+		// Let's wait twice the normal time
+		waitForGetLockAttempt()
+		waitForGetLockAttempt()
+		checkState(t, s, FTStandby)
+	}
+}
+
+// This is same that TestFTPartition, but roles are reversed. This is mainly for
+// code coverage report.
+func TestFTPartitionReversed(t *testing.T) {
+	ds := *ftPartitionDB
+	parentProcess := ds == ""
+	nOpts := natsdTest.DefaultTestOptions
+	var natsURL string
+	if parentProcess {
+		ds = defaultDataStore
+		cleanupDatastore(t, ds)
+		defer cleanupDatastore(t, ds)
+
+		nOpts.Cluster.ListenStr = "nats://localhost:6222"
+		nOpts.RoutesStr = "nats://localhost:6223"
+		natsURL = "nats://localhost:4222"
+	} else {
+		nOpts.Port = 4223
+		nOpts.Cluster.ListenStr = "nats://localhost:6223"
+		nOpts.RoutesStr = "nats://localhost:6222"
+		natsURL = "nats://localhost:4223"
+	}
+
+	// Start NATS server independently
+	ns := natsdTest.RunServer(&nOpts)
+	defer shutdownRestartedNATSServerOnTestExit(&ns)
+
+	if parentProcess {
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		errCh := make(chan error, 1)
+		go func() {
+			defer wg.Done()
+			// Start a process that will be the standby
+			out, err := exec.Command(os.Args[0], "-ft_partition", ds,
+				"-test.v", "-test.run=TestFTPartitionReversed$").CombinedOutput()
+			if err != nil {
+				errCh <- fmt.Errorf("Active error: %v - %v", err, string(out))
+			}
+		}()
+
+		// Wait for the child process to become active server.
+		waitForGetLockAttempt()
+
+		sOpts := getTestFTDefaultOptions()
+		sOpts.NATSServerURL = natsURL
+		sOpts.FilestoreDir = ds
+		s := runServerWithOpts(t, sOpts, nil)
+		defer s.Shutdown()
+
+		waitForGetLockAttempt()
+		checkState(t, s, FTStandby)
+
+		// The active server's NATS server is going to be killed.
+		// The standby here will try to become active, but should fail
+		// to do so and stay standby
+		waitForGetLockAttempt()
+		checkState(t, s, FTStandby)
+
+		wg.Wait()
+		select {
+		case e := <-errCh:
+			t.Fatal(e)
+		default:
+		}
+	} else {
+		sOpts := getTestFTDefaultOptions()
+		sOpts.NATSServerURL = natsURL
+		sOpts.FilestoreDir = ds
+		s := runServerWithOpts(t, sOpts, nil)
+		defer s.Shutdown()
+
+		// Wait this process to be the active server
+		waitForGetLockAttempt()
+		checkState(t, s, FTActive)
+
+		// Shutdown NATS server to cause standby to try to become active
+		ns.Shutdown()
+		waitForGetLockAttempt()
+		ns = natsdTest.RunServer(&nOpts)
+		waitForGetLockAttempt()
+		checkState(t, s, FTActive)
+	}
+}
+
+func TestFTFailedStartup(t *testing.T) {
+	cleanupDatastore(t, defaultDataStore)
+	defer cleanupDatastore(t, defaultDataStore)
+
+	opts := getTestFTDefaultOptions()
+	s := runServerWithOpts(t, opts, nil)
+	// Wait for it to become active
+	getFTActiveServer(t, s)
+	// Now shut it down
+	s.Shutdown()
+	// And restart with wrong cluster name.
+	opts.ID = "wrongClusterName"
+	// We should not get an error until it becomes active
+	// because until then, it cannot know that it's cluster ID
+	// does not match the one stored.
+	s = runServerWithOpts(t, opts, nil)
+	defer s.Shutdown()
+	waitForGetLockAttempt()
+	// to be more reliable, wait one more time.
+	waitForGetLockAttempt()
+	checkState(t, s, FTFailed)
+	if err := s.FTError(); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("Expected error regarding non matching cluster ID, got %v", err)
+	}
+}
+
+func TestFTImmediateShutdownOnStartup(t *testing.T) {
+	cleanupDatastore(t, defaultDataStore)
+	defer cleanupDatastore(t, defaultDataStore)
+
+	opts := getTestFTDefaultOptions()
+	s := runServerWithOpts(t, opts, nil)
+	s.Shutdown()
+	checkState(t, s, Shutdown)
+}
+
+func TestFTGetStoreLockReturnsError(t *testing.T) {
+	cleanupDatastore(t, defaultDataStore)
+	defer cleanupDatastore(t, defaultDataStore)
+
+	delayFirstLockAttempt()
+	defer cancelFirstLockAttemptDelay()
+
+	opts := getTestFTDefaultOptions()
+	s := runServerWithOpts(t, opts, nil)
+	defer s.Shutdown()
+	replaceWithMockedStore(s, false, fmt.Errorf("on purpose"))
+	ftReleasePause()
+	waitForGetLockAttempt()
+	checkState(t, s, FTFailed)
+	// Should get an error about getting an error getting the store lock
+	if err := s.FTError(); err == nil || !strings.Contains(err.Error(), "store lock") {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestFTStayStandbyIfStoreAlreadyLocked(t *testing.T) {
+	cleanupDatastore(t, defaultDataStore)
+	defer cleanupDatastore(t, defaultDataStore)
+
+	delayFirstLockAttempt()
+	defer cancelFirstLockAttemptDelay()
+
+	opts := getTestFTDefaultOptions()
+	s := runServerWithOpts(t, opts, nil)
+	defer s.Shutdown()
+	replaceWithMockedStore(s, false, nil)
+	ftReleasePause()
+	checkState(t, s, FTStandby)
+	// Now shutdown and check state
+	s.Shutdown()
+	checkState(t, s, Shutdown)
+}
+
+func TestFTSteppingDown(t *testing.T) {
+	cleanupDatastore(t, defaultDataStore)
+	defer cleanupDatastore(t, defaultDataStore)
+
+	delayFirstLockAttempt()
+	defer cancelFirstLockAttemptDelay()
+
+	ftNoPanic = true
+	defer func() {
+		ftNoPanic = false
+	}()
+
+	// For this test, run a central NATS server
+	ns := natsdTest.RunDefaultServer()
+	defer shutdownRestartedNATSServerOnTestExit(&ns)
+
+	// Start first server
+	opts1 := getTestFTDefaultOptions()
+	opts1.NATSServerURL = "nats://localhost:4222"
+	s1 := runServerWithOpts(t, opts1, nil)
+	defer s1.Shutdown()
+	ftReleasePause()
+	// Wait for it to be active
+	getFTActiveServer(t, s1)
+
+	// Start 2nd server, give it a mock store that says it can get the lock
+	opts2 := getTestFTDefaultOptions()
+	opts2.NATSServerURL = "nats://localhost:4222"
+	s2 := runServerWithOpts(t, opts2, nil)
+	defer s2.Shutdown()
+	replaceWithMockedStore(s2, true, nil)
+	ftReleasePause()
+	// Shutdown the NATS server
+	ns.Shutdown()
+	// Wait the next attempt to grab the lock
+	waitForGetLockAttempt()
+	// And restart it
+	ns = natsdTest.RunDefaultServer()
+	// Make sure that streaming has time to reconnect and wait for HBs
+	// exchange to realize that there are 2 actives.
+	time.Sleep(time.Second)
+	// Since s1 activated before s2, we want s1 to stay and s2 to exit.
+	checkState(t, s1, FTActive)
+	checkState(t, s2, FTFailed)
+	if err := s2.FTError(); err == nil || !strings.Contains(err.Error(), "aborting") {
+		t.Fatalf("Expected server to have exited due to both servers being active, got %v", err)
+	}
+}
+
+func TestFTActiveSendsHB(t *testing.T) {
+	cleanupDatastore(t, defaultDataStore)
+	defer cleanupDatastore(t, defaultDataStore)
+
+	// For this test, make the HB interval very small so that we have more
+	// chance to get actual failure when we disconnect from NATS.
+	ftHBInterval = time.Millisecond
+	defer setFTTestsHBInterval()
+
+	ns := natsdTest.RunDefaultServer()
+	defer shutdownRestartedNATSServerOnTestExit(&ns)
+
+	// Start Streaming server
+	opts := getTestFTDefaultOptions()
+	opts.NATSServerURL = "nats://localhost:4222"
+	s := runServerWithOpts(t, opts, nil)
+	defer s.Shutdown()
+	// Wait for it to be active
+	getFTActiveServer(t, s)
+
+	s.mu.RLock()
+	subj := s.ftSubject
+	reconnDelay := s.ftnc.Opts.ReconnectWait
+	s.mu.RUnlock()
+
+	// setup bare NATS subscriber that checks FT hbs.
+	// We use the same reconnect delay than the Streaming server
+	// uses.
+	rch := make(chan bool)
+	nc, err := nats.Connect(nats.DefaultURL,
+		nats.ReconnectWait(reconnDelay),
+		nats.MaxReconnects(-1),
+		nats.ReconnectHandler(func(_ *nats.Conn) {
+			rch <- true
+		}))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc.Close()
+
+	hbarch := make(chan bool)
+	reconnected := int32(0)
+	hbBefore := int32(0)
+	if _, err = nc.Subscribe(subj, func(m *nats.Msg) {
+		if atomic.LoadInt32(&reconnected) == 1 {
+			hbarch <- true
+			m.Sub.Unsubscribe()
+		} else {
+			atomic.AddInt32(&hbBefore, 1)
+		}
+	}); err != nil {
+		t.Fatalf("Error on subscribe: %v", err)
+	}
+	if err := nc.Flush(); err != nil {
+		t.Fatalf("Error on flush: %v", err)
+	}
+	// Wait for some HBs to be sent before the disconnect
+	time.Sleep(50 * time.Millisecond)
+	// Shutdown the NATS server
+	ns.Shutdown()
+	time.Sleep(time.Second)
+	// Start again
+	ns = natsdTest.RunDefaultServer()
+	atomic.StoreInt32(&reconnected, 1)
+	// Wait that we know we have reconnected.
+	if err := Wait(rch); err != nil {
+		t.Fatal("Did not get reconnected")
+	}
+	// Wait to receive an HB after the reconnect
+	if err := Wait(hbarch); err != nil {
+		t.Fatal("Did not get our HB after reconnect")
+	}
+	// We should have received some before the disconnect
+	if atomic.LoadInt32(&hbBefore) == 0 {
+		t.Fatal("Should have received HB before the disconnect")
+	}
+}
+
+func TestFTActiveReceivesInvalidHBMessages(t *testing.T) {
+	cleanupDatastore(t, defaultDataStore)
+	defer cleanupDatastore(t, defaultDataStore)
+
+	ns := natsdTest.RunDefaultServer()
+	defer ns.Shutdown()
+
+	// Start Streaming server
+	opts := getTestFTDefaultOptions()
+	opts.NATSServerURL = "nats://localhost:4222"
+	s := runServerWithOpts(t, opts, nil)
+	defer s.Shutdown()
+	// Wait for it to be active
+	getFTActiveServer(t, s)
+
+	s.mu.RLock()
+	subj := s.ftSubject
+	s.mu.RUnlock()
+
+	// use bare NATS connection to send fake FT HBs.
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc.Close()
+
+	// Sending invalid HBs, waiting a bit to make sure
+	// server processes it and check that it is still FTActive
+
+	// Send nil message
+	nc.Publish(subj, nil)
+	time.Sleep(50 * time.Millisecond)
+	checkState(t, s, FTActive)
+
+	// Send invalid protobuf
+	nc.Publish(subj, []byte("wrong msg"))
+	time.Sleep(50 * time.Millisecond)
+	checkState(t, s, FTActive)
+
+	// Send valid protobuf but with invalid activation time
+	hb := spb.CtrlMsg{
+		MsgType:  spb.CtrlMsg_FTHeartbeat,
+		ServerID: "otherserver",
+		Data:     []byte("wrong time"),
+	}
+	bytes, _ := hb.Marshal()
+	nc.Publish(subj, bytes)
+	time.Sleep(50 * time.Millisecond)
+	checkState(t, s, FTActive)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -46,6 +46,9 @@ const (
 	// to change them). Add the new ones as private.
 	acksSubsPoolPrefix = "_STAN.subacks"
 
+	// Prefix of subject active server is sending HBs to
+	ftHBPrefix = "_STAN.ft"
+
 	// DefaultHeartBeatInterval is the interval at which server sends heartbeat to a client
 	DefaultHeartBeatInterval = 30 * time.Second
 	// DefaultClientHBTimeout is how long server waits for a heartbeat response
@@ -259,11 +262,13 @@ type StanServer struct {
 	acksSubsPrefixLen int
 
 	// For FT mode
-	ftnc      *nats.Conn
-	ftSubject string
-	ftHBCh    chan *nats.Msg
-	ftQuit    chan struct{}
-	ftError   error
+	ftnc               *nats.Conn
+	ftSubject          string
+	ftHBInterval       time.Duration
+	ftHBMissedInterval time.Duration
+	ftHBCh             chan *nats.Msg
+	ftQuit             chan struct{}
+	ftError            error
 
 	state State
 

--- a/server/server.go
+++ b/server/server.go
@@ -31,7 +31,7 @@ import (
 // Server defaults.
 const (
 	// VERSION is the current version for the NATS Streaming server.
-	VERSION = "0.3.9"
+	VERSION = "0.4.0"
 
 	DefaultClusterID      = "test-cluster"
 	DefaultDiscoverPrefix = "_STAN.discover"
@@ -165,6 +165,35 @@ type subStartInfo struct {
 	isDurable bool
 }
 
+// State represents the possible server states
+type State int8
+
+// Possible server states
+const (
+	Standalone State = iota
+	FTActive
+	FTStandby
+	FTFailed
+	Shutdown
+)
+
+func (state State) String() string {
+	switch state {
+	case Standalone:
+		return "STANDALONE"
+	case FTActive:
+		return "FT_ACTIVE"
+	case FTStandby:
+		return "FT_STANDBY"
+	case FTFailed:
+		return "FT_FAILED"
+	case Shutdown:
+		return "SHUTDOWN"
+	default:
+		return "UNKNOW STATE"
+	}
+}
+
 // StanServer structure represents the STAN server
 type StanServer struct {
 	// Keep all members for which we use atomic at the beginning of the
@@ -173,7 +202,7 @@ type StanServer struct {
 	// at 64bit. See https://github.com/golang/go/issues/599
 	ioChannelStatsMaxBatchSize int64 // stats of the max number of messages than went into a single batch
 
-	sync.RWMutex
+	mu         sync.RWMutex
 	shutdown   bool
 	serverID   string
 	info       spb.ServerInfo // Contains cluster ID and subjects
@@ -209,7 +238,6 @@ type StanServer struct {
 	// Used to fix out-of-order processing of subUnsub/subClose/connClose
 	// requests due to use of different NATS subscribers for various
 	// protocols.
-	srvCtrlMsgID  string         // NUID used to filter control messages not intended for this server.
 	closeProtosMu sync.Mutex     // Mutex used for unsub/close requests.
 	connCloseReqs map[string]int // Key: clientID Value: ref count
 
@@ -229,6 +257,15 @@ type StanServer struct {
 	acksSubs          []*nats.Subscription
 	acksSubsPrefix    string
 	acksSubsPrefixLen int
+
+	// For FT mode
+	ftnc      *nats.Conn
+	ftSubject string
+	ftHBCh    chan *nats.Msg
+	ftQuit    chan struct{}
+	ftError   error
+
+	state State
 
 	// Use these flags for Debug/Trace in places where speed matters.
 	// Normally, Debugf and Tracef will check an atomic variable to
@@ -602,6 +639,7 @@ type Options struct {
 	ClientHBTimeout    time.Duration // How long server waits for a heartbeat response.
 	ClientHBFailCount  int           // Number of failed heartbeats before server closes client connection.
 	AckSubsPoolSize    int           // Number of internal subscriptions handling incoming ACKs (0 means one per client's subscription).
+	FTGroupName        string        // Name of the FT Group. A group can be 2 or more servers with a single active server and all sharing the same datastore.
 }
 
 // DefaultOptions are default options for the STAN server
@@ -754,6 +792,17 @@ func (s *StanServer) createNatsClientConn(name string, sOpts *Options, nOpts *se
 			return nil, err
 		}
 	}
+	// Shorten the time we wait to try to reconnect.
+	// Don't make it too often because it may exhaust the number of FDs.
+	ncOpts.ReconnectWait = 250 * time.Millisecond
+	// Make it try to reconnect for ever.
+	ncOpts.MaxReconnect = -1
+	// For FT make the reconnect buffer as small as possible since
+	// we don't really want FT HBs to be buffered while we are disconnected
+	// and be sent as a burst on reconnect.
+	if name == "ft" {
+		ncOpts.ReconnectBufSize = 128
+	}
 
 	Tracef("STAN:  NATS conn opts: %v", ncOpts)
 
@@ -770,6 +819,9 @@ func (s *StanServer) createNatsConnections(sOpts *Options, nOpts *server.Options
 	if err == nil {
 		s.nc, err = s.createNatsClientConn("general", sOpts, nOpts)
 	}
+	if err == nil && sOpts.FTGroupName != "" {
+		s.ftnc, err = s.createNatsClientConn("ft", sOpts, nOpts)
+	}
 	return err
 }
 
@@ -782,7 +834,7 @@ func RunServer(ID string) (*StanServer, error) {
 }
 
 // RunServerWithOpts will startup an embedded STAN server and a nats-server to support it.
-func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (*StanServer, error) {
+func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (newServer *StanServer, returnedError error) {
 	testInbox := nats.NewInbox()
 	// We rely heavily on the format of a NATS inbox.
 	// Since we vendor nats and nuid, it should not change without our knowledge.
@@ -813,7 +865,6 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (*StanServer
 		dupMaxCIDRoutines: defaultMaxDupCIDRoutines,
 		dupCIDTimeout:     defaultCheckDupCIDTimeout,
 		ioChannelQuit:     make(chan struct{}, 1),
-		srvCtrlMsgID:      nuid.Next(),
 		connCloseReqs:     make(map[string]int),
 		trace:             sOpts.Trace,
 		debug:             sOpts.Debug,
@@ -822,19 +873,28 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (*StanServer
 		acksSubsPoolSize:  sOpts.AckSubsPoolSize,
 	}
 
-	// Ensure that we shutdown the server if there is a panic during startup.
+	// ServerID is used to check that a brodcast protocol is not ours,
+	// for instance with FT. Some err/warn messages may be printed
+	// regarding other instance's ID, so print it on startup.
+	Noticef("STAN: ServerID: %v", s.serverID)
+
+	// Ensure that we shutdown the server if there is a panic/error during startup.
 	// This will ensure that stores are closed (which otherwise would cause
 	// issues during testing) and that the NATS Server (if started) is also
 	// properly shutdown. To do so, we recover from the panic in order to
 	// call Shutdown, then issue the original panic.
 	defer func() {
+		// We used to issue panic for common errors but now return error
+		// instead. Still we want to log the reason for the panic.
 		if r := recover(); r != nil {
 			s.Shutdown()
-			// Log the reason for the panic. We use noticef here since
-			// Fatalf() would cause an exit.
 			Noticef("Failed to start: %v", r)
-			// Issue the original panic now that the store is closed.
 			panic(r)
+		} else if returnedError != nil {
+			s.Shutdown()
+			// Log it as a fatal error, process will exit (if
+			// running from executable or logger is configured).
+			Fatalf("Failed to start: %v", returnedError)
 		}
 	}()
 
@@ -842,11 +902,8 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (*StanServer
 	limits := &sOpts.StoreLimits
 
 	var (
-		err            error
-		recoveredState *stores.RecoveredState
-		recoveredSubs  []*subState
-		store          stores.Store
-		callStoreInit  bool
+		err   error
+		store stores.Store
 	)
 
 	// Ensure store type option is in upper-case
@@ -855,12 +912,7 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (*StanServer
 	// Create the store. So far either memory or file-based.
 	switch sOpts.StoreType {
 	case stores.TypeFile:
-		// The dir must be specified
-		if sOpts.FilestoreDir == "" {
-			err = fmt.Errorf("for %v stores, root directory must be specified", stores.TypeFile)
-			break
-		}
-		store, recoveredState, err = stores.NewFileStore(sOpts.FilestoreDir, limits,
+		store, err = stores.NewFileStore(sOpts.FilestoreDir, limits,
 			stores.AllOptions(&sOpts.FileStoreOpts))
 	case stores.TypeMemory:
 		store, err = stores.NewMemoryStore(limits)
@@ -868,7 +920,7 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (*StanServer
 		err = fmt.Errorf("unsupported store type: %v", sOpts.StoreType)
 	}
 	if err != nil {
-		goto handleError
+		return nil, err
 	}
 	// StanServer.store (s.store here) is of type stores.Store, which is an
 	// interace. If we assign s.store in the call of the constructor and there
@@ -883,26 +935,87 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (*StanServer
 	// Create clientStore
 	s.clients = &clientStore{store: s.store}
 
+	// If no NATS server url is provided, it means that we embed the NATS Server
+	if sOpts.NATSServerURL == "" {
+		if err := s.startNATSServer(nOpts); err != nil {
+			return nil, err
+		}
+	}
+	// Create our connections
+	if err := s.createNatsConnections(sOpts, nOpts); err != nil {
+		return nil, err
+	}
+
+	// In FT mode, server cannot recover the store until it is elected leader.
+	if s.opts.FTGroupName != "" {
+		if err := s.ftSetup(); err != nil {
+			return nil, err
+		}
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			if err := s.ftStart(); err != nil {
+				s.ftSetError(err)
+			}
+		}()
+	} else {
+		if err := s.start(Standalone); err != nil {
+			return nil, err
+		}
+	}
+	return &s, nil
+}
+
+// This is either running inside RunServerWithOpts() and before any reference
+// to the server is returned, so locking is not really an issue, or it is
+// running from a go-routine when the server has been elected the FT active.
+// Therefore, this function grabs the server lock for the duration of this
+// call and so care must be taken to not invoke - directly or indirectly -
+// code that would attempt to grab the server lock.
+func (s *StanServer) start(runningState State) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.shutdown {
+		return nil
+	}
+
+	var (
+		err            error
+		recoveredState *stores.RecoveredState
+		recoveredSubs  []*subState
+		callStoreInit  bool
+	)
+
+	limits := &s.opts.StoreLimits
+
+	// Recover the state.
+	recoveredState, err = s.store.Recover()
+	if err != nil {
+		return err
+	}
+	subjID := s.opts.ID
+	if runningState == Standalone {
+		subjID = nuid.Next()
+	}
 	if recoveredState != nil {
 		// Copy content
 		s.info = *recoveredState.Info
 		// Check cluster IDs match
 		if s.opts.ID != s.info.ClusterID {
-			err = fmt.Errorf("cluster ID %q does not match recovered value of %q",
+			return fmt.Errorf("cluster ID %q does not match recovered value of %q",
 				s.opts.ID, s.info.ClusterID)
-			goto handleError
 		}
 		// Check to see if SubClose subject is present or not.
 		// If not, it means we recovered from an older server, so
 		// need to update.
 		if s.info.SubClose == "" {
-			s.info.SubClose = fmt.Sprintf("%s.%s", DefaultSubClosePrefix, nuid.Next())
+			s.info.SubClose = fmt.Sprintf("%s.%s", DefaultSubClosePrefix, subjID)
 			// Update the store with the server info
 			callStoreInit = true
 		}
 		// Same for AcksSubs (use of pool of subscriptions for subscriptions' acks)
 		if s.info.AcksSubs == "" {
-			s.info.AcksSubs = fmt.Sprintf("%s.%s", acksSubsPoolPrefix, nuid.Next())
+			s.info.AcksSubs = fmt.Sprintf("%s.%s", acksSubsPoolPrefix, subjID)
 			callStoreInit = true
 		}
 
@@ -914,38 +1027,27 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (*StanServer
 	} else {
 		s.info.ClusterID = s.opts.ID
 		// Generate Subjects
-		// FIXME(dlc) guid needs to be shared in cluster mode
 		s.info.Discovery = fmt.Sprintf("%s.%s", s.opts.DiscoverPrefix, s.info.ClusterID)
-		s.info.Publish = fmt.Sprintf("%s.%s", DefaultPubPrefix, nuid.Next())
-		s.info.Subscribe = fmt.Sprintf("%s.%s", DefaultSubPrefix, nuid.Next())
-		s.info.SubClose = fmt.Sprintf("%s.%s", DefaultSubClosePrefix, nuid.Next())
-		s.info.Unsubscribe = fmt.Sprintf("%s.%s", DefaultUnSubPrefix, nuid.Next())
-		s.info.Close = fmt.Sprintf("%s.%s", DefaultClosePrefix, nuid.Next())
-		s.info.AcksSubs = fmt.Sprintf("%s.%s", acksSubsPoolPrefix, nuid.Next())
+		s.info.Publish = fmt.Sprintf("%s.%s", DefaultPubPrefix, subjID)
+		s.info.Subscribe = fmt.Sprintf("%s.%s", DefaultSubPrefix, subjID)
+		s.info.SubClose = fmt.Sprintf("%s.%s", DefaultSubClosePrefix, subjID)
+		s.info.Unsubscribe = fmt.Sprintf("%s.%s", DefaultUnSubPrefix, subjID)
+		s.info.Close = fmt.Sprintf("%s.%s", DefaultClosePrefix, subjID)
+		s.info.AcksSubs = fmt.Sprintf("%s.%s", acksSubsPoolPrefix, subjID)
 
 		callStoreInit = true
 	}
 	if callStoreInit {
 		// Initialize the store with the server info
-		err = s.store.Init(&s.info)
-		if err != nil {
-			err = fmt.Errorf("Unable to initialize the store: %v", err)
-			goto handleError
+		if err := s.store.Init(&s.info); err != nil {
+			return fmt.Errorf("Unable to initialize the store: %v", err)
 		}
 	}
 
-	// If no NATS server url is provided, it means that we embed the NATS Server
-	if sOpts.NATSServerURL == "" {
-		err = s.startNATSServer(nOpts)
-	}
-	if err == nil {
-		err = s.createNatsConnections(sOpts, nOpts)
-	}
-	if err == nil {
-		err = s.ensureRunningStandAlone()
-	}
-	if err != nil {
-		goto handleError
+	if runningState == Standalone {
+		if err := s.ensureRunningStandAlone(); err != nil {
+			return err
+		}
 	}
 
 	// Start the go-routine responsible to start sending messages to newly
@@ -955,27 +1057,22 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (*StanServer
 	s.wg.Add(1)
 	go s.processSubscriptionsStart()
 
-	err = s.initSubscriptions()
-	if err != nil {
-		goto handleError
+	if err := s.initSubscriptions(); err != nil {
+		return err
 	}
 
 	if recoveredState != nil {
 		// Do some post recovery processing (create subs on AckInbox, setup
 		// some timers, etc...)
-		err = s.postRecoveryProcessing(recoveredState.Clients, recoveredSubs)
-		if err != nil {
-			err = fmt.Errorf("error during post recovery processing: %v", err)
-			goto handleError
+		if err := s.postRecoveryProcessing(recoveredState.Clients, recoveredSubs); err != nil {
+			return fmt.Errorf("error during post recovery processing: %v", err)
 		}
 	}
 
 	// Flush to make sure all subscriptions are processed before
 	// we return control to the user.
-	err = s.nc.Flush()
-	if err != nil {
-		err = fmt.Errorf("could not flush the subscriptions, %v", err)
-		goto handleError
+	if err := s.nc.Flush(); err != nil {
+		return fmt.Errorf("could not flush the subscriptions, %v", err)
 	}
 
 	Noticef("STAN: Message store is %s", s.store.Name())
@@ -997,13 +1094,8 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (*StanServer
 	// and release newOnHold
 	s.wg.Add(1)
 	go s.performRedeliveryOnStartup(recoveredSubs)
-
-	return &s, nil
-
-handleError:
-	s.Shutdown()
-	Fatalf("Failed to start: %v", err)
-	return nil, err
+	s.state = runningState
+	return nil
 }
 
 func printLimits(isGlobal bool, limits, parentLimits *stores.ChannelLimits) {
@@ -1057,36 +1149,52 @@ func friendlyBytes(msgbytes int64) string {
 
 // TODO:  Explore parameter passing in gnatsd.  Keep seperate for now.
 func (s *StanServer) configureClusterOpts(opts *server.Options) error {
-	if opts.Cluster.ListenStr == "" {
+	// If we don't have cluster defined in the configuration
+	// file and no cluster listen string override, but we do
+	// have a routes override, we need to report misconfiguration.
+	if opts.Cluster.ListenStr == "" && opts.Cluster.Host == "" &&
+		opts.Cluster.Port == 0 {
 		if opts.RoutesStr != "" {
-			Fatalf("Solicited routes require cluster capabilities, e.g. --cluster")
+			err := fmt.Errorf("solicited routes require cluster capabilities, e.g. --cluster")
+			Fatalf(err.Error())
+			// Also return error in case server is started from application
+			// and no logger has been set.
+			return err
 		}
 		return nil
 	}
 
-	clusterURL, err := url.Parse(opts.Cluster.ListenStr)
-	if err != nil {
-		return err
-	}
-	h, p, err := net.SplitHostPort(clusterURL.Host)
-	if err != nil {
-		return err
-	}
-	opts.Cluster.Host = h
-	_, err = fmt.Sscan(p, &opts.Cluster.Port)
-	if err != nil {
-		return err
-	}
-
-	if clusterURL.User != nil {
-		pass, hasPassword := clusterURL.User.Password()
-		if !hasPassword {
-			return fmt.Errorf("Expected cluster password to be set")
+	// If cluster flag override, process it
+	if opts.Cluster.ListenStr != "" {
+		clusterURL, err := url.Parse(opts.Cluster.ListenStr)
+		if err != nil {
+			return err
 		}
-		opts.Cluster.Password = pass
+		h, p, err := net.SplitHostPort(clusterURL.Host)
+		if err != nil {
+			return err
+		}
+		opts.Cluster.Host = h
+		_, err = fmt.Sscan(p, &opts.Cluster.Port)
+		if err != nil {
+			return err
+		}
 
-		user := clusterURL.User.Username()
-		opts.Cluster.Username = user
+		if clusterURL.User != nil {
+			pass, hasPassword := clusterURL.User.Password()
+			if !hasPassword {
+				return fmt.Errorf("expected cluster password to be set")
+			}
+			opts.Cluster.Password = pass
+
+			user := clusterURL.User.Username()
+			opts.Cluster.Username = user
+		} else {
+			// Since we override from flag and there is no user/pwd, make
+			// sure we clear what we may have gotten from config file.
+			opts.Cluster.Username = ""
+			opts.Cluster.Password = ""
+		}
 	}
 
 	// If we have routes but no config file, fill in here.
@@ -1176,8 +1284,9 @@ func (s *StanServer) startNATSServer(opts *server.Options) error {
 // ensureRunningStandAlone prevents this streaming server from starting
 // if another is found using the same cluster ID - a possibility when
 // routing is enabled.
+// This runs under sever's lock so nothing should grab the server lock here.
 func (s *StanServer) ensureRunningStandAlone() error {
-	clusterID := s.ClusterID()
+	clusterID := s.info.ClusterID
 	hbInbox := nats.NewInbox()
 	timeout := time.Millisecond * 250
 
@@ -1517,13 +1626,13 @@ func (s *StanServer) connectCB(m *nats.Msg) {
 		// to check on shutdown status. Note that s.wg is for all server's
 		// go routines, not specific to duplicate CID handling. Use server's
 		// lock here.
-		s.Lock()
+		s.mu.Lock()
 		shutdown := s.shutdown
 		if !shutdown {
 			// Assume we are going to start a go routine.
 			s.wg.Add(1)
 		}
-		s.Unlock()
+		s.mu.Unlock()
 
 		if shutdown {
 			// The client will timeout on connect
@@ -1743,7 +1852,7 @@ func (s *StanServer) processCloseRequest(m *nats.Msg) {
 
 	ctrlMsg := &spb.CtrlMsg{
 		MsgType:  spb.CtrlMsg_ConnClose,
-		ServerID: s.srvCtrlMsgID,
+		ServerID: s.serverID,
 		Data:     []byte(req.ClientID),
 	}
 	ctrlBytes, _ := ctrlMsg.Marshal()
@@ -1860,7 +1969,7 @@ func (s *StanServer) processInternalCloseRequest(m *nats.Msg, onlyConnClose bool
 	}
 	// If this control message is not intended for us, simply
 	// ignore the request and does not return a failure.
-	if cm.ServerID != s.srvCtrlMsgID {
+	if cm.ServerID != s.serverID {
 		return true
 	}
 	// If we expect only a connection close request but get
@@ -2578,7 +2687,7 @@ func (s *StanServer) performSubUnsubOrClose(reqType spb.CtrlMsg_Type, schedule b
 		if !sub.removed {
 			ctrlMsg := &spb.CtrlMsg{
 				MsgType:  reqType,
-				ServerID: s.srvCtrlMsgID,
+				ServerID: s.serverID,
 				Data:     m.Data,
 			}
 			ctrlBytes, _ := ctrlMsg.Marshal()
@@ -3255,23 +3364,56 @@ func (s *StanServer) setSubStartSequence(cs *stores.ChannelStore, sub *subState,
 	sub.Unlock()
 }
 
+// startGoRoutine starts the given function as a go routine if and only if
+// the server was not shutdown at that time. This is required because
+// we cannot increment the wait group after the shutdown process has started.
+func (s *StanServer) startGoRoutine(f func()) {
+	s.mu.Lock()
+	if !s.shutdown {
+		s.wg.Add(1)
+		go f()
+	}
+	s.mu.Unlock()
+}
+
 // ClusterID returns the STAN Server's ID.
 func (s *StanServer) ClusterID() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.info.ClusterID
+}
+
+// State returns the state of this server.
+func (s *StanServer) State() State {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.state
+}
+
+// FTError returns the possible error that an FT standby server
+// got in the process of activating, or in tests conditions,
+// if the active server exited due to detection of more than
+// one active servers.
+func (s *StanServer) FTError() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.ftError
 }
 
 // Shutdown will close our NATS connection and shutdown any embedded NATS server.
 func (s *StanServer) Shutdown() {
 	Noticef("STAN: Shutting down.")
 
-	s.Lock()
+	s.mu.Lock()
 	if s.shutdown {
-		s.Unlock()
+		s.mu.Unlock()
 		return
 	}
 
 	// Allows Shutdown() to be idempotent
 	s.shutdown = true
+	// Change the state too
+	s.state = Shutdown
 
 	// We need to make sure that the storeIOLoop returns before
 	// closing the Store
@@ -3295,7 +3437,11 @@ func (s *StanServer) Shutdown() {
 	} else {
 		waitForIOStoreLoop = false
 	}
-	s.Unlock()
+	// In case we are running in FT mode.
+	if s.ftQuit != nil {
+		s.ftQuit <- struct{}{}
+	}
+	s.mu.Unlock()
 
 	// Make sure the StoreIOLoop returns before closing the Store
 	if waitForIOStoreLoop {

--- a/server/server.go
+++ b/server/server.go
@@ -3432,6 +3432,7 @@ func (s *StanServer) Shutdown() {
 	// we won't panic.
 	ncs := s.ncs
 	nc := s.nc
+	ftnc := s.ftnc
 
 	// Stop processing subscriptions start requests
 	s.subStartQuit <- struct{}{}
@@ -3464,6 +3465,9 @@ func (s *StanServer) Shutdown() {
 	}
 	if nc != nil {
 		nc.Close()
+	}
+	if ftnc != nil {
+		ftnc.Close()
 	}
 	if ns != nil {
 		ns.Shutdown()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -49,6 +49,8 @@ func init() {
 	defaultDataStore = tmpDir
 	// Set debug and trace for this file.
 	setDebugAndTraceToDefaultOptions(true)
+	// For FT tests, reduce the HB/Timeout intervals
+	setFTTestsHBInterval()
 }
 
 func stackFatalf(t tLogger, f string, args ...interface{}) {
@@ -71,6 +73,13 @@ func stackFatalf(t tLogger, f string, args ...interface{}) {
 
 // Helper function to shutdown last, a server that is being restarted in a test.
 func shutdownRestartedServerOnTestExit(s **StanServer) {
+	srv := *s
+	srv.Shutdown()
+	srv = nil
+}
+
+// Helper function to shutdown last, a NATS server that is being restarted in a test.
+func shutdownRestartedNATSServerOnTestExit(s **natsd.Server) {
 	srv := *s
 	srv.Shutdown()
 	srv = nil
@@ -301,6 +310,15 @@ func TestDoubleShutdown(t *testing.T) {
 	if err := Wait(ch); err != nil {
 		t.Fatal("Second shutdown blocked")
 	}
+}
+
+func TestServerStates(t *testing.T) {
+	s := runServer(t, clusterName)
+	defer s.Shutdown()
+	checkState(t, s, Standalone)
+	s.Shutdown()
+	checkState(t, s, Shutdown)
+	// FT states are checked in ft_test.go
 }
 
 type response interface {
@@ -4256,11 +4274,15 @@ func TestNonDurableRemovedFromStoreOnConnClose(t *testing.T) {
 	s.Shutdown()
 	// Open the store directly and verify that the sub record is not even found.
 	limits := stores.DefaultStoreLimits
-	store, recoveredState, err := stores.NewFileStore(defaultDataStore, &limits)
+	store, err := stores.NewFileStore(defaultDataStore, &limits)
 	if err != nil {
 		t.Fatalf("Error opening file: %v", err)
 	}
 	defer store.Close()
+	recoveredState, err := store.Recover()
+	if err != nil {
+		t.Fatalf("Error recovering state: %v", err)
+	}
 	if recoveredState == nil {
 		t.Fatal("Expected to recover state, got none")
 	}
@@ -4464,13 +4486,13 @@ func checkQueueGroupSize(t *testing.T, s *StanServer, channelName, groupName str
 	if cs == nil {
 		stackFatalf(t, "Expected channel store %q to exist", channelName)
 	}
-	s.RLock()
+	s.mu.RLock()
 	groupSize := 0
 	group, exist := cs.UserData.(*subStore).qsubs[groupName]
 	if exist {
 		groupSize = len(group.subs)
 	}
-	s.RUnlock()
+	s.mu.RUnlock()
 	if expectedExist && !exist {
 		stackFatalf(t, "Expected group to still exist, does not")
 	}
@@ -5046,9 +5068,9 @@ func TestPerChannelLimits(t *testing.T) {
 			}
 		}
 		// Check messages count
-		s.RLock()
+		s.mu.RLock()
 		n, _, err := s.store.MsgsState("foo")
-		s.RUnlock()
+		s.mu.RUnlock()
 		if err != nil {
 			t.Fatalf("Unexpected error getting state: %v", err)
 		}
@@ -5064,9 +5086,9 @@ func TestPerChannelLimits(t *testing.T) {
 			}
 		}
 		// Check messages count
-		s.RLock()
+		s.mu.RLock()
 		n, b, err := s.store.MsgsState("bar")
-		s.RUnlock()
+		s.mu.RUnlock()
 		if err != nil {
 			t.Fatalf("Unexpected error getting state: %v", err)
 		}
@@ -5389,7 +5411,7 @@ func closeSubscriber(t *testing.T, subType string) {
 	}
 	wait()
 
-	s.RLock()
+	s.mu.RLock()
 	cs := s.store.LookupChannel("foo")
 	ss := cs.UserData.(*subStore)
 	var dur *subState
@@ -5398,7 +5420,7 @@ func closeSubscriber(t *testing.T, subType string) {
 	} else {
 		dur = ss.qsubs[durKey].subs[0]
 	}
-	s.RUnlock()
+	s.mu.RUnlock()
 	if dur == nil {
 		stackFatalf(t, "Durable should have been found")
 	}
@@ -5572,10 +5594,10 @@ func TestFileStoreQMemberRemovedFromStore(t *testing.T) {
 		t.Fatal("Did not get our message")
 	}
 	// Check server state
-	s.RLock()
+	s.mu.RLock()
 	cs, _ := s.lookupOrCreateChannel("foo")
 	ss := cs.UserData.(*subStore)
-	s.RUnlock()
+	s.mu.RUnlock()
 	ss.RLock()
 	qs := ss.qsubs["dur:group"]
 	ss.RUnlock()
@@ -5824,9 +5846,9 @@ func TestFileStoreAcksPool(t *testing.T) {
 
 	// Check server's ackSub pool
 	checkPoolSize := func() {
-		s.RLock()
+		s.mu.RLock()
 		poolSize := len(s.acksSubs)
-		s.RUnlock()
+		s.mu.RUnlock()
 		if poolSize != opts.AckSubsPoolSize {
 			stackFatalf(t, "Expected acksSubs pool size to be %v, got %v", opts.AckSubsPoolSize, poolSize)
 		}
@@ -6032,15 +6054,15 @@ func TestAckSubsSubjectsInPoolUseUniqueSubject(t *testing.T) {
 	// Wait for ack of sc2 to be processed by s2
 	waitForAcks(t, s2, "otherClient", 1, 0)
 
-	s1.Lock()
+	s1.mu.Lock()
 	s1AcksReceived, _ := s1.acksSubs[0].Delivered()
-	s1.Unlock()
+	s1.mu.Unlock()
 	if s1AcksReceived != 1 {
 		t.Fatalf("Expected pooled ack sub to receive only 1 message, got %v", s1AcksReceived)
 	}
-	s2.Lock()
+	s2.mu.Lock()
 	s2AcksReceived, _ := s2.acksSubs[0].Delivered()
-	s2.Unlock()
+	s2.mu.Unlock()
 	if s2AcksReceived != 1 {
 		t.Fatalf("Expected pooled ack sub to receive only 1 message, got %v", s2AcksReceived)
 	}

--- a/spb/protocol.pb.go
+++ b/spb/protocol.pb.go
@@ -37,17 +37,20 @@ const (
 	CtrlMsg_SubUnsubscribe CtrlMsg_Type = 0
 	CtrlMsg_SubClose       CtrlMsg_Type = 1
 	CtrlMsg_ConnClose      CtrlMsg_Type = 2
+	CtrlMsg_FTHeartbeat    CtrlMsg_Type = 3
 )
 
 var CtrlMsg_Type_name = map[int32]string{
 	0: "SubUnsubscribe",
 	1: "SubClose",
 	2: "ConnClose",
+	3: "FTHeartbeat",
 }
 var CtrlMsg_Type_value = map[string]int32{
 	"SubUnsubscribe": 0,
 	"SubClose":       1,
 	"ConnClose":      2,
+	"FTHeartbeat":    3,
 }
 
 func (x CtrlMsg_Type) String() string {

--- a/spb/protocol.proto
+++ b/spb/protocol.proto
@@ -65,6 +65,7 @@ message CtrlMsg {
     SubUnsubscribe = 0; // Subscription Unsubscribe request.
     SubClose       = 1; // Subscription Close request.
     ConnClose      = 2; // Connection Close request.
+    FTHeartbeat    = 3; // FT heartbeats.
   }
   Type    MsgType  = 1; // Type of the control message.
   string  ServerID = 2; // Allows a server to detect if it is the intended receipient.

--- a/stores/bench_test.go
+++ b/stores/bench_test.go
@@ -19,9 +19,13 @@ func benchCleanupDatastore(b *testing.B, dir string) {
 }
 
 func benchCreateDefaultFileStore(t *testing.B) *FileStore {
-	fs, state, err := NewFileStore(defaultDataStore, &testDefaultStoreLimits)
+	fs, err := NewFileStore(defaultDataStore, &testDefaultStoreLimits)
 	if err != nil {
 		stackFatalf(t, "Unable to create a FileStore instance: %v", err)
+	}
+	state, err := fs.Recover()
+	if err != nil {
+		stackFatalf(t, "Unable to restore the state: %v", err)
 	}
 	if state == nil {
 		info := testDefaultServerInfo
@@ -127,12 +131,16 @@ func BenchmarkRecoverSubs(b *testing.B) {
 	// Measure recovery
 	b.N = count * numSubs
 	b.StartTimer()
-	s, state, err := NewFileStore(defaultDataStore, &testDefaultStoreLimits)
+	s, err = NewFileStore(defaultDataStore, &testDefaultStoreLimits)
 	b.StopTimer()
 	if err != nil {
 		b.Fatalf("Unable to create a FileStore instance: %v", err)
 	}
 	defer s.Close()
+	state, err := s.Recover()
+	if err != nil {
+		b.Fatalf("Unable to restore the state: %v", err)
+	}
 	if state == nil {
 		b.Fatal("State should have been recovered")
 	}

--- a/stores/common.go
+++ b/stores/common.go
@@ -71,6 +71,12 @@ func (gs *genericStore) init(name string, limits *StoreLimits) {
 	gs.clients = make(map[string]*Client)
 }
 
+// GetExclusiveLock implements the Store interface.
+func (gs *genericStore) GetExclusiveLock() (bool, error) {
+	// Need to be implementation specific.
+	return false, ErrNotSupported
+}
+
 // Init can be used to initialize the store with server's information.
 func (gs *genericStore) Init(info *spb.ServerInfo) error {
 	return nil
@@ -79,6 +85,13 @@ func (gs *genericStore) Init(info *spb.ServerInfo) error {
 // Name returns the type name of this store
 func (gs *genericStore) Name() string {
 	return gs.name
+}
+
+// Recover implements the Store interface.
+func (gs *genericStore) Recover() (*RecoveredState, error) {
+	// Implementations that can recover their state need to
+	// override this.
+	return nil, nil
 }
 
 // setLimits makes a copy of the given StoreLimits,

--- a/stores/delegate.go
+++ b/stores/delegate.go
@@ -1,0 +1,92 @@
+// Copyright 2016-2017 Apcera Inc. All rights reserved.
+
+package stores
+
+import (
+	"github.com/nats-io/nats-streaming-server/spb"
+)
+
+// DelegateStore delegates all the Store's APIs calls to the
+// store it was given when created.
+// This is used by tests programs trying to create a mocked
+// store with the ability to override some of the APIs.
+// To do so, they would create an object that embeds a
+// DelegateStore and simply override the API of their choice.
+type DelegateStore struct {
+	S Store
+}
+
+// GetExclusiveLock implements the Store interface
+func (ms *DelegateStore) GetExclusiveLock() (bool, error) {
+	return ms.S.GetExclusiveLock()
+}
+
+// Init implements the Store interface
+func (ms *DelegateStore) Init(si *spb.ServerInfo) error {
+	return ms.S.Init(si)
+}
+
+// Name implements the Store interface
+func (ms *DelegateStore) Name() string {
+	return ms.S.Name()
+}
+
+// Recover implements the Store interface
+func (ms *DelegateStore) Recover() (*RecoveredState, error) {
+	return ms.S.Recover()
+}
+
+// SetLimits implements the Store interface
+func (ms *DelegateStore) SetLimits(limits *StoreLimits) error {
+	return ms.S.SetLimits(limits)
+}
+
+// CreateChannel implements the Store interface
+func (ms *DelegateStore) CreateChannel(channel string, userData interface{}) (*ChannelStore, bool, error) {
+	return ms.S.CreateChannel(channel, userData)
+}
+
+// LookupChannel implements the Store interface
+func (ms *DelegateStore) LookupChannel(channel string) *ChannelStore {
+	return ms.S.LookupChannel(channel)
+}
+
+// HasChannel implements the Store interface
+func (ms *DelegateStore) HasChannel() bool {
+	return ms.S.HasChannel()
+}
+
+// MsgsState implements the Store interface
+func (ms *DelegateStore) MsgsState(channel string) (numMessages int, byteSize uint64, err error) {
+	return ms.S.MsgsState(channel)
+}
+
+// AddClient implements the Store interface
+func (ms *DelegateStore) AddClient(clientID, hbInbox string, userData interface{}) (*Client, bool, error) {
+	return ms.S.AddClient(clientID, hbInbox, userData)
+}
+
+// GetClient implements the Store interface
+func (ms *DelegateStore) GetClient(clientID string) *Client {
+	return ms.S.GetClient(clientID)
+}
+
+// GetClients implements the Store interface
+func (ms *DelegateStore) GetClients() map[string]*Client {
+	return ms.S.GetClients()
+}
+
+// GetClientsCount implements the Store interface
+func (ms *DelegateStore) GetClientsCount() int {
+	return ms.S.GetClientsCount()
+}
+
+// DeleteClient implements the Store interface
+func (ms *DelegateStore) DeleteClient(clientID string) *Client {
+	return ms.S.DeleteClient(clientID)
+}
+
+// Close implements the Store interface
+func (ms *DelegateStore) Close() error {
+	return ms.S.Close()
+}

--- a/stores/delegate_test.go
+++ b/stores/delegate_test.go
@@ -1,0 +1,64 @@
+// Copyright 2017 Apcera Inc. All rights reserved.
+
+package stores
+
+import (
+	"testing"
+)
+
+func TestDelegateStore(t *testing.T) {
+	// First create a MemStore
+	ms := createDefaultMemStore(t)
+	defer ms.Close()
+
+	// Now a delegate store and use this mem store.
+	ds := &DelegateStore{S: ms}
+	// Call all APIs
+
+	if locked, err := ds.GetExclusiveLock(); locked || err.Error() != "not supported" {
+		t.Fatalf("GetExclusiveLock returned: %v, %v", locked, err)
+	}
+	if err := ds.Init(nil); err != nil {
+		t.Fatalf("Init returned: %v", err)
+	}
+	if ds.Name() != TypeMemory {
+		t.Fatalf("Expected memory store, got %v", ds.Name())
+	}
+	if state, err := ds.Recover(); state != nil || err != nil {
+		t.Fatalf("Recover returned: %v - %v", state, err)
+	}
+	limits := DefaultStoreLimits
+	if err := ds.SetLimits(&limits); err != nil {
+		t.Fatalf("Error on SetLimits: %v", err)
+	}
+	if cs, isNew, err := ds.CreateChannel("foo", nil); cs == nil || !isNew || err != nil {
+		t.Fatalf("CreateChannel returned: %v - %v - %v", cs, isNew, err)
+	}
+	if cs := ds.LookupChannel("foo"); cs == nil {
+		t.Fatal("LookupChannel should have returned a channel store")
+	}
+	if !ds.HasChannel() {
+		t.Fatal("HasChannel should have returned true")
+	}
+	if n, s, err := ds.MsgsState("foo"); n != 0 || s != 0 || err != nil {
+		t.Fatalf("MsgState returned: %v - %v - %v", n, s, err)
+	}
+	if c, isNew, err := ds.AddClient("me", "inbox", nil); c == nil || !isNew || err != nil {
+		t.Fatalf("AddClient returned: %v - %v - %v", c, isNew, err)
+	}
+	if c := ds.GetClient("me"); c == nil || c.ID != "me" {
+		t.Fatalf("GetClient returned: %v", c)
+	}
+	if m := ds.GetClients(); m == nil || len(m) != 1 || m["me"] == nil {
+		t.Fatalf("GetClients returned: %v", m)
+	}
+	if c := ds.GetClientsCount(); c != 1 {
+		t.Fatalf("GetClientsCount returned: %v", c)
+	}
+	if c := ds.DeleteClient("me"); c == nil || c.ID != "me" {
+		t.Fatalf("DeleteClient returned: %v", c)
+	}
+	if err := ds.Close(); err != nil {
+		t.Fatalf("Close returned: %v", err)
+	}
+}

--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -94,6 +94,9 @@ const (
 
 	// defaultFileFlags are the default file flags used when opening a file
 	defaultFileFlags = os.O_RDWR | os.O_CREATE | os.O_APPEND
+
+	// Lock file name
+	lockFileName = ".rootdir.lck"
 )
 
 // FileStoreOption is a function on the options for a File Store
@@ -1167,7 +1170,7 @@ func (fs *FileStore) GetExclusiveLock() (bool, error) {
 	if fs.lockFile != nil {
 		return true, nil
 	}
-	f, err := util.CreateLockFile(filepath.Join(fs.fm.rootDir, "ft.lck"))
+	f, err := util.CreateLockFile(filepath.Join(fs.fm.rootDir, lockFileName))
 	if err != nil {
 		if err == util.ErrUnableToLockNow {
 			return false, nil

--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -1169,7 +1169,7 @@ func (fs *FileStore) GetExclusiveLock() (bool, error) {
 	}
 	f, err := util.CreateLockFile(filepath.Join(fs.fm.rootDir, "ft.lck"))
 	if err != nil {
-		if err == util.ErrAlreadyLocked {
+		if err == util.ErrUnableToLockNow {
 			return false, nil
 		}
 		return false, err

--- a/stores/filestore_test.go
+++ b/stores/filestore_test.go
@@ -4394,7 +4394,7 @@ func TestFSGetExclusiveLock(t *testing.T) {
 		t.Fatal("LockFile should have been closed")
 	}
 
-	fLockName := filepath.Join(defaultDataStore, "ft.lck")
+	fLockName := filepath.Join(defaultDataStore, lockFileName)
 	defer os.Chmod(fLockName, 0666)
 	os.Chmod(fLockName, 0400)
 	fs = createDefaultFileStore(t)

--- a/stores/memstore_test.go
+++ b/stores/memstore_test.go
@@ -218,3 +218,31 @@ func TestMSIncrementalTimestamp(t *testing.T) {
 
 	testIncrementalTimestamp(t, ms)
 }
+
+func TestMSGetExclusiveLock(t *testing.T) {
+	ms := createDefaultMemStore(t)
+	defer ms.Close()
+	// GetExclusiveLock is not supported
+	locked, err := ms.GetExclusiveLock()
+	if err == nil {
+		t.Fatal("Should have failed, it did not")
+	}
+	if locked {
+		t.Fatal("Should not be locked")
+	}
+}
+
+func TestMSRecover(t *testing.T) {
+	ms, err := NewMemoryStore(nil)
+	if err != nil {
+		t.Fatalf("Error creating store: %v", err)
+	}
+	defer ms.Close()
+	state, err := ms.Recover()
+	if err != nil {
+		t.Fatalf("Recover should not return an error, got %v", err)
+	}
+	if state != nil {
+		t.Fatalf("State should be nil, got %v", state)
+	}
+}

--- a/stores/store.go
+++ b/stores/store.go
@@ -151,8 +151,15 @@ type Store interface {
 	// If the lock cannot be acquired, this call will return
 	// `false` with no error: the caller can try again later.
 	//
-	// If, while trying to obtain the lock, an unexpected error occurs,
-	// this call should return `false` and the error.
+	// If, however, the lock cannot be acquired due to a fatal
+	// error, this call should return `false` and the error.
+	//
+	// It is important to note that the implementation should
+	// make an effort to distinguish error conditions deemed
+	// fatal (and therefore trying again would invariabily result
+	// in the same error) and those deemed transient, in which
+	// case no error should be returned to indicate that the
+	// caller could try later.
 	//
 	// Implementations that do not support exclusive locks should
 	// return `false` and `ErrNotSupported`.

--- a/test/configs/test_parse.conf
+++ b/test/configs/test_parse.conf
@@ -10,6 +10,7 @@ hb_interval: "10s"
 hb_timeout: "1s"
 hb_fail_count: 2
 ack_subs_pool_size: 3
+ft_group: "ft"
 
 store_limits: {
     max_channels: 11

--- a/util/lockfile_test.go
+++ b/util/lockfile_test.go
@@ -1,0 +1,92 @@
+package util
+
+import (
+	"flag"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+var lockFileName = flag.String("lockFile", "", "")
+
+func TestLockFile(t *testing.T) {
+	// To test locking, we need to spawn a new process to check that
+	// the file cannot be locked by another process.
+	// We have the parent lock the file and try to have a child process
+	// lock it, then we reverse the test: this is just for code coverage
+	// that would otherwise not show the code coverage for when the
+	// file is already locked.
+
+	fname := *lockFileName
+	parentProcess := fname == ""
+	if fname == "" {
+		fname = "test.lck"
+		defer os.Remove(fname)
+	}
+
+	// First test with invalid file
+	if parentProcess {
+		f, err := CreateLockFile("dummy/test.lck")
+		if err == nil {
+			f.Close()
+			t.Fatal("Expected to fail for invalid file name")
+		}
+	}
+
+	f, err := CreateLockFile(fname)
+	if err != nil {
+		t.Fatalf("Error creating lock file: %v", err)
+	}
+	defer f.Close()
+
+	// If we are the parent process, try to spawn a new process
+	// that will try to grab the lock for same file
+	if parentProcess {
+		out, err := exec.Command(os.Args[0], "-lockFile", fname,
+			"-test.v", "-test.run=TestLockFile$").CombinedOutput()
+		if err == nil {
+			t.Fatal("CreateLockFile should have failed while other process holds lock")
+		}
+		if !strings.Contains(string(out), ErrAlreadyLocked.Error()) {
+			t.Fatalf("Error should contain: %q, got %q", ErrAlreadyLocked.Error(), string(out))
+		}
+	} else {
+		// If the child process, wait a bit while parent process
+		// tries to get the lock.
+		time.Sleep(2 * time.Second)
+	}
+	// Release the lock
+	if err := f.Close(); err != nil {
+		t.Fatalf("Unexpected error on close: %v", err)
+	}
+	// Check state
+	if !f.IsClosed() {
+		t.Fatal("File should be closed")
+	}
+	if parentProcess {
+		// Try again with different process, it should work now.
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			out, err := exec.Command(os.Args[0], "-lockFile", fname,
+				"-test.v", "-test.run=TestLockFile$").CombinedOutput()
+			if err != nil {
+				t.Fatalf("Other process should have been able to get the lock, got %v - %v",
+					err, out)
+			}
+		}()
+		// Give a chance for the child process to run
+		time.Sleep(time.Second)
+		// The parent process should now be the one that fails
+		f, err := CreateLockFile(fname)
+		if err == nil {
+			f.Close()
+			t.Fatal("Expected CreateLockFile to fail, it did not")
+		}
+		wg.Wait()
+	}
+}

--- a/util/lockfile_unix.go
+++ b/util/lockfile_unix.go
@@ -1,0 +1,73 @@
+// Copyright 2017 Apcera Inc. All rights reserved.
+// +build !windows
+
+package util
+
+import (
+	"io"
+	"os"
+	"sync"
+	"syscall"
+)
+
+type lockFile struct {
+	sync.Mutex
+	f *os.File
+}
+
+// CreateLockFile attempt to lock the given file, creating it
+// if necessary. On success, the file is returned, otherwise
+// an error is returned.
+// The file returned should be closed to release the lock
+// quicker than if left to the operating systen.
+func CreateLockFile(file string) (LockFile, error) {
+	f, err := os.Create(file)
+	if err != nil {
+		return nil, err
+	}
+	spec := &syscall.Flock_t{
+		Type:   syscall.F_WRLCK,
+		Whence: int16(io.SeekStart),
+		Start:  0,
+		Len:    0, // 0 means to lock the entire file.
+	}
+	if err := syscall.FcntlFlock(f.Fd(), syscall.F_SETLK, spec); err != nil {
+		if err == syscall.EAGAIN || err == syscall.EACCES {
+			err = ErrAlreadyLocked
+		}
+		// TODO: If error is not ErrAlreadyLocked, it may mean that
+		// the call is not supported on that platform, etc...
+		// We should have another level of verification, for instance
+		// check content of the lockfile is not being updated by the
+		// owner of the file, etc...
+		f.Close()
+		return nil, err
+	}
+	return &lockFile{f: f}, nil
+}
+
+// Close implements the LockFile interface
+func (lf *lockFile) Close() error {
+	lf.Lock()
+	defer lf.Unlock()
+	if lf.f == nil {
+		return nil
+	}
+	spec := &syscall.Flock_t{
+		Type:   syscall.F_UNLCK,
+		Whence: int16(io.SeekStart),
+		Start:  0,
+		Len:    0, // 0 means to lock the entire file.
+	}
+	err := syscall.FcntlFlock(lf.f.Fd(), syscall.F_SETLK, spec)
+	err = CloseFile(err, lf.f)
+	lf.f = nil
+	return err
+}
+
+// IsClosed implements the LockFile interface
+func (lf *lockFile) IsClosed() bool {
+	lf.Lock()
+	defer lf.Unlock()
+	return lf.f == nil
+}

--- a/util/lockfile_win.go
+++ b/util/lockfile_win.go
@@ -1,0 +1,65 @@
+// Copyright 2017 Apcera Inc. All rights reserved.
+// +build windows
+
+package util
+
+import (
+	"strings"
+	"sync"
+	"syscall"
+)
+
+type lockFile struct {
+	sync.Mutex
+	f syscall.Handle
+}
+
+// CreateLockFile attempt to lock the given file, creating it
+// if necessary. On success, the file is returned, otherwise
+// an error is returned.
+// The file returned should be closed to release the lock
+// quicker than if left to the operating systen.
+func CreateLockFile(file string) (LockFile, error) {
+	fname, err := syscall.UTF16PtrFromString(file)
+	if err != nil {
+		return nil, err
+	}
+	f, err := syscall.CreateFile(fname,
+		syscall.GENERIC_READ|syscall.GENERIC_WRITE,
+		0, // dwShareMode: 0 means "Prevents other processes from opening a file or device if they request delete, read, or write access."
+		nil,
+		syscall.CREATE_ALWAYS,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		// TODO: There HAS to be a better way, but I can't seem to
+		// find how to get Windows error codes (also syscall.GetLastError()
+		// returns nil here).
+		if strings.Contains(err.Error(), "used by another process") {
+			err = ErrAlreadyLocked
+		}
+		syscall.CloseHandle(f)
+		return nil, err
+	}
+	return &lockFile{f: f}, nil
+}
+
+// Close implements the LockFile interface
+func (lf *lockFile) Close() error {
+	lf.Lock()
+	defer lf.Unlock()
+	if lf.f == syscall.InvalidHandle {
+		return nil
+	}
+	err := syscall.CloseHandle(lf.f)
+	lf.f = syscall.InvalidHandle
+	return err
+}
+
+// IsClosed implements the LockFile interface
+func (lf *lockFile) IsClosed() bool {
+	lf.Lock()
+	defer lf.Unlock()
+	return lf.f == syscall.InvalidHandle
+}

--- a/util/lockfile_win.go
+++ b/util/lockfile_win.go
@@ -37,7 +37,7 @@ func CreateLockFile(file string) (LockFile, error) {
 		// find how to get Windows error codes (also syscall.GetLastError()
 		// returns nil here).
 		if strings.Contains(err.Error(), "used by another process") {
-			err = ErrAlreadyLocked
+			err = ErrUnableToLockNow
 		}
 		syscall.CloseHandle(f)
 		return nil, err

--- a/util/util.go
+++ b/util/util.go
@@ -4,11 +4,21 @@ package util
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
-	"os"
 	"time"
 )
+
+// ErrAlreadyLocked is used to indicate that a lock cannot be
+// immediately acquired.
+var ErrAlreadyLocked = errors.New("unable to acquire the lock")
+
+// LockFile is an interface for lock files utility.
+type LockFile interface {
+	io.Closer
+	IsClosed() bool
+}
 
 // ByteOrder specifies how to convert byte sequences into 16-, 32-, or 64-bit
 // unsigned integers.
@@ -119,7 +129,7 @@ func ReadInt(r io.Reader) (int, error) {
 
 // CloseFile closes the given file and report the possible error only
 // if the given error `err` is not already set.
-func CloseFile(err error, f *os.File) error {
+func CloseFile(err error, f io.Closer) error {
 	if lerr := f.Close(); lerr != nil && err == nil {
 		err = lerr
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -10,9 +10,9 @@ import (
 	"time"
 )
 
-// ErrAlreadyLocked is used to indicate that a lock cannot be
+// ErrUnableToLockNow is used to indicate that a lock cannot be
 // immediately acquired.
-var ErrAlreadyLocked = errors.New("unable to acquire the lock")
+var ErrUnableToLockNow = errors.New("unable to acquire the lock at the moment")
 
 // LockFile is an interface for lock files utility.
 type LockFile interface {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -154,7 +154,7 @@ func TestBackoffTimeCheck(t *testing.T) {
 	}
 	for i, f := range freqs {
 		dur := time.Duration(expected[i] * int64(time.Millisecond))
-		if f < dur-5*time.Millisecond || f > dur+5*time.Millisecond {
+		if f < dur-15*time.Millisecond || f > dur+15*time.Millisecond {
 			t.Fatalf("Expected frequency to be +/- %v, got %v", dur, f)
 		}
 	}
@@ -163,7 +163,7 @@ func TestBackoffTimeCheck(t *testing.T) {
 	// 2x the max frequency pass *after* the allowed next print,
 	// which at this point is 100ms ahead of us. So we need to
 	// sleep for at least 300ms. Sleep a bit more.
-	time.Sleep(350 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 	// At this point, it is as if we were calling for the first time:
 	if !print.Ok() {
 		t.Fatal("Should have returned true")


### PR DESCRIPTION
This PR is a second take at FT, without the use of RAFT as in #268.

 - [X] Link to issue
 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #263

### Changes proposed in this pull request: 

 - Updated the Store Interface to specified recovery and a way for a server to get an exclusive lock on a store. 
 - Added file locking based on advisory locks for unix'es and special windows open file call.
 - Added a DelegateStore that can be used to create mock stores in order to override some store APIs for test purposes.
 - When in FT mode, server starts as a standby until it is elected active, in which case it recovers the state and starts servicing clients.
- Documentation in README.md about FT but also a pass at basic Streaming concepts that were lacking.
 
/cc @nats-io/core