### PR TITLE
[FIXED] Server not rejecting wildcard channel names in config

### DIFF
--- a/server/conf.go
+++ b/server/conf.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Apcera Inc. All rights reserved.
+// Copyright 2016-2017 Apcera Inc. All rights reserved.
 
 package server
 
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nats-io/gnatsd/conf"
 	"github.com/nats-io/nats-streaming-server/stores"
+	"github.com/nats-io/nats-streaming-server/util"
 )
 
 // ProcessConfigFile parses the configuration file `configFile` and updates
@@ -232,6 +233,9 @@ func parsePerChannelLimits(itf interface{}, opts *Options) error {
 		limitsMap, ok := limits.(map[string]interface{})
 		if !ok {
 			return fmt.Errorf("expected channel limits to be a map/struct, got %v", limits)
+		}
+		if !util.IsSubjectValid(channelName) {
+			return fmt.Errorf("invalid channel name %q", channelName)
 		}
 		cl := &stores.ChannelLimits{}
 		for k, v := range limitsMap {

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -17,6 +17,7 @@ const (
 	mapStructErr = "map/struct"
 	wrongTypeErr = "value is expected to be"
 	wrongTimeErr = "time: "
+	wrongSubjErr = "invalid channel name"
 )
 
 func TestParseConfig(t *testing.T) {
@@ -264,6 +265,9 @@ func TestParseWrongTypes(t *testing.T) {
 	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_age:\"1h:0m\"}}}", wrongTimeErr)
 	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_age:false}}}", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_subs:false}}}", wrongTypeErr)
+	expectFailureFor(t, "store_limits:{channels:{\"foo.*\":{}}}", wrongSubjErr)
+	expectFailureFor(t, "store_limits:{channels:{\"foo.>\":{}}}", wrongSubjErr)
+	expectFailureFor(t, "store_limits:{channels:{\"foo..bar\":{}}}", wrongSubjErr)
 	expectFailureFor(t, "tls:{client_cert:123}", wrongTypeErr)
 	expectFailureFor(t, "tls:{client_key:123}", wrongTypeErr)
 	expectFailureFor(t, "tls:{client_ca:123}", wrongTypeErr)

--- a/server/server.go
+++ b/server/server.go
@@ -1955,7 +1955,7 @@ func (s *StanServer) processClientPublish(m *nats.Msg) {
 	}
 
 	// Make sure we have a clientID, guid, etc.
