### PR TITLE
Updated Store's dropping messages notice to use friendly bytes

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -5,7 +5,6 @@ package server
 import (
 	"errors"
 	"fmt"
-	"math"
 	"net"
 	"net/url"
 	"regexp"
@@ -1131,7 +1130,7 @@ func getLimitStr(isGlobal bool, val, parentVal int64, limitType int) string {
 	} else {
 		switch limitType {
 		case limitBytes:
-			valStr = friendlyBytes(val)
+			valStr = util.FriendlyBytes(val)
 		case limitDuration:
 			valStr = fmt.Sprintf("%v", time.Duration(val))
 		default:
@@ -1139,20 +1138,6 @@ func getLimitStr(isGlobal bool, val, parentVal int64, limitType int) string {
 		}
 	}
 	return fmt.Sprintf("%13s%s", valStr, inherited)
-}
-
-func friendlyBytes(msgbytes int64) string {
-	bytes := float64(msgbytes)
-	base := 1024
-	pre := []string{"K", "M", "G", "T", "P", "E"}
-	var post = "B"
-	if bytes < float64(base) {
-		return fmt.Sprintf("%v B", bytes)
-	}
-	exp := int(math.Log(bytes) / math.Log(float64(base)))
-	index := exp - 1
-	units := pre[index] + post
-	return fmt.Sprintf("%.2f %s", bytes/math.Pow(float64(base), float64(exp)), units)
 }
 
 // TODO:  Explore parameter passing in gnatsd.  Keep seperate for now.

--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -2318,7 +2318,8 @@ func (ms *FileMsgStore) enforceLimits(reportHitLimit, lockFile bool) error {
 		ms.removeFirstMsg(nil, lockFile)
 		if reportHitLimit && !ms.hitLimit {
 			ms.hitLimit = true
-			Noticef(droppingMsgsFmt, ms.subject, ms.totalCount, ms.limits.MaxMsgs, ms.totalBytes, ms.limits.MaxBytes)
+			Noticef(droppingMsgsFmt, ms.subject, ms.totalCount, ms.limits.MaxMsgs,
+				util.FriendlyBytes(int64(ms.totalBytes)), util.FriendlyBytes(ms.limits.MaxBytes))
 		}
 	}
 	return nil

--- a/stores/memstore.go
+++ b/stores/memstore.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/nats-io/go-nats-streaming/pb"
+	"github.com/nats-io/nats-streaming-server/util"
 )
 
 // MemoryStore is a factory for message and subscription stores.
@@ -118,7 +119,8 @@ func (ms *MemoryMsgStore) Store(data []byte) (uint64, error) {
 			ms.removeFirstMsg()
 			if !ms.hitLimit {
 				ms.hitLimit = true
-				Noticef(droppingMsgsFmt, ms.subject, ms.totalCount, ms.limits.MaxMsgs, ms.totalBytes, ms.limits.MaxBytes)
+				Noticef(droppingMsgsFmt, ms.subject, ms.totalCount, ms.limits.MaxMsgs,
+					util.FriendlyBytes(int64(ms.totalBytes)), util.FriendlyBytes(ms.limits.MaxBytes))
 			}
 		}
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"time"
 )
 
@@ -153,4 +154,18 @@ func IsSubjectValid(subject string) bool {
 		}
 	}
 	return true
+}
+
+// FriendlyBytes returns a string with the given bytes int64
+// represented as a size, such as 1KB, 10MB, etc...
+func FriendlyBytes(bytes int64) string {
+	fbytes := float64(bytes)
+	base := 1024
+	pre := []string{"K", "M", "G", "T", "P", "E"}
+	if fbytes < float64(base) {
+		return fmt.Sprintf("%v B", fbytes)
+	}
+	exp := int(math.Log(fbytes) / math.Log(float64(base)))
+	index := exp - 1
+	return fmt.Sprintf("%.2f %sB", fbytes/math.Pow(float64(base), float64(exp)), pre[index])
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -5,6 +5,7 @@ package util
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -201,4 +202,20 @@ func TestIsSubjectValid(t *testing.T) {
 			t.Fatalf("Subject %q expected to be invalid", s)
 		}
 	}
+}
+
+func TestFriendlyBytes(t *testing.T) {
+	check := func(val int64, expectedSuffix string) {
+		res := FriendlyBytes(val)
+		if !strings.HasSuffix(res, expectedSuffix) {
+			t.Fatalf("For %v, expected suffix to be %v, got %v", val, expectedSuffix, res)
+		}
+	}
+	check(1000, " B")
+	check(2000, " KB")
+	check(10<<20, " MB")
+	check(10<<30, " GB")
+	check(10<<40, " TB")
+	check(10<<50, " PB")
+	check(0xFFFFFFFFFFFFFFF, " EB")
 }


### PR DESCRIPTION
When a channel hits a limit, the store prints a message with
the current/limit values for number of messages and bytes.
This PR prints the size as KB, MB, etc.. instead of raw numbers.

To do so, I have promoted the server's friendlyBytes function
to a util function, and added tests for that.