### PR TITLE
Fixed AckSubs pool

### DIFF
--- a/spb/protocol.pb.go
+++ b/spb/protocol.pb.go
@@ -100,6 +100,7 @@ type ServerInfo struct {
 	Unsubscribe string `protobuf:"bytes,5,opt,name=Unsubscribe,proto3" json:"Unsubscribe,omitempty"`
 	Close       string `protobuf:"bytes,6,opt,name=Close,proto3" json:"Close,omitempty"`
 	SubClose    string `protobuf:"bytes,7,opt,name=SubClose,proto3" json:"SubClose,omitempty"`
+	AcksSubs    string `protobuf:"bytes,8,opt,name=AcksSubs,proto3" json:"AcksSubs,omitempty"`
 }
 
 func (m *ServerInfo) Reset()         { *m = ServerInfo{} }
@@ -330,6 +331,12 @@ func (m *ServerInfo) MarshalTo(data []byte) (int, error) {
 		i = encodeVarintProtocol(data, i, uint64(len(m.SubClose)))
 		i += copy(data[i:], m.SubClose)
 	}
+	if len(m.AcksSubs) > 0 {
+		data[i] = 0x42
+		i++
+		i = encodeVarintProtocol(data, i, uint64(len(m.AcksSubs)))
+		i += copy(data[i:], m.AcksSubs)
+	}
 	return i, nil
 }
 
@@ -541,6 +548,10 @@ func (m *ServerInfo) Size() (n int) {
 		n += 1 + l + sovProtocol(uint64(l))
 	}
 	l = len(m.SubClose)
+	if l > 0 {
+		n += 1 + l + sovProtocol(uint64(l))
+	}
+	l = len(m.AcksSubs)
 	if l > 0 {
 		n += 1 + l + sovProtocol(uint64(l))
 	}
@@ -1282,6 +1293,35 @@ func (m *ServerInfo) Unmarshal(data []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.SubClose = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AcksSubs", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowProtocol
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthProtocol
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AcksSubs = string(data[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/spb/protocol.proto
+++ b/spb/protocol.proto
@@ -47,6 +47,7 @@ message ServerInfo {
   string Unsubscribe = 5; // Subject server receives unsubscribe requests on.
   string Close       = 6; // Subject server receives close requests on.
   string SubClose    = 7; // Subject server receives subscription close requests on.
+  string AcksSubs    = 8; // Subject prefix server receives subscription acks when using pool of ack subscribers.
 }
 
 // ClientInfo contains information related to a Client


### PR DESCRIPTION
Until we have clustering, the subject prefix should be unique (but
recoverable from store). The uniqueness per server will be needed
if used in conjunction with channel partitioning.

There was also an issue when a server initially running with -ack_subs
was then restarted without. Currently running subscriptions would
then timeout during ACK because the server was creating individual
subscriptions with the wrong subject.

NOTE: The ack subs pool feature was not yet part of a public release.
If user have started to use it and stop/restart server with this
version, currently running subscriptions would fail to ack messages
since the AckInbox subject exchanged from server to clients will have
changed. Users will need to restart their applications.