### PR TITLE
[FIX] Fix parsing of the --file_slice_max_age parameter.

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -397,7 +397,7 @@ func overrideWithCmdLineParams(opts *stand.Options) error {
 					return
 				}
 				o.SetInt(int64(resVal.(int64)))
-			case "MaxAge", "ClientHBInterval", "ClientHBTimeout":
+			case "MaxAge", "ClientHBInterval", "ClientHBTimeout", "FileStoreOpts.SliceMaxAge":
 				var dur time.Duration
 				dur, err = time.ParseDuration(val.(string))
 				if err != nil {


### PR DESCRIPTION
The `--file_slice_max_age` parameter was not being parsed as a duration.