### PR TITLE
[FIXED] Server starting even with negative store limits

### DIFF
--- a/stores/common.go
+++ b/stores/common.go
@@ -60,15 +60,18 @@ type genericMsgStore struct {
 ////////////////////////////////////////////////////////////////////////////
 
 // init initializes the structure of a generic store
-func (gs *genericStore) init(name string, limits *StoreLimits) {
+func (gs *genericStore) init(name string, limits *StoreLimits) error {
 	gs.name = name
 	if limits == nil {
 		limits = &DefaultStoreLimits
 	}
-	gs.setLimits(limits)
+	if err := gs.setLimits(limits); err != nil {
+		return err
+	}
 	// Do not use limits values to create the map.
 	gs.channels = make(map[string]*ChannelStore)
 	gs.clients = make(map[string]*Client)
+	return nil
 }
 
 // GetExclusiveLock implements the Store interface.

--- a/stores/common_test.go
+++ b/stores/common_test.go
@@ -876,3 +876,27 @@ func testIncrementalTimestamp(t *testing.T, s Store) {
 		}
 	}
 }
+
+func testNegativeLimit(t *testing.T, s Store) {
+	limits := DefaultStoreLimits
+
+	checkLimitError := func() {
+		if err := s.SetLimits(&limits); err == nil {
+			stackFatalf(t, "Setting negative limit should have failed")
+		}
+	}
+	limits.MaxAge, _ = time.ParseDuration("-1.5h")
+	checkLimitError()
+	limits = DefaultStoreLimits
+	limits.MaxBytes = -1000
+	checkLimitError()
+	limits = DefaultStoreLimits
+	limits.MaxChannels = -1000
+	checkLimitError()
+	limits = DefaultStoreLimits
+	limits.MaxMsgs = -1000
+	checkLimitError()
+	limits = DefaultStoreLimits
+	limits.MaxSubscriptions = -1000
+	checkLimitError()
+}

--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -1016,7 +1016,9 @@ func NewFileStore(rootDir string, limits *StoreLimits, options ...FileStoreOptio
 	}
 
 	fs := &FileStore{opts: DefaultFileStoreOptions}
-	fs.init(TypeFile, limits)
+	if err := fs.init(TypeFile, limits); err != nil {
+		return nil, err
+	}
 
 	for _, opt := range options {
 		if err := opt(&fs.opts); err != nil {

--- a/stores/filestore_test.go
+++ b/stores/filestore_test.go
@@ -4402,3 +4402,21 @@ func TestFSGetExclusiveLock(t *testing.T) {
 		t.Fatal("Locked should be false")
 	}
 }
+
+func TestFSNegativeLimits(t *testing.T) {
+	cleanupDatastore(t, defaultDataStore)
+	defer cleanupDatastore(t, defaultDataStore)
+
+	limits := DefaultStoreLimits
+	limits.MaxMsgs = -1000
+	if fs, err := NewFileStore(defaultDataStore, &limits); fs != nil || err == nil {
+		if fs != nil {
+			fs.Close()
+		}
+		t.Fatal("Should have failed to create store with a negative limit")
+	}
+	fs := createDefaultFileStore(t)
+	defer fs.Close()
+
+	testNegativeLimit(t, fs)
+}

--- a/stores/memstore.go
+++ b/stores/memstore.go
@@ -37,7 +37,9 @@ type MemoryMsgStore struct {
 // DefaultStoreLimits.
 func NewMemoryStore(limits *StoreLimits) (*MemoryStore, error) {
 	ms := &MemoryStore{}
-	ms.init(TypeMemory, limits)
+	if err := ms.init(TypeMemory, limits); err != nil {
+		return nil, err
+	}
 	return ms, nil
 }
 

--- a/stores/memstore_test.go
+++ b/stores/memstore_test.go
@@ -246,3 +246,18 @@ func TestMSRecover(t *testing.T) {
 		t.Fatalf("State should be nil, got %v", state)
 	}
 }
+
+func TestMSNegativeLimits(t *testing.T) {
+	limits := DefaultStoreLimits
+	limits.MaxMsgs = -1000
+	if ms, err := NewMemoryStore(&limits); ms != nil || err == nil {
+		if ms != nil {
+			ms.Close()
+		}
+		t.Fatal("Should have failed to create store with a negative limit")
+	}
+	ms := createDefaultMemStore(t)
+	defer ms.Close()
+
+	testNegativeLimit(t, ms)
+}


### PR DESCRIPTION
The server should not allow to have negative values and therefore
fail to start when any store limit is negative.

Resolves #276