-	if pm.Guid == "" || !s.clients.IsValid(pm.ClientID) || !isValidSubject(pm.Subject) {
+	if pm.Guid == "" || !s.clients.IsValid(pm.ClientID) || !util.IsSubjectValid(pm.Subject) {
 		Errorf("Received invalid client publish message %v", pm)
 		s.sendPublishErr(m.Reply, pm.Guid, ErrInvalidPubReq)
 		return
@@ -2749,20 +2749,6 @@ func (s *StanServer) sendSubscriptionResponseErr(reply string, err error) {
 	s.ncs.Publish(reply, b)
 }
 
-// Check for valid subjects
-func isValidSubject(subject string) bool {
-	if subject == "" {
-		return false
-	}
-	for i := 0; i < len(subject); i++ {
-		c := subject[i]
-		if c == '*' || c == '>' {
-			return false
-		}
-	}
-	return true
-}
-
 // Clear the ackTimer.
 // sub Lock held in entry.
 func (sub *subState) clearAckTimer() {
@@ -2929,7 +2915,7 @@ func (s *StanServer) processSubscriptionRequest(m *nats.Msg) {
 	}
 
 	// Make sure subject is valid
-	if !isValidSubject(sr.Subject) {
+	if !util.IsSubjectValid(sr.Subject) {
 		Errorf("[Client:%s] Invalid Subject %q in subscription request from %s",
 			sr.ClientID, sr.Subject, m.Subject)
 		s.sendSubscriptionResponseErr(m.Reply, ErrInvalidSubject)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,3 +1,5 @@
+// Copyright 2016-2017 Apcera Inc. All rights reserved.
+
 package server
 
 import (
@@ -4836,30 +4838,6 @@ func TestFileStoreDurableQueueSubRedeliveryOnRejoin(t *testing.T) {
 	// Message should be redelivered
 	if err := Wait(ch); err != nil {
 		t.Fatal("Did not get our message")
-	}
-}
-
-func TestIsValidSubject(t *testing.T) {
-	subject := ""
-	for i := 0; i < 100; i++ {
-		subject += "foo."
-	}
-	subject += "foo"
-	if !isValidSubject(subject) {
-		t.Fatalf("Subject %q should be valid", subject)
-	}
-	subjects := []string{
-		"foo.bar*",
-		"foo.bar>",
-		"foo.bar.*",
-		"foo.bar.>",
-		"foo*.bar",
-		"foo>.bar",
-	}
-	for _, s := range subjects {
-		if isValidSubject(s) {
-			t.Fatalf("Subject %q expected to be invalid", s)
-		}
 	}
 }
 

--- a/stores/limits_test.go
+++ b/stores/limits_test.go
@@ -147,6 +147,22 @@ func TestBuildErrors(t *testing.T) {
 	sl.AddPerChannel("foo", cl)
 	sl.AddPerChannel("bar", &cl2)
 	expectError("Max subscriptions for channel \"foo\"")
+
+	// Reset sl
+	sl = testDefaultStoreLimits
+	cl = &ChannelLimits{}
+	sl.AddPerChannel("foo.*", cl)
+	expectError("invalid channel name")
+
+	sl = testDefaultStoreLimits
+	cl = &ChannelLimits{}
+	sl.AddPerChannel("foo.>", cl)
+	expectError("invalid channel name")
+
+	sl = testDefaultStoreLimits
+	cl = &ChannelLimits{}
+	sl.AddPerChannel("foo.", cl)
+	expectError("invalid channel name")
 }
 
 func TestAppliedInheritance(t *testing.T) {

--- a/util/util.go
+++ b/util/util.go
@@ -135,3 +135,22 @@ func CloseFile(err error, f io.Closer) error {
 	}
 	return err
 }
+
+// IsSubjectValid returns false if the string if any of this condition apply:
+// - is empty
+// - contains wildcards `*` or `>`
+// - token separator `.` is first or last
+// - there are two consecutives token separators `.`
+func IsSubjectValid(subject string) bool {
+	if subject == "" || subject[0] == '.' {
+		return false
+	}
+	for i := 0; i < len(subject); i++ {
+		c := subject[i]
+		if c == '*' || c == '>' ||
+			(c == '.' && (i == len(subject)-1 || subject[i+1] == '.')) {
+			return false
+		}
+	}
+	return true
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -173,3 +173,32 @@ func TestBackoffTimeCheck(t *testing.T) {
 		t.Fatal("No auto-reset done")
 	}
 }
+
+func TestIsSubjectValid(t *testing.T) {
+	subject := ""
+	for i := 0; i < 100; i++ {
+		subject += "foo."
+	}
+	subject += "foo"
+	if !IsSubjectValid(subject) {
+		t.Fatalf("Subject %q should be valid", subject)
+	}
+	subjects := []string{
+		"foo.bar*",
+		"foo.bar>",
+		"foo.bar.*",
+		"foo.bar.>",
+		"foo*.bar",
+		"foo>.bar",
+		"foo..bar",
+		".foo.bar",
+		"foo.bar.",
+		"..",
+		".",
+	}
+	for _, s := range subjects {
+		if IsSubjectValid(s) {
+			t.Fatalf("Subject %q expected to be invalid", s)
+		}
+	}
+}


### PR DESCRIPTION
Since wildcards are not supported - even in the context of
channel limits, the server must reject the configuration of
channel names with wildcards.

Resolves #280