### PR TITLE
Changed error texts in fmt.Errorf() calls to not use uppercase

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -290,7 +290,7 @@ func parseFlags() (*stand.Options, *natsd.Options) {
 	// what is found in the file, possibly overriding the defaults.
 	if stanConfigFile != "" {
 		if err := stand.ProcessConfigFile(stanConfigFile, stanOpts); err != nil {
-			natsd.PrintAndDie(err.Error())
+			natsd.PrintAndDie(fmt.Sprintf("Configuration error: %v", err.Error()))
 		}
 	}
 	// Now apply all parameters provided on the command line.

--- a/server/conf.go
+++ b/server/conf.go
@@ -47,7 +47,7 @@ func ProcessConfigFile(configFile string, opts *Options) error {
 			case stores.TypeMemory:
 				opts.StoreType = stores.TypeMemory
 			default:
-				return fmt.Errorf("Unknown store type: %v", v.(string))
+				return fmt.Errorf("unknown store type: %v", v.(string))
 			}
 		case "dir", "datastore":
 			if err := checkType(k, reflect.String, v); err != nil {
@@ -128,7 +128,7 @@ func ProcessConfigFile(configFile string, opts *Options) error {
 func checkType(name string, kind reflect.Kind, v interface{}) error {
 	actualKind := reflect.TypeOf(v).Kind()
 	if actualKind != kind {
-		return fmt.Errorf("Parameter %q value is expected to be %v, got %v",
+		return fmt.Errorf("parameter %q value is expected to be %v, got %v",
 			name, kind.String(), actualKind.String())
 	}
 	return nil
@@ -138,7 +138,7 @@ func checkType(name string, kind reflect.Kind, v interface{}) error {
 func parseTLS(itf interface{}, opts *Options) error {
 	m, ok := itf.(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("Expected TLS to be a map/struct, got %v", itf)
+		return fmt.Errorf("expected TLS to be a map/struct, got %v", itf)
 	}
 	for k, v := range m {
 		name := strings.ToLower(k)
@@ -167,7 +167,7 @@ func parseTLS(itf interface{}, opts *Options) error {
 func parseStoreLimits(itf interface{}, opts *Options) error {
 	m, ok := itf.(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("Expected store limits to be a map/struct, got %v", itf)
+		return fmt.Errorf("expected store limits to be a map/struct, got %v", itf)
 	}
 	for k, v := range m {
 		name := strings.ToLower(k)
@@ -226,12 +226,12 @@ func parseChannelLimits(cl *stores.ChannelLimits, k, name string, v interface{})
 func parsePerChannelLimits(itf interface{}, opts *Options) error {
 	m, ok := itf.(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("Expected per channel limits to be a map/struct, got %v", itf)
+		return fmt.Errorf("expected per channel limits to be a map/struct, got %v", itf)
 	}
 	for channelName, limits := range m {
 		limitsMap, ok := limits.(map[string]interface{})
 		if !ok {
-			return fmt.Errorf("Expected channel limits to be a map/struct, got %v", limits)
+			return fmt.Errorf("expected channel limits to be a map/struct, got %v", limits)
 		}
 		cl := &stores.ChannelLimits{}
 		for k, v := range limitsMap {
@@ -249,7 +249,7 @@ func parsePerChannelLimits(itf interface{}, opts *Options) error {
 func parseFileOptions(itf interface{}, opts *Options) error {
 	m, ok := itf.(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("Expected file options to be a map/struct, got %v", itf)
+		return fmt.Errorf("expected file options to be a map/struct, got %v", itf)
 	}
 	for k, v := range m {
 		name := strings.ToLower(k)

--- a/server/server.go
+++ b/server/server.go
@@ -1048,7 +1048,7 @@ func (s *StanServer) start(runningState State) error {
 	if callStoreInit {
 		// Initialize the store with the server info
 		if err := s.store.Init(&s.info); err != nil {
-			return fmt.Errorf("Unable to initialize the store: %v", err)
+			return fmt.Errorf("unable to initialize the store: %v", err)
 		}
 	}
 

--- a/stores/common.go
+++ b/stores/common.go
@@ -128,7 +128,7 @@ func (gs *genericStore) SetLimits(limits *StoreLimits) error {
 // `true` to indicate that the channel is new, false if it already exists.
 func (gs *genericStore) CreateChannel(channel string, userData interface{}) (*ChannelStore, bool, error) {
 	// no-op
-	return nil, false, fmt.Errorf("Generic store, feature not implemented")
+	return nil, false, fmt.Errorf("generic store: feature not implemented")
 }
 
 // LookupChannel returns a ChannelStore for the given channel.

--- a/stores/limits.go
+++ b/stores/limits.go
@@ -25,7 +25,7 @@ func (sl *StoreLimits) AddPerChannel(name string, cl *ChannelLimits) {
 func (sl *StoreLimits) Build() error {
 	// Check that there is no negative value
 	if sl.MaxChannels < 0 {
-		return fmt.Errorf("Max channels limit cannot be negative")
+		return fmt.Errorf("max channels limit cannot be negative")
 	}
 	if err := sl.checkChannelLimits(&sl.ChannelLimits, ""); err != nil {
 		return err
@@ -35,7 +35,7 @@ func (sl *StoreLimits) Build() error {
 		return nil
 	}
 	if len(sl.PerChannel) > sl.MaxChannels {
-		return fmt.Errorf("Too many channels defined (%v). The max channels limit is set to %v",
+		return fmt.Errorf("too many channels defined (%v). The max channels limit is set to %v",
 			len(sl.PerChannel), sl.MaxChannels)
 	}
 	for cn, cl := range sl.PerChannel {
@@ -92,17 +92,17 @@ func verifyLimit(errText, channelName string, limit, globalLimit int64) error {
 	// global limit.
 	if channelName == "" {
 		if limit < 0 {
-			return fmt.Errorf("Max %s for global limit cannot be negative", errText)
+			return fmt.Errorf("max %s for global limit cannot be negative", errText)
 		}
 		return nil
 	}
 	// Per-channel limit specific here.
 	if limit < 0 {
-		return fmt.Errorf("Max %s for channel %q cannot be negative. "+
+		return fmt.Errorf("max %s for channel %q cannot be negative. "+
 			"Set it to 0 to be equal to the global limit of %v", errText, channelName, globalLimit)
 	}
 	if limit > globalLimit {
-		return fmt.Errorf("Max %s for channel %q cannot be higher than global limit "+
+		return fmt.Errorf("max %s for channel %q cannot be higher than global limit "+
 			"of %v", errText, channelName, globalLimit)
 	}
 	return nil

--- a/stores/limits_test.go
+++ b/stores/limits_test.go
@@ -44,8 +44,10 @@ func TestBuildErrors(t *testing.T) {
 		if err == nil {
 			stackFatalf(t, "Expected error on build, did not get one")
 		}
-		if !strings.HasPrefix(err.Error(), errTxt) {
-			stackFatalf(t, "Expected error to be about %q, got %v", errTxt, err.Error())
+		expectedErrTxt := strings.ToLower(errTxt)
+		gotErrorTxt := strings.ToLower(err.Error())
+		if !strings.HasPrefix(gotErrorTxt, expectedErrTxt) {
+			stackFatalf(t, "Expected error to be about %q, got %v", expectedErrTxt, gotErrorTxt)
 		}
 	}
 	// Check that we get an error for negative values.


### PR DESCRIPTION
The rationale is that when a function returns an error, that function
does not know if the error is going to be printed/logged as standalone
or as a suffix of another error message. So functions should not
return error texts with uppercase.

First letter changed to lower case except for:
- tests (avoid using uppercase in the future, but no need to go
  over all tests to change them now)
- panics: since this is the only error that is going to be printed,
  starting with uppercase is ok