### PR TITLE
[ADDED] Partitioning

### DIFF
--- a/server/conf.go
+++ b/server/conf.go
@@ -120,6 +120,11 @@ func ProcessConfigFile(configFile string, opts *Options) error {
 				return err
 			}
 			opts.FTGroupName = v.(string)
+		case "partitioning":
+			if err := checkType(k, reflect.Bool, v); err != nil {
+				return err
+			}
+			opts.Partitioning = v.(bool)
 		}
 	}
 	return nil
@@ -246,7 +251,7 @@ func parsePerChannelLimits(itf interface{}, opts *Options) error {
 		if !ok {
 			return fmt.Errorf("expected channel limits to be a map/struct, got %v", limits)
 		}
-		if !util.IsSubjectValid(channelName) {
+		if !util.IsSubjectValid(channelName, true) {
 			return fmt.Errorf("invalid channel name %q", channelName)
 		}
 		cl := &stores.ChannelLimits{}

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Apcera Inc. All rights reserved.
+// Copyright 2016-2017 Apcera Inc. All rights reserved.
 
 package server
 
@@ -168,6 +168,9 @@ func TestParseConfig(t *testing.T) {
 	if opts.FTGroupName != "ft" {
 		t.Fatalf("Expected FTGroupName to be %q, got %q", "ft", opts.FTGroupName)
 	}
+	if !opts.Partitioning {
+		t.Fatalf("Expected Partitioning to be true, got false")
+	}
 }
 
 func TestParsePermError(t *testing.T) {
@@ -285,6 +288,7 @@ func TestParseWrongTypes(t *testing.T) {
 	expectFailureFor(t, "hb_fail_count: false", wrongTypeErr)
 	expectFailureFor(t, "ack_subs_pool_size: false", wrongTypeErr)
 	expectFailureFor(t, "ft_group: 123", wrongTypeErr)
+	expectFailureFor(t, "partitioning: 123", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{max_channels:false}", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{max_msgs:false}", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{max_bytes:false}", wrongTypeErr)
@@ -296,8 +300,8 @@ func TestParseWrongTypes(t *testing.T) {
 	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_age:\"1h:0m\"}}}", wrongTimeErr)
 	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_age:false}}}", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_subs:false}}}", wrongTypeErr)
-	expectFailureFor(t, "store_limits:{channels:{\"foo.*\":{}}}", wrongSubjErr)
-	expectFailureFor(t, "store_limits:{channels:{\"foo.>\":{}}}", wrongSubjErr)
+	expectFailureFor(t, "store_limits:{channels:{\"foo.*bar\":{}}}", wrongSubjErr)
+	expectFailureFor(t, "store_limits:{channels:{\"foo.>.>\":{}}}", wrongSubjErr)
 	expectFailureFor(t, "store_limits:{channels:{\"foo..bar\":{}}}", wrongSubjErr)
 	expectFailureFor(t, "tls:{client_cert:123}", wrongTypeErr)
 	expectFailureFor(t, "tls:{client_key:123}", wrongTypeErr)

--- a/server/partitions.go
+++ b/server/partitions.go
@@ -1,0 +1,383 @@
+// Copyright 2017 Apcera Inc. All rights reserved.
+
+package server
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	natsd "github.com/nats-io/gnatsd/server"
+	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats-streaming-server/spb"
+	"github.com/nats-io/nats-streaming-server/stores"
+	"github.com/nats-io/nats-streaming-server/util"
+)
+
+// Constants related to partitioning
+const (
+	// Prefix of subject to send list of channels in this server's partition
+	partitionsPrefix = "_STAN.part"
+	// Default timeout for a server to wait for replies to its request
+	partitionsDefaultRequestTimeout = time.Second
+	// This is the value that is stored in the sublist for a given subject
+	channelInterest = 1
+	// Messages channel size
+	partitionsMsgChanSize = 65536
+	// Number of bytes used to encode a channel name
+	partitionsEncodedChannelLen = 2
+)
+
+// So that we can override in tests
+var (
+	partitionsRequestTimeout = partitionsDefaultRequestTimeout
+	partitionsNoPanic        = false
+)
+
+type partitions struct {
+	sync.Mutex
+	s               *StanServer
+	channels        []string
+	sl              *util.Sublist
+	nc              *nats.Conn
+	sendListSubject string
+	ctrlMsgSubject  string // send to this subject when processing close/unsub requests
+	msgsCh          chan *nats.Msg
+	isShutdown      bool
+	quitCh          chan struct{}
+}
+
+// Creates the subscription for partitioning communication, sends
+// the initial request (in case there are other servers listening) and
+// starts the go routines handling HBs and cleanup of servers map.
+func (s *StanServer) initPartitions(sOpts *Options, nOpts *natsd.Options, storeChannels map[string]*stores.ChannelLimits) error {
+	// The option says that the server should only use the pre-defined channels,
+	// but none was specified. Don't see the point in continuing...
+	if len(storeChannels) == 0 {
+		return ErrNoChannel
+	}
+	nc, err := s.createNatsClientConn("pc", sOpts, nOpts)
+	if err != nil {
+		return err
+	}
+	p := &partitions{
+		s:  s,
+		nc: nc,
+	}
+	// Now that the connection is created, we need to set s.partitioning to cp
+	// so that server shutdown can properly close this connection.
+	s.partitions = p
+	p.createChannelsMapAndSublist(storeChannels)
+	p.sendListSubject = partitionsPrefix + "." + sOpts.ID
+	// Use the partitions' own connection for channels list requests
+	sub, err := p.nc.Subscribe(p.sendListSubject, p.processChannelsListRequests)
+	if err != nil {
+		return fmt.Errorf("unable to subscribe: %v", err)
+	}
+	sub.SetPendingLimits(-1, -1)
+	p.Lock()
+	// Set this before the first attempt so we don't miss any notification
+	// of a change in topology. Since we hold the lock, and even if there
+	// was a notification happening now, the callback will execute only
+	// after we are done with the initial check.
+	nc.SetDiscoveredServersHandler(p.topologyChanged)
+	// Now send our list and check if any server is complaining
+	// about having one channel in common.
+	if err := p.checkChannelsUniqueInCluster(); err != nil {
+		p.Unlock()
+		return err
+	}
+	p.Unlock()
+	p.msgsCh = make(chan *nats.Msg, partitionsMsgChanSize)
+	p.quitCh = make(chan struct{}, 1)
+	s.wg.Add(1)
+	go p.postClientPublishIncomingMsgs()
+	return nil
+}
+
+// Creates the channels map based on the store's PerChannel map that was given.
+func (p *partitions) createChannelsMapAndSublist(storeChannels map[string]*stores.ChannelLimits) {
+	p.channels = make([]string, 0, len(storeChannels))
+	p.sl = util.NewSublist()
+	for c := range storeChannels {
+		p.channels = append(p.channels, c)
+		// When creating the store, we have already checked that channel names
+		// were valid. So this call cannot fail.
+		p.sl.Insert(c, channelInterest)
+	}
+}
+
+// Topology changed. Sends the list of channels.
+func (p *partitions) topologyChanged(_ *nats.Conn) {
+	p.Lock()
+	defer p.Unlock()
+	if p.isShutdown {
+		return
+	}
+	if err := p.checkChannelsUniqueInCluster(); err != nil {
+		// If server is started from command line, the Fatalf
+		// call will cause the process to exit. If the server
+		// is run programmatically and no logger has been set
+		// we need to exit with the panic.
+		Fatalf("Partitioning error: %v", err)
+		// For tests
+		if partitionsNoPanic {
+			p.s.setLastError(err)
+			return
+		}
+		panic(err)
+	}
+}
+
+// We use a channel subscription in order to minimize the number
+// of go routines for all the explicit pub subscriptions.
+// This go routine simply pulls a message from the channel and
+// invokes processClientPublish(). We may have slow consumer issues,
+// if so, will have to figure out another way.
+func (p *partitions) postClientPublishIncomingMsgs() {
+	defer p.s.wg.Done()
+	for {
+		select {
+		case <-p.quitCh:
+			return
+		case m := <-p.msgsCh:
+			p.s.processClientPublish(m)
+		}
+	}
+}
+
+// Create the internal subscriptions on the list of channels.
+func (p *partitions) initSubscriptions() error {
+	// NOTE: Use the server's nc connection here, not the partitions' one.
+	for _, channelName := range p.channels {
+		pubSubject := fmt.Sprintf("%s.%s", p.s.info.Publish, channelName)
+		if _, err := p.s.nc.ChanSubscribe(pubSubject, p.msgsCh); err != nil {
+			return fmt.Errorf("could not subscribe to publish subject %q, %v", channelName, err)
+		}
+	}
+	// Add a dedicated subject for when we try to schedule a control
+	// message to be processed after all messages from a given client
+	// have been processed.
+	p.ctrlMsgSubject = fmt.Sprintf("%s.%s", p.s.info.Publish, nats.NewInbox())
+	if _, err := p.s.nc.ChanSubscribe(p.ctrlMsgSubject, p.msgsCh); err != nil {
+		return fmt.Errorf("could not subscribe to subject %q, %v", p.ctrlMsgSubject, err)
+	}
+	return nil
+}
+
+// Sends a request to the rest of the cluster and wait a bit for
+// responses (we don't know if or how many servers there may be).
+// No server lock used since this is called inside RunServerWithOpts().
+func (p *partitions) checkChannelsUniqueInCluster() error {
+	// We will use a subscription on an inbox to get the replies
+	replyInbox := nats.NewInbox()
+	replySub, err := p.nc.SubscribeSync(replyInbox)
+	if err != nil {
+		return fmt.Errorf("unable to create sync subscription: %v", err)
+	}
+	defer replySub.Unsubscribe()
+	// Send our list
+	if err := p.sendChannelsList(replyInbox); err != nil {
+		return fmt.Errorf("unable to send channels list: %v", err)
+	}
+	// Since we don't know how many servers are out there, keep
+	// calling NextMsg until we get a timeout
+	for {
+		reply, err := replySub.NextMsg(partitionsRequestTimeout)
+		if err == nats.ErrTimeout {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("unable to get partitioning reply: %v", err)
+		}
+		resp := spb.CtrlMsg{}
+		if err := resp.Unmarshal(reply.Data); err != nil {
+			return fmt.Errorf("unable to decode partitioning response: %v", err)
+		}
+		if len(resp.Data) > 0 {
+			return fmt.Errorf("channel %q causes conflict with channels on server %q",
+				string(resp.Data), resp.ServerID)
+		}
+	}
+}
+
+// Sends the list of channels to a known subject, possibly splitting the list
+// in several requests if it cannot fit in a single message.
+func (p *partitions) sendChannelsList(replyInbox string) error {
+	// Since the NATS message payload is limited, we need to repeat
+	// requests if all channels can't fit in a request.
+	maxPayload := int(p.nc.MaxPayload())
+	// Reuse this request object to send the (possibly many) protocol message(s).
+	header := &spb.CtrlMsg{
+		ServerID: p.s.serverID,
+		MsgType:  spb.CtrlMsg_Partitioning,
+	}
+	// The Data field (a byte array) will require 1+len(array)+(encoded size of array).
+	// To be conservative, let's just use a 8 bytes integer
+	headerSize := header.Size() + 1 + 8
+	var (
+		bytes []byte // Reused buffer in which the request is to marshal info
+		n     int    // Size of the serialized request in the above buffer
+		count int    // Number of channels added to the request
+	)
+	for start := 0; start != len(p.channels); start += count {
+		bytes, n, count = p.encodeRequest(header, bytes, headerSize, maxPayload, start)
+		if count == 0 {
+			return fmt.Errorf("message payload too small to send partitioning channels list")
+		}
+		if err := p.nc.PublishRequest(p.sendListSubject, replyInbox, bytes[:n]); err != nil {
+			return err
+		}
+	}
+	return p.nc.Flush()
+}
+
+// Adds as much channels as possible (based on the NATS max message payload) and
+// returns a serialized request. The buffer `reqBytes` is passed (and returned) so
+// that it can be reused if more than one request is needed. This call will
+// expand the size as needed. The number of bytes used in this buffer is returned
+// along with the number of encoded channels.
+func (p *partitions) encodeRequest(request *spb.CtrlMsg, reqBytes []byte, headerSize, maxPayload, start int) ([]byte, int, int) {
+	// Each string will be encoded in the form:
+	// - length (2 bytes)
+	// - string as a byte array.
+	var _encodedSize = [partitionsEncodedChannelLen]byte{}
+	encodedSize := _encodedSize[:]
+	// We are going to encode the channels in this buffer
+	chanBuf := make([]byte, 0, maxPayload)
+	var (
+		count         int          // Number of encoded channels
+		estimatedSize = headerSize // This is not an overestimation of the total size
+		numBytes      int          // This is what is returned by MarshalTo
+	)
+	for i := start; i < len(p.channels); i++ {
+		c := []byte(p.channels[i])
+		cl := len(c)
+		needed := partitionsEncodedChannelLen + cl
+		// Check if adding this channel to current buffer makes us go over
+		if estimatedSize+needed > maxPayload {
+			// Special case if we cannot even encode 1 channel
+			if count == 0 {
+				return reqBytes, 0, 0
+			}
+			break
+		}
+		// Encoding the channel here. First the size, then the channel name as byte array.
+		util.ByteOrder.PutUint16(encodedSize, uint16(cl))
+		chanBuf = append(chanBuf, encodedSize...)
+		chanBuf = append(chanBuf, c...)
+		count++
+		estimatedSize += needed
+	}
+	if count > 0 {
+		request.Data = chanBuf
+		reqBytes = util.EnsureBufBigEnough(reqBytes, estimatedSize)
+		numBytes, _ = request.MarshalTo(reqBytes)
+		if numBytes > maxPayload {
+			panic(fmt.Errorf("partitioning: request size is %v (max payload is %v)", numBytes, maxPayload))
+		}
+	}
+	return reqBytes, numBytes, count
+}
+
+// Decode the incoming partitioning protocol message.
+// It can be an HB, in which case, if it is from a new server
+// we send our list to the cluster, or it can be a request
+// from another server. If so, we reply to the given inbox
+// with either an empty Data field or the name of the first
+// channel we have in common.
+func (p *partitions) processChannelsListRequests(m *nats.Msg) {
+	// Message cannot be empty, we are supposed to receive
+	// a spb.CtrlMsg_Partitioning protocol. We should also
+	// have a repy subject
+	if len(m.Data) == 0 || m.Reply == "" {
+		return
+	}
+	req := spb.CtrlMsg{}
+	if err := req.Unmarshal(m.Data); err != nil {
+		Errorf("Error processing partitioning request: %v", err)
+		return
+	}
+	// If this is our own request, ignore
+	if req.ServerID == p.s.serverID {
+		return
+	}
+	channels, err := decodeChannels(req.Data)
+	if err != nil {
+		Errorf("Error processing partitioning request: %v", err)
+		return
+	}
+	// Check that we don't have any of these channels defined.
+	// If we do, send a reply with simply the name of the offending
+	// channel in reply.Data
+	reply := spb.CtrlMsg{
+		ServerID: p.s.serverID,
+		MsgType:  spb.CtrlMsg_Partitioning,
+	}
+	gotError := false
+	sl := util.NewSublist()
+	for _, c := range channels {
+		if r := p.sl.Match(c); len(r) > 0 {
+			reply.Data = []byte(c)
+			gotError = true
+			break
+		}
+		sl.Insert(c, channelInterest)
+	}
+	if !gotError {
+		// Go over our channels and check with the other server sublist
+		for _, c := range p.channels {
+			if r := sl.Match(c); len(r) > 0 {
+				reply.Data = []byte(c)
+				break
+			}
+		}
+	}
+	replyBytes, _ := reply.Marshal()
+	// If there is no duplicate, reply.Data will be empty, which means
+	// that there was no conflict.
+	if err := p.nc.Publish(m.Reply, replyBytes); err != nil {
+		Errorf("Error sending reply to partitioning request: %v", err)
+	}
+}
+
+// decodes from the given by array the list of channel names and return
+// them as an array of strings.
+func decodeChannels(data []byte) ([]string, error) {
+	channels := []string{}
+	pos := 0
+	for pos < len(data) {
+		if pos+2 > len(data) {
+			return nil, fmt.Errorf("partitioning: unable to decode size, pos=%v len=%v", pos, len(data))
+		}
+		cl := int(util.ByteOrder.Uint16(data[pos:]))
+		pos += partitionsEncodedChannelLen
+		end := pos + cl
+		if end > len(data) {
+			return nil, fmt.Errorf("partitioning: unable to decode channel, pos=%v len=%v max=%v (string=%v)",
+				pos, cl, len(data), string(data[pos:]))
+		}
+		c := string(data[pos:end])
+		channels = append(channels, c)
+		pos = end
+	}
+	return channels, nil
+}
+
+// Notifies all go-routines used by partitioning code that the
+// server is shuting down and closes the internal NATS connection.
+func (p *partitions) shutdown() {
+	p.Lock()
+	if p.isShutdown {
+		p.Unlock()
+		return
+	}
+	p.isShutdown = true
+	p.Unlock()
+	if p.quitCh != nil {
+		p.quitCh <- struct{}{}
+	}
+	if p.nc != nil {
+		p.nc.Close()
+	}
+}

--- a/server/partitions_test.go
+++ b/server/partitions_test.go
@@ -1,0 +1,596 @@
+// Copyright 2017 Apcera Inc. All rights reserved.
+
+package server
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	natsd "github.com/nats-io/gnatsd/server"
+	natsdTest "github.com/nats-io/gnatsd/test"
+	"github.com/nats-io/go-nats"
+	"github.com/nats-io/go-nats-streaming"
+	"github.com/nats-io/nats-streaming-server/spb"
+	"github.com/nats-io/nats-streaming-server/stores"
+)
+
+func setPartitionsVarsForTest() {
+	partitionsRequestTimeout = 250 * time.Millisecond
+	partitionsNoPanic = true
+}
+
+func resetDefaultPartitionsVars() {
+	partitionsRequestTimeout = partitionsDefaultRequestTimeout
+	partitionsNoPanic = false
+}
+
+func TestPartitionsNoChannelConfiguredError(t *testing.T) {
+	setPartitionsVarsForTest()
+	defer resetDefaultPartitionsVars()
+
+	opts := GetDefaultOptions()
+	opts.Partitioning = true
+	s, err := RunServerWithOpts(opts, nil)
+	if s != nil {
+		s.Shutdown()
+		t.Fatalf("No server should be returned")
+	}
+	if err != ErrNoChannel {
+		t.Fatalf("Expected ErrNoStaticChannel error, got: %v", err)
+	}
+}
+
+func TestPartitionsInvalidChannelName(t *testing.T) {
+	setPartitionsVarsForTest()
+	defer resetDefaultPartitionsVars()
+
+	opts := GetDefaultOptions()
+	opts.Partitioning = true
+	serverShouldFail := func(subject string) {
+		opts.StoreLimits.PerChannel = nil
+		opts.StoreLimits.AddPerChannel(subject, &stores.ChannelLimits{})
+		s, err := RunServerWithOpts(opts, nil)
+		if s != nil {
+			s.Shutdown()
+		}
+		if err == nil || !strings.Contains(err.Error(), "channel name") {
+			t.Fatalf("Expected error about invalid channel name, got %v", err)
+		}
+	}
+	serverShouldFail(".")
+	serverShouldFail(".foo")
+	serverShouldFail("foo.")
+	serverShouldFail("foo*")
+	serverShouldFail("foo.*.")
+	serverShouldFail("foo.>.bar")
+}
+
+func TestPartitionsInvalidRequest(t *testing.T) {
+	setPartitionsVarsForTest()
+	defer resetDefaultPartitionsVars()
+
+	opts := GetDefaultOptions()
+	opts.Partitioning = true
+	opts.StoreLimits.AddPerChannel("foo", &stores.ChannelLimits{})
+	s := runServerWithOpts(t, opts, nil)
+	defer s.Shutdown()
+
+	// Use raw NATS to send invalid requests
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc.Close()
+
+	subj := partitionsPrefix + "." + clusterName
+
+	// Sending those invalid requests should not make the server crash
+	// and we should not get a response back
+	msgCh := make(chan *nats.Msg)
+	inbox := nats.NewInbox()
+	if _, err := nc.Subscribe(inbox, func(m *nats.Msg) {
+		msgCh <- m
+	}); err != nil {
+		t.Fatalf("Error on subscribe: %v", err)
+	}
+	verifyNoResponse := func() {
+		select {
+		case <-msgCh:
+			stackFatalf(t, "Should not have receive a response, got: %v")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	// Send message without Reply
+	nc.Publish(subj, []byte("hello"))
+	verifyNoResponse()
+
+	// Send request with empty body.
+	nc.PublishRequest(subj, inbox, nil)
+	verifyNoResponse()
+
+	// Send dummy request (Unmarshal should fail).
+	nc.PublishRequest(subj, inbox, []byte("hello"))
+	verifyNoResponse()
+
+	// Send invalid data for the channels encoding
+	req := &spb.CtrlMsg{
+		ServerID: "otherserver",
+		MsgType:  spb.CtrlMsg_Partitioning,
+		Data:     []byte{1, 2, 3, 4, 5},
+	}
+	reqBytes, _ := req.Marshal()
+	nc.PublishRequest(subj, inbox, reqBytes)
+	verifyNoResponse()
+
+	req.Data = []byte{1}
+	reqBytes, _ = req.Marshal()
+	nc.PublishRequest(subj, inbox, reqBytes)
+	verifyNoResponse()
+}
+
+func TestPartitionsMaxPayload(t *testing.T) {
+	setPartitionsVarsForTest()
+	defer resetDefaultPartitionsVars()
+
+	// For this test, both server will connect to same NATS Server
+	ncOpts := natsdTest.DefaultTestOptions
+	// Change MaxPayload
+	ncOpts.MaxPayload = 50
+	ns := natsdTest.RunServer(&ncOpts)
+	defer ns.Shutdown()
+
+	opts1 := GetDefaultOptions()
+	opts1.NATSServerURL = "nats://localhost:4222"
+	opts1.Partitioning = true
+	opts1.StoreLimits.AddPerChannel("foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo", &stores.ChannelLimits{})
+	failSrv, err := RunServerWithOpts(opts1, nil)
+	if failSrv != nil {
+		failSrv.Shutdown()
+	}
+	// It should fail since we would not be able to send a single channel
+	// due to MaxPayload restrictions.
+	if err == nil {
+		t.Fatal("Should have failed")
+	}
+	ns.Shutdown()
+
+	// Change MaxPayload
+	ncOpts.MaxPayload = 100
+	ns = natsdTest.RunServer(&ncOpts)
+	defer ns.Shutdown()
+
+	opts1 = GetDefaultOptions()
+	opts1.NATSServerURL = "nats://localhost:4222"
+	opts1.Partitioning = true
+	opts1.StoreLimits.AddPerChannel("foo", &stores.ChannelLimits{})
+	s1 := runServerWithOpts(t, opts1, nil)
+	defer s1.Shutdown()
+
+	// Create raw subscriber to check what is being sent by s2
+	nc, err := nats.Connect(fmt.Sprintf("nats://%s:%d", ncOpts.Host, ncOpts.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc.Close()
+
+	total := 100
+	count := 0
+	ch := make(chan bool)
+	verifyChannels := make(map[string]struct{})
+	cb := func(m *nats.Msg) {
+		req := &spb.CtrlMsg{}
+		req.Unmarshal(m.Data)
+		channels, _ := decodeChannels(req.Data)
+		for _, c := range channels {
+			verifyChannels[c] = struct{}{}
+			count++
+		}
+		if count == total {
+			ch <- true
+		}
+	}
+	if _, err := nc.Subscribe(partitionsPrefix+"."+clusterName, cb); err != nil {
+		t.Fatalf("Error on subscribe: %v", err)
+	}
+	if err := nc.Flush(); err != nil {
+		t.Fatalf("Error on flush: %v", err)
+	}
+
+	opts2 := GetDefaultOptions()
+	opts2.NATSServerURL = "nats://localhost:4222"
+	opts2.Partitioning = true
+	for i := 0; i < total-1; i++ {
+		channelName := fmt.Sprintf("channel.number.%d", (i + 1))
+		opts2.StoreLimits.AddPerChannel(channelName, &stores.ChannelLimits{})
+	}
+	// Add "foo". There is no guarantee that foo is in the last message
+	// sent to s1, but we want to make sure that all requests are processed
+	// and s2 receives an error back.
+	opts2.StoreLimits.AddPerChannel("foo", &stores.ChannelLimits{})
+	// This is expected to fail
+	s2, err := RunServerWithOpts(opts2, nil)
+	if s2 != nil {
+		s2.Shutdown()
+	}
+	if err == nil {
+		t.Fatal("Expected server to fail to start, did not")
+	}
+	// Wait that we have received all channels
+	if err := Wait(ch); err != nil {
+		t.Fatal("Did not get our channels list")
+	}
+	// We have received the total amount, now verify that we have all unique ones
+	if len(verifyChannels) != total {
+		t.Fatalf("Expected to get %d distinct channels, got %v", total, len(verifyChannels))
+	}
+}
+
+func TestPartitionsOnlyThoseWork(t *testing.T) {
+	setPartitionsVarsForTest()
+	defer resetDefaultPartitionsVars()
+
+	okChannel := "foo"
+	notOkChannel := "bar"
+
+	opts := GetDefaultOptions()
+	opts.Partitioning = true
+	opts.StoreLimits.AddPerChannel(okChannel, &stores.ChannelLimits{})
+	s := runServerWithOpts(t, opts, nil)
+	defer s.Shutdown()
+
+	sc, err := stan.Connect(clusterName, clientName,
+		stan.ConnectWait(250*time.Millisecond), // works also for subscription requests
+		stan.PubAckWait(250*time.Millisecond))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer sc.Close()
+	// Should not be a problem to send a message to "foo"
+	if err := sc.Publish(okChannel, []byte("msg to foo")); err != nil {
+		t.Fatalf("Unexpected error on publish: %v", err)
+	}
+	// However, sending to bar should timeout
+	if err := sc.Publish(notOkChannel, []byte("should fail")); err != stan.ErrTimeout {
+		t.Fatalf("Expected timeout, got: %v", err)
+	}
+	// Creating subscription to "foo" should work and we should get the message
+	ch := make(chan bool)
+	if _, err := sc.Subscribe(okChannel, func(_ *stan.Msg) {
+		ch <- true
+	}, stan.DeliverAllAvailable()); err != nil {
+		t.Fatalf("Unexpected error on subscribe: %v", err)
+	}
+	if err := Wait(ch); err != nil {
+		t.Fatal("Did not get our message")
+	}
+	// Creating subscription on "bar" should fail with timeout since at this
+	// point there is a single server and it is not handling "bar".
+	if _, err := sc.Subscribe(notOkChannel, func(_ *stan.Msg) {}); err != stan.ErrSubReqTimeout {
+		t.Fatalf("Expected timeout on subscribe, got: %v", err)
+	}
+}
+
+func TestPartitionsWithClusterOfServers(t *testing.T) {
+	setPartitionsVarsForTest()
+	defer resetDefaultPartitionsVars()
+
+	// For this test, create a single NATS server to which both servers connect to.
+	ns := natsdTest.RunDefaultServer()
+	defer ns.Shutdown()
+
+	fooSubj := "foo"
+	barSubj := "bar"
+
+	opts1 := GetDefaultOptions()
+	opts1.NATSServerURL = "nats://localhost:4222"
+	opts1.Partitioning = true
+	opts1.StoreLimits.AddPerChannel(fooSubj, &stores.ChannelLimits{})
+	s1 := runServerWithOpts(t, opts1, nil)
+	defer s1.Shutdown()
+
+	opts2 := GetDefaultOptions()
+	opts2.NATSServerURL = "nats://localhost:4222"
+	opts2.Partitioning = true
+	opts2.StoreLimits.AddPerChannel(barSubj, &stores.ChannelLimits{})
+	s2 := runServerWithOpts(t, opts2, nil)
+	defer s2.Shutdown()
+
+	sc, err := stan.Connect(clusterName, clientName,
+		stan.ConnectWait(250*time.Millisecond), // works also for subscription requests
+		stan.PubAckWait(250*time.Millisecond))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer sc.Close()
+	send := func(subj string) {
+		if err := sc.Publish(subj, []byte("msg")); err != nil {
+			stackFatalf(t, "Unexpected error on publish: %v", err)
+		}
+	}
+	// Should not be a problem to send a message to "foo"
+	send(fooSubj)
+	// Sending to bar should work too..
+	send(barSubj)
+
+	sub := func(subj string) {
+		ch := make(chan bool)
+		sub, err := sc.Subscribe(subj, func(_ *stan.Msg) {
+			ch <- true
+		}, stan.DeliverAllAvailable())
+		if err != nil {
+			stackFatalf(t, "Unexpected error on subscribe: %v", err)
+		}
+		if err := Wait(ch); err != nil {
+			stackFatalf(t, "Did not get our message")
+		}
+		// Make sure we don't have any timeout error
+		if err := sub.Unsubscribe(); err != nil {
+			stackFatalf(t, "Error on unsubscribe: %v", err)
+		}
+	}
+	// Creating subscription to "foo" should work and we should get the message
+	sub(fooSubj)
+	// Same for bar
+	sub(barSubj)
+
+	// Now verify that each server handled only the channel it should.
+	checkChannel := func(s *StanServer, chanOk, chanNotOk string) {
+		if s.store.LookupChannel(chanNotOk) != nil {
+			stackFatalf(t, "Server should not have channel %v", chanNotOk)
+		}
+		if n, _, err := s.store.MsgsState(chanOk); n != 1 || err != nil {
+			stackFatalf(t, "Channel %q should have 1 message and no error, got %v - %v",
+				chanOk, n, err)
+		}
+	}
+	checkChannel(s1, fooSubj, barSubj)
+	checkChannel(s2, barSubj, fooSubj)
+
+	// Make sure we don't have timeout error on close
+	if err := sc.Close(); err != nil {
+		t.Fatalf("Error on close: %v", err)
+	}
+}
+
+func TestPartitionsDuplicatedOnTwoServers(t *testing.T) {
+	setPartitionsVarsForTest()
+	defer resetDefaultPartitionsVars()
+
+	// For this test, create a single NATS server to which both servers connect to.
+	ns := natsdTest.RunDefaultServer()
+	defer ns.Shutdown()
+
+	fooSubj := "foo"
+	barSubj := "bar"
+
+	opts1 := GetDefaultOptions()
+	opts1.NATSServerURL = "nats://localhost:4222"
+	opts1.Partitioning = true
+	opts1.StoreLimits.AddPerChannel(fooSubj, &stores.ChannelLimits{})
+	opts1.StoreLimits.AddPerChannel(barSubj, &stores.ChannelLimits{})
+	s1 := runServerWithOpts(t, opts1, nil)
+	defer s1.Shutdown()
+
+	opts2 := GetDefaultOptions()
+	opts2.NATSServerURL = "nats://localhost:4222"
+	opts2.Partitioning = true
+	opts2.StoreLimits.AddPerChannel(barSubj, &stores.ChannelLimits{})
+	// Expecting this to fail
+	s2, err := RunServerWithOpts(opts2, nil)
+	if s2 != nil || err == nil {
+		if s2 != nil {
+			s2.Shutdown()
+		}
+		t.Fatal("Expected server to fail because of same channel defined in 2 servers")
+	}
+}
+
+func TestPartitionsConflictDueToWildcards(t *testing.T) {
+	setPartitionsVarsForTest()
+	defer resetDefaultPartitionsVars()
+
+	opts1 := GetDefaultOptions()
+	opts1.Partitioning = true
+	opts1.StoreLimits.AddPerChannel("foo.*", &stores.ChannelLimits{})
+	s1 := runServerWithOpts(t, opts1, nil)
+	defer s1.Shutdown()
+
+	opts2 := GetDefaultOptions()
+	opts2.NATSServerURL = "nats://localhost:4222"
+	opts2.Partitioning = true
+	opts2.StoreLimits.AddPerChannel("foo.bar", &stores.ChannelLimits{})
+	// Expecting this to fail
+	s2, err := RunServerWithOpts(opts2, nil)
+	if s2 != nil || err == nil {
+		if s2 != nil {
+			s2.Shutdown()
+		}
+		t.Fatal("Expected server to fail because of channel overlap on 2 servers")
+	}
+	opts2.StoreLimits.PerChannel = nil
+	opts2.StoreLimits.AddPerChannel(">", &stores.ChannelLimits{})
+	// Expecting this to fail
+	s2, err = RunServerWithOpts(opts2, nil)
+	if s2 != nil || err == nil {
+		if s2 != nil {
+			s2.Shutdown()
+		}
+		t.Fatal("Expected server to fail because of channel overlap on 2 servers")
+	}
+}
+
+func TestPartitionsSendListAfterRouteEstablished(t *testing.T) {
+	setPartitionsVarsForTest()
+	defer resetDefaultPartitionsVars()
+
+	ncOpts1 := natsdTest.DefaultTestOptions
+	ncOpts1.Cluster.Host = "localhost"
+	ncOpts1.Cluster.Port = 6222
+	ncOpts1.Routes = natsd.RoutesFromStr("nats://localhost:6223")
+	ns1 := natsdTest.RunServer(&ncOpts1)
+	defer ns1.Shutdown()
+
+	var s1, s2 *StanServer
+	var mu sync.Mutex
+
+	fooFromS1 := 0
+	fooFromS2 := 0
+	cb := func(s **StanServer, count *int) func(m *nats.Msg) {
+		return func(m *nats.Msg) {
+			req := &spb.CtrlMsg{}
+			req.Unmarshal(m.Data)
+			channels, _ := decodeChannels(req.Data)
+			for _, c := range channels {
+				mu.Lock()
+				if c == "foo" && *s != nil && req.ServerID == (*s).serverID {
+					(*count)++
+				}
+				mu.Unlock()
+			}
+		}
+	}
+	// Create raw subscriber to check the list of channels sent by s1
+	nc1, err := nats.Connect(fmt.Sprintf("nats://%s:%d", ncOpts1.Host, ncOpts1.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc1.Close()
+	if _, err := nc1.Subscribe(partitionsPrefix+"."+clusterName, cb(&s1, &fooFromS1)); err != nil {
+		t.Fatalf("Error on subscribe: %v", err)
+	}
+	if err := nc1.Flush(); err != nil {
+		t.Fatalf("Error on flush: %v", err)
+	}
+
+	opts1 := GetDefaultOptions()
+	opts1.NATSServerURL = "nats://localhost:4222"
+	opts1.Partitioning = true
+	opts1.AddPerChannel("foo", &stores.ChannelLimits{})
+	// Do this under this lock since the list will be received in the callback
+	// above before s1 is set.
+	mu.Lock()
+	s1 = runServerWithOpts(t, opts1, nil)
+	defer s1.Shutdown()
+	mu.Unlock()
+
+	// Setup the 2nd server but do not explicitly create a route to
+	// ns1, so we will wait for ns1 to connect to ns2, which since
+	// ns1 has an explicit route to ns2, ns1 will try to connect
+	// to ns2 every 2 seconds. If we are "lucky" (for this test),
+	// it means that s2 will first start without being connected
+	// to s1 and should not know that there is a duplicate channel.
+	// Once the route is established, this should trigger a resend
+	// of the list and then the two servers should fail.
+	ncOpts2 := natsdTest.DefaultTestOptions
+	ncOpts2.Port = 4223
+	ncOpts2.Cluster.Host = "localhost"
+	ncOpts2.Cluster.Port = 6223
+	ns2 := natsdTest.RunServer(&ncOpts2)
+	defer ns2.Shutdown()
+
+	// Create raw subscriber to check the list of channels sent by s2
+	nc2, err := nats.Connect(fmt.Sprintf("nats://%s:%d", ncOpts2.Host, ncOpts2.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc2.Close()
+	if _, err := nc2.Subscribe(partitionsPrefix+"."+clusterName, cb(&s2, &fooFromS2)); err != nil {
+		t.Fatalf("Error on subscribe: %v", err)
+	}
+	if err := nc2.Flush(); err != nil {
+		t.Fatalf("Error on flush: %v", err)
+	}
+
+	opts2 := GetDefaultOptions()
+	opts2.NATSServerURL = "nats://localhost:4223"
+	opts2.MaxChannels = 1000
+	opts2.Partitioning = true
+	opts2.AddPerChannel("foo", &stores.ChannelLimits{})
+	mu.Lock()
+	s2 = runServerWithOpts(t, opts2, nil)
+	defer s2.Shutdown()
+	mu.Unlock()
+
+	// Wait for ns1 and ns2 to report that the route is established
+	timeout := time.Now().Add(3 * time.Second)
+	ok := false
+	for time.Now().Before(timeout) {
+		if ns1.NumRoutes() == 1 && ns2.NumRoutes() == 1 {
+			ok = true
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	if !ok {
+		t.Fatal("Route still not established")
+	}
+	// The two servers should fail but since we prevent panic
+	// for the test, servers will still be running.
+	// After the route is established, each server should resend
+	// their list, so the total of times each server receives
+	// the list should be 2.
+	time.Sleep(500 * time.Millisecond)
+	mu.Lock()
+	cs1 := fooFromS1
+	cs2 := fooFromS2
+	mu.Unlock()
+	if cs1 != 2 {
+		t.Fatalf("Expected to receive foo from S1 only twice, got %v", cs1)
+	}
+	if cs2 != 2 {
+		t.Fatalf("Expected to receive foo from S2 only twice, got %v", cs2)
+	}
+	// Now one or 2 of the servers should have failed.
+	s1Err := s1.LastError()
+	s2Err := s2.LastError()
+	if s1Err == nil || s2Err == nil {
+		t.Fatal("Both servers should have stopped")
+	}
+	if !strings.Contains(s1Err.Error(), "foo") {
+		t.Fatalf("Expected error about channel foo already defined, got %v", s1Err)
+	}
+	if !strings.Contains(s2Err.Error(), "foo") {
+		t.Fatalf("Expected error about channel foo already defined, got %v", s2Err)
+	}
+}
+
+func TestPartitionsWildcards(t *testing.T) {
+	setPartitionsVarsForTest()
+	defer resetDefaultPartitionsVars()
+
+	opts := GetDefaultOptions()
+	opts.Partitioning = true
+	opts.AddPerChannel("foo.*", &stores.ChannelLimits{})
+	opts.AddPerChannel("bar.>", &stores.ChannelLimits{})
+	s := runServerWithOpts(t, opts, nil)
+	defer s.Shutdown()
+
+	sc, err := stan.Connect(clusterName, clientName, stan.ConnectWait(500*time.Millisecond))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer sc.Close()
+	cb := func(_ *stan.Msg) {}
+	// These should succeed
+	if _, err := sc.Subscribe("foo.bar", cb); err != nil {
+		t.Fatalf("Unexpected error on subscribe: %v", err)
+	}
+	if _, err := sc.Subscribe("bar.foo", cb); err != nil {
+		t.Fatalf("Unexpected error on subscribe: %v", err)
+	}
+	if _, err := sc.Subscribe("bar.foo.baz", cb); err != nil {
+		t.Fatalf("Unexpected error on subscribe: %v", err)
+	}
+	// This one should fail
+	if _, err := sc.Subscribe("foo.*", cb); err == nil {
+		t.Fatal("Expected error on subscribe, got none")
+	}
+	// This one should timeout
+	if _, err := sc.Subscribe("foo.bar.baz", cb); err == nil {
+		t.Fatal("Expected error on subscribe, got none")
+	}
+}

--- a/spb/protocol.pb.go
+++ b/spb/protocol.pb.go
@@ -38,6 +38,7 @@ const (
 	CtrlMsg_SubClose       CtrlMsg_Type = 1
 	CtrlMsg_ConnClose      CtrlMsg_Type = 2
 	CtrlMsg_FTHeartbeat    CtrlMsg_Type = 3
+	CtrlMsg_Partitioning   CtrlMsg_Type = 4
 )
 
 var CtrlMsg_Type_name = map[int32]string{
@@ -45,12 +46,14 @@ var CtrlMsg_Type_name = map[int32]string{
 	1: "SubClose",
 	2: "ConnClose",
 	3: "FTHeartbeat",
+	4: "Partitioning",
 }
 var CtrlMsg_Type_value = map[string]int32{
 	"SubUnsubscribe": 0,
 	"SubClose":       1,
 	"ConnClose":      2,
 	"FTHeartbeat":    3,
+	"Partitioning":   4,
 }
 
 func (x CtrlMsg_Type) String() string {

--- a/spb/protocol.proto
+++ b/spb/protocol.proto
@@ -1,4 +1,4 @@
-// Copyright 2016 Apcera Inc. All rights reserved.
+// Copyright 2016-2017 Apcera Inc. All rights reserved.
 //
 // Uses https://github.com/gogo/protobuf
 // compiled via `protoc -I=. -I=$GOPATH/src  --gogofaster_out=. protocol.proto`
@@ -66,6 +66,7 @@ message CtrlMsg {
     SubClose       = 1; // Subscription Close request.
     ConnClose      = 2; // Connection Close request.
     FTHeartbeat    = 3; // FT heartbeats.
+    Partitioning   = 4; // When partitioning is enabled, server sends this to other servers with same cluster ID.
   }
   Type    MsgType  = 1; // Type of the control message.
   string  ServerID = 2; // Allows a server to detect if it is the intended receipient.

--- a/stores/common.go
+++ b/stores/common.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nats-io/go-nats-streaming/pb"
 	"github.com/nats-io/nats-streaming-server/spb"
+	"github.com/nats-io/nats-streaming-server/util"
 )
 
 // format string used to report that limit is reached when storing
@@ -25,7 +26,8 @@ type commonStore struct {
 // genericStore is the generic store implementation with a map of channels.
 type genericStore struct {
 	commonStore
-	limits   StoreLimits
+	limits   *StoreLimits
+	sublist  *util.Sublist
 	name     string
 	channels map[string]*ChannelStore
 	clients  map[string]*Client
@@ -100,20 +102,38 @@ func (gs *genericStore) Recover() (*RecoveredState, error) {
 // setLimits makes a copy of the given StoreLimits,
 // validates the limits and if ok, applies the inheritance.
 func (gs *genericStore) setLimits(limits *StoreLimits) error {
-	// Make a copy
-	gs.limits = *limits
-	// of the map too
-	if len(limits.PerChannel) > 0 {
-		gs.limits.PerChannel = make(map[string]*ChannelLimits, len(limits.PerChannel))
-		for key, val := range limits.PerChannel {
-			// Make a copy of the values. We want ownership
-			// of those structures
-			gs.limits.PerChannel[key] = &(*val)
-		}
-	}
+	// Make a copy.
+	gs.limits = limits.Clone()
 	// Build will validate and apply inheritance if no error.
-	sl := &gs.limits
-	return sl.Build()
+	if err := gs.limits.Build(); err != nil {
+		return err
+	}
+	// We don't need the PerChannel map and the sublist. So replace
+	// the map with the sublist instead.
+	gs.sublist = util.NewSublist()
+	for key, val := range gs.limits.PerChannel {
+		// val is already a copy of the original limits.PerChannel[key],
+		// so don't need to make a copy again, we own this.
+		gs.sublist.Insert(key, val)
+	}
+	// Get rid of the map now.
+	gs.limits.PerChannel = nil
+	return nil
+}
+
+// Returns the appropriate limits for this channel based on inheritance.
+// The channel is assumed to be a literal, and the store lock held on entry.
+func (gs *genericStore) getChannelLimits(channel string) *ChannelLimits {
+	r := gs.sublist.Match(channel)
+	if len(r) == 0 {
+		// If there is no match, that means we need to use the global limits.
+		return &gs.limits.ChannelLimits
+	}
+	// If there is a match, use the limits from the last element because
+	// we know that the returned array is ordered from widest to narrowest,
+	// and the only literal that there is would be the channel we are
+	// looking up.
+	return r[len(r)-1].(*ChannelLimits)
 }
 
 // SetLimits sets limits for this store

--- a/stores/filestore_test.go
+++ b/stores/filestore_test.go
@@ -499,13 +499,15 @@ func TestFSInit(t *testing.T) {
 }
 
 func TestFSUseDefaultLimits(t *testing.T) {
+	cleanupDatastore(t, defaultDataStore)
+	defer cleanupDatastore(t, defaultDataStore)
 	fs, _, err := newFileStore(t, defaultDataStore, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	defer fs.Close()
-	if !reflect.DeepEqual(fs.limits, DefaultStoreLimits) {
-		t.Fatalf("Default limits are not used: %v\n", fs.limits)
+	if !reflect.DeepEqual(*fs.limits, DefaultStoreLimits) {
+		t.Fatalf("Default limits are not used: %v\n", *fs.limits)
 	}
 }
 
@@ -4517,6 +4519,14 @@ func TestFSNegativeLimits(t *testing.T) {
 	defer fs.Close()
 
 	testNegativeLimit(t, fs)
+}
+
+func TestFSLimitWithWildcardsInConfig(t *testing.T) {
+	cleanupDatastore(t, defaultDataStore)
+	defer cleanupDatastore(t, defaultDataStore)
+	fs := createDefaultFileStore(t)
+	defer fs.Close()
+	testLimitWithWildcardsInConfig(t, fs)
 }
 
 func TestFSParallelRecovery(t *testing.T) {

--- a/stores/limits.go
+++ b/stores/limits.go
@@ -4,9 +4,30 @@ package stores
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/nats-io/nats-streaming-server/util"
 )
+
+// Used for display of limits
+const (
+	limitCount = iota
+	limitBytes
+	limitDuration
+)
+
+// Clone returns a copy of the store limits
+func (sl *StoreLimits) Clone() *StoreLimits {
+	cloned := *sl
+	if len(sl.PerChannel) > 0 {
+		cloned.PerChannel = make(map[string]*ChannelLimits, len(sl.PerChannel))
+		for k, v := range sl.PerChannel {
+			copyVal := *v
+			cloned.PerChannel[k] = &copyVal
+		}
+	}
+	return &cloned
+}
 
 // AddPerChannel stores limits for the given channel `name` in the StoreLimits.
 // Inheritance (that is, specifying 0 for a limit means that the global limit
@@ -17,6 +38,13 @@ func (sl *StoreLimits) AddPerChannel(name string, cl *ChannelLimits) {
 		sl.PerChannel = make(map[string]*ChannelLimits)
 	}
 	sl.PerChannel[name] = cl
+}
+
+type channelLimitInfo struct {
+	name        string
+	limits      *ChannelLimits
+	isLiteral   bool
+	isProcessed bool
 }
 
 // Build sets the global limits into per-channel limits that are set
@@ -33,41 +61,82 @@ func (sl *StoreLimits) Build() error {
 	if len(sl.PerChannel) == 0 {
 		return nil
 	}
-	if sl.MaxChannels > 0 && len(sl.PerChannel) > sl.MaxChannels {
-		return fmt.Errorf("too many channels defined (%v). The max channels limit is set to %v",
-			len(sl.PerChannel), sl.MaxChannels)
-	}
-	for cn := range sl.PerChannel {
-		if !util.IsSubjectValid(cn) {
+	literals := 0
+	sublist := util.NewSublist()
+	for cn, cl := range sl.PerChannel {
+		if !util.IsSubjectValid(cn, true) {
 			return fmt.Errorf("invalid channel name %q", cn)
 		}
+		isLiteral := util.IsSubjectLiteral(cn)
+		if isLiteral {
+			literals++
+			if sl.MaxChannels > 0 && literals > sl.MaxChannels {
+				return fmt.Errorf("too many channels defined (%v). The max channels limit is set to %v",
+					literals, sl.MaxChannels)
+			}
+		}
+		cli := &channelLimitInfo{
+			name:      cn,
+			limits:    cl,
+			isLiteral: isLiteral,
+		}
+		sublist.Insert(cn, cli)
 	}
-
 	// If we are here, it means that there was no error,
 	// so we now apply inheritance.
-	for _, cl := range sl.PerChannel {
-		if cl.MaxSubscriptions < 0 {
-			cl.MaxSubscriptions = 0
-		} else if cl.MaxSubscriptions == 0 {
-			cl.MaxSubscriptions = sl.MaxSubscriptions
+	sl.applyInheritance(sublist)
+	return nil
+}
+
+func (sl *StoreLimits) applyInheritance(sublist *util.Sublist) {
+	// Get the subjects from the sublist. This ensure that they are ordered
+	// from the widest to the narrowest of subjects.
+	channels := sublist.Subjects()
+	for _, cn := range channels {
+		r := sublist.Match(cn)
+		// There has to be at least 1 match (the current channel name we
+		// are trying to match).
+		channel := r[0].(*channelLimitInfo)
+		if channel.isLiteral && channel.isProcessed {
+			continue
 		}
-		if cl.MaxMsgs < 0 {
-			cl.MaxMsgs = 0
-		} else if cl.MaxMsgs == 0 {
-			cl.MaxMsgs = sl.MaxMsgs
+		if !channel.isProcessed {
+			sl.inheritLimits(channel, &sl.ChannelLimits)
 		}
-		if cl.MaxBytes < 0 {
-			cl.MaxBytes = 0
-		} else if cl.MaxBytes == 0 {
-			cl.MaxBytes = sl.MaxBytes
-		}
-		if cl.MaxAge < 0 {
-			cl.MaxAge = 0
-		} else if cl.MaxAge == 0 {
-			cl.MaxAge = sl.MaxAge
+		prev := channel
+		for i := 1; i < len(r); i++ {
+			channel = r[i].(*channelLimitInfo)
+			if !channel.isProcessed {
+				sl.inheritLimits(channel, prev.limits)
+			}
+			prev = channel
 		}
 	}
-	return nil
+}
+
+func (sl *StoreLimits) inheritLimits(channel *channelLimitInfo, parentLimits *ChannelLimits) {
+	cl := channel.limits
+	if cl.MaxSubscriptions < 0 {
+		cl.MaxSubscriptions = 0
+	} else if cl.MaxSubscriptions == 0 {
+		cl.MaxSubscriptions = parentLimits.MaxSubscriptions
+	}
+	if cl.MaxMsgs < 0 {
+		cl.MaxMsgs = 0
+	} else if cl.MaxMsgs == 0 {
+		cl.MaxMsgs = parentLimits.MaxMsgs
+	}
+	if cl.MaxBytes < 0 {
+		cl.MaxBytes = 0
+	} else if cl.MaxBytes == 0 {
+		cl.MaxBytes = parentLimits.MaxBytes
+	}
+	if cl.MaxAge < 0 {
+		cl.MaxAge = 0
+	} else if cl.MaxAge == 0 {
+		cl.MaxAge = parentLimits.MaxAge
+	}
+	channel.isProcessed = true
 }
 
 func (sl *StoreLimits) checkGlobalLimits() error {
@@ -87,4 +156,140 @@ func (sl *StoreLimits) checkGlobalLimits() error {
 		return fmt.Errorf("max age limit cannot be negative (%v)", sl.MaxAge)
 	}
 	return nil
+}
+
+// Print returns an array of strings suitable for printing the store limits.
+func (sl *StoreLimits) Print() []string {
+	sublist := util.NewSublist()
+	for cn, cl := range sl.PerChannel {
+		sublist.Insert(cn, &channelLimitInfo{
+			name:      cn,
+			limits:    cl,
+			isLiteral: util.IsSubjectLiteral(cn),
+		})
+	}
+	maxLevels := sublist.NumLevels()
+	txt := []string{}
+	title := "---------- Store Limits ----------"
+	txt = append(txt, title)
+	txt = append(txt, fmt.Sprintf("Channels:        %s",
+		getLimitStr(true, int64(sl.MaxChannels),
+			int64(DefaultStoreLimits.MaxChannels),
+			limitCount)))
+	maxLen := len(title)
+	txt = append(txt, "--------- Channels Limits --------")
+	txt = append(txt, getGlobalLimitsPrintLines(&sl.ChannelLimits)...)
+	if len(sl.PerChannel) > 0 {
+		channels := sublist.Subjects()
+		channelLines := []string{}
+		for _, cn := range channels {
+			r := sublist.Match(cn)
+			var prev *channelLimitInfo
+			for i := 0; i < len(r); i++ {
+				channel := r[i].(*channelLimitInfo)
+				if channel.name == cn {
+					var parentLimits *ChannelLimits
+					if prev == nil {
+						parentLimits = &sl.ChannelLimits
+					} else {
+						parentLimits = prev.limits
+					}
+					channelLines = append(channelLines,
+						getChannelLimitsPrintLines(i, maxLevels, &maxLen, channel.name, channel.limits, parentLimits)...)
+					break
+				}
+				prev = channel
+			}
+		}
+		title := " List of Channels "
+		numberDashesLeft := (maxLen - len(title)) / 2
+		numberDashesRight := maxLen - len(title) - numberDashesLeft
+		title = fmt.Sprintf("%s%s%s",
+			repeatChar("-", numberDashesLeft),
+			title,
+			repeatChar("-", numberDashesRight))
+		txt = append(txt, title)
+		txt = append(txt, channelLines...)
+	}
+	txt = append(txt, repeatChar("-", maxLen))
+	return txt
+}
+
+func getLimitStr(isGlobal bool, val, parentVal int64, limitType int) string {
+	valStr := ""
+	inherited := ""
+	if !isGlobal && (val == parentVal) {
+		return ""
+	}
+	if val == parentVal {
+		inherited = " *"
+	}
+	if val == 0 {
+		valStr = "unlimited"
+	} else {
+		switch limitType {
+		case limitBytes:
+			valStr = util.FriendlyBytes(val)
+		case limitDuration:
+			valStr = fmt.Sprintf("%v", time.Duration(val))
+		default:
+			valStr = fmt.Sprintf("%v", val)
+		}
+	}
+	return fmt.Sprintf("%13s%s", valStr, inherited)
+}
+
+func getGlobalLimitsPrintLines(limits *ChannelLimits) []string {
+	defaultLimits := &DefaultStoreLimits
+	defMaxSubs := int64(defaultLimits.MaxSubscriptions)
+	defMaxMsgs := int64(defaultLimits.MaxMsgs)
+	defMaxBytes := defaultLimits.MaxBytes
+	defMaxAge := defaultLimits.MaxAge
+	txt := []string{}
+	txt = append(txt, fmt.Sprintf("  Subscriptions: %s", getLimitStr(true, int64(limits.MaxSubscriptions), defMaxSubs, limitCount)))
+	txt = append(txt, fmt.Sprintf("  Messages     : %s", getLimitStr(true, int64(limits.MaxMsgs), defMaxMsgs, limitCount)))
+	txt = append(txt, fmt.Sprintf("  Bytes        : %s", getLimitStr(true, limits.MaxBytes, defMaxBytes, limitBytes)))
+	txt = append(txt, fmt.Sprintf("  Age          : %s", getLimitStr(true, int64(limits.MaxAge), int64(defMaxAge), limitDuration)))
+	return txt
+}
+
+func getChannelLimitsPrintLines(level, maxLevels int, maxLen *int, channelName string, limits, parentLimits *ChannelLimits) []string {
+	plMaxSubs := int64(parentLimits.MaxSubscriptions)
+	plMaxMsgs := int64(parentLimits.MaxMsgs)
+	plMaxBytes := parentLimits.MaxBytes
+	plMaxAge := parentLimits.MaxAge
+	maxSubsOverride := getLimitStr(false, int64(limits.MaxSubscriptions), plMaxSubs, limitCount)
+	maxMsgsOverride := getLimitStr(false, int64(limits.MaxMsgs), plMaxMsgs, limitCount)
+	maxBytesOverride := getLimitStr(false, limits.MaxBytes, plMaxBytes, limitBytes)
+	maxAgeOverride := getLimitStr(false, int64(limits.MaxAge), int64(plMaxAge), limitDuration)
+	paddingLeft := repeatChar(" ", level)
+	paddingRight := repeatChar(" ", maxLevels-level)
+	txt := []string{}
+	txt = append(txt, fmt.Sprintf("%s%s", paddingLeft, channelName))
+	if maxSubsOverride != "" {
+		txt = append(txt, fmt.Sprintf("%s |-> Subscriptions %s%s", paddingLeft, paddingRight, maxSubsOverride))
+	}
+	if maxMsgsOverride != "" {
+		txt = append(txt, fmt.Sprintf("%s |-> Messages      %s%s", paddingLeft, paddingRight, maxMsgsOverride))
+	}
+	if maxBytesOverride != "" {
+		txt = append(txt, fmt.Sprintf("%s |-> Bytes         %s%s", paddingLeft, paddingRight, maxBytesOverride))
+	}
+	if maxAgeOverride != "" {
+		txt = append(txt, fmt.Sprintf("%s |-> Age           %s%s", paddingLeft, paddingRight, maxAgeOverride))
+	}
+	for _, l := range txt {
+		if len(l) > *maxLen {
+			*maxLen = len(l)
+		}
+	}
+	return txt
+}
+
+func repeatChar(char string, len int) string {
+	res := ""
+	for i := 0; i < len; i++ {
+		res += char
+	}
+	return res
 }

--- a/stores/limits_test.go
+++ b/stores/limits_test.go
@@ -3,14 +3,13 @@
 package stores
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 )
 
-func TestAddPerChannel(t *testing.T) {
+func TestLimitsAddPerChannel(t *testing.T) {
 	sl := testDefaultStoreLimits
 	cl := &ChannelLimits{
 		MsgStoreLimits{
@@ -35,7 +34,7 @@ func TestAddPerChannel(t *testing.T) {
 	}
 }
 
-func TestBuildErrors(t *testing.T) {
+func TestLimitsBuildErrors(t *testing.T) {
 	sl := testDefaultStoreLimits
 
 	// This function calls Build(), expects and error and check
@@ -93,41 +92,168 @@ func TestBuildErrors(t *testing.T) {
 	sl.AddPerChannel("bar", cl)
 	expectError("Too many channels")
 
-	// Reset sl
+	// Reset sl, check invalid channel names
 	sl = testDefaultStoreLimits
 	cl = &ChannelLimits{}
-	sl.AddPerChannel("foo.*", cl)
+	sl.AddPerChannel("foo.*bar", cl)
 	expectError("invalid channel name")
 
 	sl = testDefaultStoreLimits
 	cl = &ChannelLimits{}
-	sl.AddPerChannel("foo.>", cl)
+	sl.AddPerChannel("foo.**.bar", cl)
+	expectError("invalid channel name")
+
+	sl = testDefaultStoreLimits
+	cl = &ChannelLimits{}
+	sl.AddPerChannel("foo.>.bar", cl)
 	expectError("invalid channel name")
 
 	sl = testDefaultStoreLimits
 	cl = &ChannelLimits{}
 	sl.AddPerChannel("foo.", cl)
 	expectError("invalid channel name")
+
+	sl = testDefaultStoreLimits
+	cl = &ChannelLimits{}
+	sl.AddPerChannel(".foo", cl)
+	expectError("invalid channel name")
 }
 
-func TestAppliedInheritance(t *testing.T) {
+func TestLimitsPerChannelOverride(t *testing.T) {
+	sl := testDefaultStoreLimits
+
+	// This function calls Build(), expects no error.
+	expectNoError := func(channel string, expectedLimits *ChannelLimits) {
+		if err := sl.Build(); err != nil {
+			stackFatalf(t, "Unexpected error on Build: %v", err)
+		}
+		cl := sl.PerChannel[channel]
+		if !reflect.DeepEqual(*cl, *expectedLimits) {
+			stackFatalf(t, "Expected limits for %q to be %v, got %v",
+				channel, *expectedLimits, *cl)
+		}
+	}
+
+	// Check per-channel values are below global limits.
+	sl.MaxChannels = 2
+	sl.MaxMsgs = 10
+	sl.MaxBytes = 20
+	sl.MaxSubscriptions = 30
+	sl.MaxAge = time.Second
+
+	cl := &ChannelLimits{}
+	cl.MaxMsgs = 5
+	sl.AddPerChannel("foo", cl)
+	cl2 := *cl
+	cl2.MaxMsgs = 12
+	sl.AddPerChannel("bar", &cl2)
+	expectNoError("bar", &cl2)
+
+	cl = &ChannelLimits{}
+	cl.MaxBytes = 25
+	cl2 = *cl
+	cl2.MaxBytes = 18
+	sl.AddPerChannel("foo", cl)
+	sl.AddPerChannel("bar", &cl2)
+	expectNoError("foo", cl)
+
+	cl = &ChannelLimits{}
+	cl.MaxAge = time.Second
+	cl2 = *cl
+	cl2.MaxAge = time.Hour
+	sl.AddPerChannel("foo", cl)
+	sl.AddPerChannel("bar", &cl2)
+	expectNoError("bar", &cl2)
+
+	cl = &ChannelLimits{}
+	cl.MaxSubscriptions = 35
+	cl2 = *cl
+	cl2.MaxSubscriptions = 10
+	sl.AddPerChannel("foo", cl)
+	sl.AddPerChannel("bar", &cl2)
+	expectNoError("foo", cl)
+
+	sl = testDefaultStoreLimits
+	cl = &ChannelLimits{}
+	cl.MaxMsgs = 10
+	cl2 = *cl
+	cl2.MaxMsgs = 20
+	sl.AddPerChannel("foo.>", cl)
+	sl.AddPerChannel("foo.*", &cl2)
+	expectNoError("foo.*", &cl2)
+
+	sl = testDefaultStoreLimits
+	// All other limits are set by default
+	sl.MaxAge = time.Hour
+	cl = &ChannelLimits{}
+	// We override MaxSubscriptions by setting to -1
+	cl.MaxSubscriptions = -1
+	sl.AddPerChannel("foo.*", cl)
+	// Check that we get what we expect
+	// After Build, we should get foo.*'s cl be equal
+	// to this (in value). The MaxSubscriptions should have
+	// been set to 0 after inheritance is applied.
+	cl2 = sl.ChannelLimits
+	cl2.MaxSubscriptions = 0
+	expectNoError("foo.*", &cl2)
+
+	// Repeat tests with each limit
+	cl = &ChannelLimits{}
+	cl.MaxMsgs = -1
+	sl.AddPerChannel("foo.*", cl)
+	// Check that we get what we expect
+	// After Build, we should get foo.*'s cl be equal
+	// to this (in value). The MaxSubscriptions should have
+	// been set to 0 after inheritance is applied.
+	cl2 = sl.ChannelLimits
+	cl2.MaxMsgs = 0
+	expectNoError("foo.*", &cl2)
+
+	cl = &ChannelLimits{}
+	cl.MaxBytes = -1
+	sl.AddPerChannel("foo.*", cl)
+	// Check that we get what we expect
+	// After Build, we should get foo.*'s cl be equal
+	// to this (in value). The MaxSubscriptions should have
+	// been set to 0 after inheritance is applied.
+	cl2 = sl.ChannelLimits
+	cl2.MaxBytes = 0
+	expectNoError("foo.*", &cl2)
+
+	cl = &ChannelLimits{}
+	cl.MaxAge = -1
+	sl.AddPerChannel("foo.*", cl)
+	// Check that we get what we expect
+	// After Build, we should get foo.*'s cl be equal
+	// to this (in value). The MaxSubscriptions should have
+	// been set to 0 after inheritance is applied.
+	cl2 = sl.ChannelLimits
+	cl2.MaxAge = 0
+	expectNoError("foo.*", &cl2)
+}
+
+func TestLimitsInheritance(t *testing.T) {
 	sl := testDefaultStoreLimits
 	sl.MaxMsgs = 11
 	sl.MaxBytes = 12
 	sl.MaxAge = 13
 	sl.MaxSubscriptions = 14
 
-	checkPerChannel := func(maxMsgs int, maxBytes, maxAge int64, maxSubs int) {
+	addPerChannel := func(channel string, maxMsgs int, maxBytes, maxAge int64, maxSubs int) {
 		cl := &ChannelLimits{}
 		cl.MaxMsgs = maxMsgs
 		cl.MaxBytes = maxBytes
 		cl.MaxAge = time.Duration(maxAge)
 		cl.MaxSubscriptions = maxSubs
-		sl.AddPerChannel("foo", cl)
+		sl.AddPerChannel(channel, cl)
+	}
+	checkPerChannel := func(channel string, maxMsgs int, maxBytes, maxAge int64, maxSubs int) {
+		sl.PerChannel = nil
+		addPerChannel(channel, maxMsgs, maxBytes, maxAge, maxSubs)
 		if err := sl.Build(); err != nil {
 			stackFatalf(t, "Unexpected error on build: %v", err)
 		}
-		builtCl := sl.PerChannel["foo"]
+		builtCl := sl.PerChannel[channel]
 		// Make sure that values from global are used for limits that were specified as 0.
 		if maxMsgs == 0 && builtCl.MaxMsgs != sl.MaxMsgs {
 			t.Fatalf("Max messages from global limit not inherited: %v", builtCl)
@@ -142,51 +268,194 @@ func TestAppliedInheritance(t *testing.T) {
 			t.Fatalf("Max messages from global limit not inherited: %v", builtCl)
 		}
 	}
-	checkPerChannel(10, 0, 0, 0)
-	checkPerChannel(0, 10, 0, 0)
-	checkPerChannel(0, 0, 10, 0)
-	checkPerChannel(0, 0, 0, 10)
+	checkPerChannel("foo", 10, 0, 0, 0)
+	checkPerChannel("foo", 0, 10, 0, 0)
+	checkPerChannel("foo", 0, 0, 10, 0)
+	checkPerChannel("foo", 0, 0, 0, 10)
+	// Should be the same even if the channel has wildcards
+	checkPerChannel("foo.*", 10, 0, 0, 0)
+	checkPerChannel("foo.*", 0, 10, 0, 0)
+	checkPerChannel("foo.*", 0, 0, 10, 0)
+	checkPerChannel("foo.*", 0, 0, 0, 10)
+	// Check inheritance between wildcard channels.
+	// We start with global limits as:
+	//             Msgs Bytes Age Subs
+	// Global        11    12  13   14
+	//
+	// Say we have the following channels
+	//
+	//             Msgs Bytes Age Subs
+	// *.*                  2
+	// *.>                          5
+	// foo.>         10
+	// foo.*.>             20
+	// foo.*.*.>               30
+	// foo.a.b.c                    40
+	// foo.d.e.f     50        60
+	// foo.baz             70       80
+	// bar.*.>       90
+	// bar.baz.>          100
+	//
+	// After build we should have:
+	//
+	//             Msgs Bytes Age Subs
+	// *.>           11    12  13    5
+	// *.*           11     2  13    5
+	// foo.>         10     2  13    5
+	// foo.*.>       10    20  13    5
+	// foo.*.*.>     10    20  30    5
+	// foo.a.b.c     10    20  30   40
+	// foo.d.e.f     50    20  60    5
+	// foo.baz       10    70  13   80
+	// bar.*.>       90    12  13    5
+	// bar.baz.>     90   100  13    5
+	sl.PerChannel = nil
+	addPerChannel("*.*", 0, 2, 0, 0)
+	addPerChannel("*.>", 0, 0, 0, 5)
+	addPerChannel("foo.>", 10, 0, 0, 0)
+	addPerChannel("foo.*.>", 0, 20, 0, 0)
+	addPerChannel("foo.*.*.>", 0, 0, 30, 0)
+	addPerChannel("foo.a.b.c", 0, 0, 0, 40)
+	addPerChannel("foo.d.e.f", 50, 0, 60, 0)
+	addPerChannel("foo.baz", 0, 70, 0, 80)
+	addPerChannel("bar.*.>", 90, 0, 0, 0)
+	addPerChannel("bar.baz.>", 0, 100, 0, 0)
+	if err := sl.Build(); err != nil {
+		t.Fatalf("Unexpected error on build: %v", err)
+	}
+	checkChannel := func(channel string, maxMsgs int, maxBytes, maxAge int64, maxSubs int) {
+		expectedLimit := &ChannelLimits{}
+		expectedLimit.MaxMsgs = maxMsgs
+		expectedLimit.MaxBytes = maxBytes
+		expectedLimit.MaxAge = time.Duration(maxAge)
+		expectedLimit.MaxSubscriptions = maxSubs
+		builtCl := sl.PerChannel[channel]
+		if !reflect.DeepEqual(*builtCl, *expectedLimit) {
+			stackFatalf(t, "Expected limits for %q to be %v, got %v",
+				channel, *expectedLimit, *builtCl)
+		}
+	}
+	checkChannel("*.>", 11, 12, 13, 5)
+	checkChannel("*.*", 11, 2, 13, 5)
+	checkChannel("foo.>", 10, 2, 13, 5)
+	checkChannel("foo.*.>", 10, 20, 13, 5)
+	checkChannel("foo.*.*.>", 10, 20, 30, 5)
+	checkChannel("foo.a.b.c", 10, 20, 30, 40)
+	checkChannel("foo.d.e.f", 50, 20, 60, 5)
+	checkChannel("foo.baz", 10, 70, 13, 80)
+	checkChannel("bar.*.>", 90, 12, 13, 5)
+	checkChannel("bar.baz.>", 90, 100, 13, 5)
 }
 
-func TestLimitsUnlimited(t *testing.T) {
-	sl := &StoreLimits{}
-	// All global are unlimited. We should be able to set any other
-	// value for a Per-Channel limit
+func TestLimitsWildcardsDontCountForMaxChannels(t *testing.T) {
+	sl := testDefaultStoreLimits
+	sl.MaxChannels = 2
+
+	sl.AddPerChannel("foo.>", &ChannelLimits{})
+	sl.AddPerChannel("foo.*", &ChannelLimits{})
+	sl.AddPerChannel("foo.bar.*", &ChannelLimits{})
+	if err := sl.Build(); err != nil {
+		t.Fatalf("Should be ok to get more wildcard channels than MaxChannels: %v", err)
+	}
+
+	sl = testDefaultStoreLimits
+	sl.MaxChannels = 2
+	sl.AddPerChannel("foo.>", &ChannelLimits{})
+	sl.AddPerChannel("foo.*", &ChannelLimits{})
+	sl.AddPerChannel("foo.bar.*", &ChannelLimits{})
+	sl.AddPerChannel("foo.bar", &ChannelLimits{})
+	sl.AddPerChannel("foo.baz", &ChannelLimits{})
+	if err := sl.Build(); err != nil {
+		t.Fatalf("Should be ok to get more wildcard channels than MaxChannels: %v", err)
+	}
+
+	sl = testDefaultStoreLimits
+	sl.MaxChannels = 2
+	sl.AddPerChannel("foo.>", &ChannelLimits{})
+	sl.AddPerChannel("foo.*", &ChannelLimits{})
+	sl.AddPerChannel("foo.bar.*", &ChannelLimits{})
+	sl.AddPerChannel("foo.bar", &ChannelLimits{})
+	sl.AddPerChannel("foo.baz", &ChannelLimits{})
+	sl.AddPerChannel("foo", &ChannelLimits{})
+	if err := sl.Build(); err == nil {
+		t.Fatal("Should have failed due to too many channels")
+	}
+}
+
+func TestLimitsPrint(t *testing.T) {
+	sl := testDefaultStoreLimits
+	sl.AddPerChannel(">", &ChannelLimits{MsgStoreLimits: MsgStoreLimits{MaxMsgs: 10}})
+	sl.AddPerChannel("foo.>", &ChannelLimits{MsgStoreLimits: MsgStoreLimits{MaxBytes: 1024}})
+	sl.AddPerChannel("foo.bar.>", &ChannelLimits{MsgStoreLimits: MsgStoreLimits{MaxAge: time.Second}})
+	sl.AddPerChannel("foo.bar.baz.>", &ChannelLimits{SubStoreLimits: SubStoreLimits{MaxSubscriptions: 20}})
+	sl.AddPerChannel("bar", &ChannelLimits{SubStoreLimits: SubStoreLimits{MaxSubscriptions: 30}})
+	if err := sl.Build(); err != nil {
+		t.Fatalf("Error on build: %v", err)
+	}
+	lines := sl.Print()
+	ok := 0
+	for i := 0; i < len(lines); i++ {
+		l := lines[i]
+		if l == ">" {
+			if lines[i+1] != " |-> Messages                     10" {
+				t.Fatalf("Unexpected content for %v", l)
+			}
+			i++
+			ok++
+		} else if l == " bar" {
+			if lines[i+1] != "  |-> Subscriptions               30" {
+				t.Fatalf("Unexpected content for %v", l)
+			}
+			i++
+			ok++
+		} else if l == " foo.>" {
+			if lines[i+1] != "  |-> Bytes                  1.00 KB" ||
+				lines[i+2] != "  foo.bar.>" ||
+				lines[i+3] != "   |-> Age                        1s" ||
+				lines[i+4] != "   foo.bar.baz.>" ||
+				lines[i+5] != "    |-> Subscriptions             20" {
+				t.Fatalf("Unexpected content for %v", l)
+			}
+			i += 5
+			ok++
+		}
+	}
+	if ok != 3 {
+		t.Fatalf("Output not as expected")
+	}
+}
+
+func TestLimitsClone(t *testing.T) {
+	slo := testDefaultStoreLimits
+	sl := &slo
 	cl := &ChannelLimits{}
-	cl.MaxMsgs = 1000000
-	cl.MaxBytes = int64(cl.MaxMsgs * 1024)
-	cl.MaxSubscriptions = 1000000
-	cl.MaxAge = time.Duration(1000000) * time.Hour
-	// Add 10 channels
-	for i := 0; i < 10; i++ {
-		sl.AddPerChannel(fmt.Sprintf("foo.%d", i), cl)
-	}
-	if err := sl.Build(); err != nil {
-		t.Fatalf("Unexpected error on build: %v", err)
-	}
-	// Use non unlimited global limits, check that we can have
-	// unlimited values for per-channel
-	sl = &StoreLimits{}
-	sl.MaxChannels = 1000
-	sl.MaxMsgs = 1
-	sl.MaxBytes = 1
-	sl.MaxAge = 1
-	sl.MaxSubscriptions = 1
-	// Set all limit for this channel to -1
-	cl = &ChannelLimits{}
-	cl.MaxMsgs = -1
-	cl.MaxBytes = -1
-	cl.MaxAge = -1
-	cl.MaxSubscriptions = -1
+	cl.MaxMsgs = 100
+	cl.MaxSubscriptions = 20
 	sl.AddPerChannel("foo", cl)
-	if err := sl.Build(); err != nil {
-		t.Fatalf("Unexpected error on build: %v", err)
+
+	clone := sl.Clone()
+	if !reflect.DeepEqual(*clone, *sl) {
+		t.Fatalf("Expected %v, got %v", sl, *clone)
 	}
-	builtCl := sl.PerChannel["foo"]
-	// the result should be that all values are set to 0.
-	// So compare with this empty structure
-	expected := ChannelLimits{}
-	if !reflect.DeepEqual(*builtCl, expected) {
-		t.Fatalf("Expected limits to be %v, got %v", expected, *builtCl)
+	// Change the original
+	cl.MaxMsgs = 200
+	// They should now be different
+	if reflect.DeepEqual(*clone, *sl) {
+		t.Fatal("Expected clone and original to now be different")
+	}
+	sl.AddPerChannel("foo", cl)
+	if reflect.DeepEqual(*clone, *sl) {
+		t.Fatal("Expected clone and original to now be different")
+	}
+	// Get a clone again
+	clone = sl.Clone()
+	if !reflect.DeepEqual(*clone, *sl) {
+		t.Fatalf("Expected %v, got %v", sl, *clone)
+	}
+	// Change one of the global properties
+	sl.MaxBytes = 100
+	// They should now be different
+	if reflect.DeepEqual(*clone, *sl) {
+		t.Fatal("Expected clone and original to now be different")
 	}
 }

--- a/stores/memstore.go
+++ b/stores/memstore.go
@@ -58,22 +58,13 @@ func (ms *MemoryStore) CreateChannel(channel string, userData interface{}) (*Cha
 		return nil, false, err
 	}
 
-	// Defaults to the global limits
-	msgStoreLimits := ms.limits.MsgStoreLimits
-	subStoreLimits := ms.limits.SubStoreLimits
-	// See if there is an override
-	thisChannelLimits, exists := ms.limits.PerChannel[channel]
-	if exists {
-		// Use this channel specific limits
-		msgStoreLimits = thisChannelLimits.MsgStoreLimits
-		subStoreLimits = thisChannelLimits.SubStoreLimits
-	}
+	channelLimits := ms.genericStore.getChannelLimits(channel)
 
 	msgStore := &MemoryMsgStore{msgs: make(map[uint64]*pb.MsgProto, 64)}
-	msgStore.init(channel, &msgStoreLimits)
+	msgStore.init(channel, &channelLimits.MsgStoreLimits)
 
 	subStore := &MemorySubStore{}
-	subStore.init(channel, &subStoreLimits)
+	subStore.init(channel, &channelLimits.SubStoreLimits)
 
 	channelStore = &ChannelStore{
 		Subs:     subStore,

--- a/stores/memstore_test.go
+++ b/stores/memstore_test.go
@@ -55,8 +55,8 @@ func TestMSUseDefaultLimits(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	defer ms.Close()
-	if !reflect.DeepEqual(ms.limits, DefaultStoreLimits) {
-		t.Fatalf("Default limits are not used: %v\n", ms.limits)
+	if !reflect.DeepEqual(*ms.limits, DefaultStoreLimits) {
+		t.Fatalf("Default limits are not used: %v\n", *ms.limits)
 	}
 }
 
@@ -260,4 +260,10 @@ func TestMSNegativeLimits(t *testing.T) {
 	defer ms.Close()
 
 	testNegativeLimit(t, ms)
+}
+
+func TestMSLimitWithWildcardsInConfig(t *testing.T) {
+	ms := createDefaultMemStore(t)
+	defer ms.Close()
+	testLimitWithWildcardsInConfig(t, ms)
 }

--- a/test/configs/test_parse.conf
+++ b/test/configs/test_parse.conf
@@ -11,6 +11,7 @@ hb_timeout: "1s"
 hb_fail_count: 2
 ack_subs_pool_size: 3
 ft_group: "ft"
+partitioning: true
 
 store_limits: {
     max_channels: 11

--- a/util/sublist.go
+++ b/util/sublist.go
@@ -1,0 +1,510 @@
+// Copyright 2017 Apcera Inc. All rights reserved.
+
+package util
+
+import (
+	"errors"
+	"sync"
+)
+
+// This is taken from NATS Server's sublist and modified to use
+// an interface{} instead of a *subscription which is relevant
+// only in NATS Server.
+
+// Common byte variables for wildcards and token separator.
+const (
+	pwc   = '*'
+	spwc  = "*"
+	fwc   = '>'
+	sfwc  = ">"
+	tsep  = "."
+	btsep = '.'
+)
+
+// cacheMax is used to bound limit the frontend cache
+const slCacheMax = 1024
+
+// Sublist related errors
+var (
+	ErrInvalidSubject = errors.New("sublist: invalid subject")
+	ErrNotFound       = errors.New("sublist: no match found")
+)
+
+// A Sublist stores and efficiently retrieves subscriptions.
+type Sublist struct {
+	sync.RWMutex
+	root  *level
+	cache map[string][]interface{}
+	count uint32
+}
+
+// A node contains subscriptions and a pointer to the next level.
+type node struct {
+	next     *level
+	elements []interface{}
+}
+
+// A level represents a group of nodes and special pointers to
+// wildcard nodes.
+type level struct {
+	nodes    map[string]*node
+	pwc, fwc *node
+}
+
+// Create a new default node.
+func newNode() *node {
+	return &node{elements: make([]interface{}, 0, 4)}
+}
+
+// Create a new default level.
+func newLevel() *level {
+	return &level{nodes: make(map[string]*node)}
+}
+
+// NewSublist creates a default sublist
+func NewSublist() *Sublist {
+	return &Sublist{root: newLevel(), cache: make(map[string][]interface{})}
+}
+
+// Insert adds a subscription into the sublist
+func (s *Sublist) Insert(subject string, element interface{}) error {
+	tsa := [32]string{}
+	tokens := tsa[:0]
+	start := 0
+	for i := 0; i < len(subject); i++ {
+		if subject[i] == btsep {
+			tokens = append(tokens, subject[start:i])
+			start = i + 1
+		}
+	}
+	tokens = append(tokens, subject[start:])
+
+	s.Lock()
+
+	sfwc := false
+	l := s.root
+	var n *node
+
+	for _, t := range tokens {
+		if len(t) == 0 || sfwc {
+			s.Unlock()
+			return ErrInvalidSubject
+		}
+
+		switch t[0] {
+		case pwc:
+			n = l.pwc
+		case fwc:
+			n = l.fwc
+			sfwc = true
+		default:
+			n = l.nodes[t]
+		}
+		if n == nil {
+			n = newNode()
+			switch t[0] {
+			case pwc:
+				l.pwc = n
+			case fwc:
+				l.fwc = n
+			default:
+				l.nodes[t] = n
+			}
+		}
+		if n.next == nil {
+			n.next = newLevel()
+		}
+		l = n.next
+	}
+	n.elements = append(n.elements, element)
+	s.addToCache(subject, element)
+	s.count++
+	s.Unlock()
+	return nil
+}
+
+// addToCache will add the new entry to existing cache
+// entries if needed. Assumes write lock is held.
+func (s *Sublist) addToCache(subject string, element interface{}) {
+	for k, r := range s.cache {
+		if matchLiteral(k, subject) {
+			// Copy since others may have a reference.
+			nr := append([]interface{}(nil), r...)
+			nr = append(nr, element)
+			s.cache[k] = nr
+		}
+	}
+}
+
+// removeFromCache will remove any active cache entries on that subject.
+// Assumes write lock is held.
+func (s *Sublist) removeFromCache(subject string) {
+	for k := range s.cache {
+		if !matchLiteral(k, subject) {
+			continue
+		}
+		// Since someone else may be referencing, can't modify the list
+		// safely, just let it re-populate.
+		delete(s.cache, k)
+	}
+}
+
+// Match will match all entries to the literal subject.
+// It will return a set of results.
+func (s *Sublist) Match(subject string) []interface{} {
+	s.RLock()
+	rc, ok := s.cache[subject]
+	s.RUnlock()
+	if ok {
+		return rc
+	}
+
+	tsa := [32]string{}
+	tokens := tsa[:0]
+	start := 0
+	for i := 0; i < len(subject); i++ {
+		if subject[i] == btsep {
+			tokens = append(tokens, subject[start:i])
+			start = i + 1
+		}
+	}
+	tokens = append(tokens, subject[start:])
+	result := make([]interface{}, 0, 4)
+
+	s.Lock()
+	matchLevel(s.root, tokens, &result)
+
+	// Add to our cache
+	s.cache[subject] = result
+	// Bound the number of entries to sublistMaxCache
+	if len(s.cache) > slCacheMax {
+		for k := range s.cache {
+			delete(s.cache, k)
+			break
+		}
+	}
+	s.Unlock()
+
+	return result
+}
+
+// matchLevel is used to recursively descend into the trie.
+func matchLevel(l *level, toks []string, results *[]interface{}) {
+	var pwc, n *node
+	for i, t := range toks {
+		if l == nil {
+			return
+		}
+		if l.fwc != nil {
+			*results = append(*results, l.fwc.elements...)
+		}
+		if pwc = l.pwc; pwc != nil {
+			matchLevel(pwc.next, toks[i+1:], results)
+		}
+		n = l.nodes[t]
+		if n != nil {
+			l = n.next
+		} else {
+			l = nil
+		}
+	}
+	if pwc != nil {
+		*results = append(*results, pwc.elements...)
+	}
+	if n != nil {
+		*results = append(*results, n.elements...)
+	}
+}
+
+// lnt is used to track descent into levels for a removal for pruning.
+type lnt struct {
+	l *level
+	n *node
+	t string
+}
+
+// Remove will remove an element from the sublist.
+func (s *Sublist) Remove(subject string, element interface{}) error {
+	tsa := [32]string{}
+	tokens := tsa[:0]
+	start := 0
+	for i := 0; i < len(subject); i++ {
+		if subject[i] == btsep {
+			tokens = append(tokens, subject[start:i])
+			start = i + 1
+		}
+	}
+	tokens = append(tokens, subject[start:])
+
+	s.Lock()
+	defer s.Unlock()
+
+	sfwc := false
+	l := s.root
+	var n *node
+
+	// Track levels for pruning
+	var lnts [32]lnt
+	levels := lnts[:0]
+
+	for _, t := range tokens {
+		if len(t) == 0 || sfwc {
+			return ErrInvalidSubject
+		}
+		if l == nil {
+			return ErrNotFound
+		}
+		switch t[0] {
+		case pwc:
+			n = l.pwc
+		case fwc:
+			n = l.fwc
+			sfwc = true
+		default:
+			n = l.nodes[t]
+		}
+		if n != nil {
+			levels = append(levels, lnt{l, n, t})
+			l = n.next
+		} else {
+			l = nil
+		}
+	}
+	if !s.removeFromNode(n, element) {
+		return ErrNotFound
+	}
+	s.count--
+	for i := len(levels) - 1; i >= 0; i-- {
+		l, n, t := levels[i].l, levels[i].n, levels[i].t
+		if n.isEmpty() {
+			l.pruneNode(n, t)
+		}
+	}
+	s.removeFromCache(subject)
+	return nil
+}
+
+// pruneNode is used to prune an empty node from the tree.
+func (l *level) pruneNode(n *node, t string) {
+	if n == nil {
+		return
+	}
+	if n == l.fwc {
+		l.fwc = nil
+	} else if n == l.pwc {
+		l.pwc = nil
+	} else {
+		delete(l.nodes, t)
+	}
+}
+
+// isEmpty will test if the node has any entries. Used
+// in pruning.
+func (n *node) isEmpty() bool {
+	if len(n.elements) == 0 {
+		if n.next == nil || n.next.numNodes() == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// Return the number of nodes for the given level.
+func (l *level) numNodes() int {
+	num := len(l.nodes)
+	if l.pwc != nil {
+		num++
+	}
+	if l.fwc != nil {
+		num++
+	}
+	return num
+}
+
+// Removes an element from a list.
+func removeFromList(element interface{}, l []interface{}) ([]interface{}, bool) {
+	for i := 0; i < len(l); i++ {
+		if l[i] == element {
+			last := len(l) - 1
+			l[i] = l[last]
+			l[last] = nil
+			l = l[:last]
+			return shrinkAsNeeded(l), true
+		}
+	}
+	return l, false
+}
+
+// Remove the sub for the given node.
+func (s *Sublist) removeFromNode(n *node, element interface{}) (found bool) {
+	if n == nil {
+		return false
+	}
+	n.elements, found = removeFromList(element, n.elements)
+	return found
+}
+
+// Checks if we need to do a resize. This is for very large growth then
+// subsequent return to a more normal size from unsubscribe.
+func shrinkAsNeeded(l []interface{}) []interface{} {
+	ll := len(l)
+	cl := cap(l)
+	// Don't bother if list not too big
+	if cl <= 8 {
+		return l
+	}
+	pFree := float32(cl-ll) / float32(cl)
+	if pFree > 0.50 {
+		return append([]interface{}(nil), l...)
+	}
+	return l
+}
+
+// Count returns the number of subscriptions.
+func (s *Sublist) Count() uint32 {
+	s.RLock()
+	defer s.RUnlock()
+	return s.count
+}
+
+// CacheCount returns the number of result sets in the cache.
+func (s *Sublist) CacheCount() int {
+	s.RLock()
+	defer s.RUnlock()
+	return len(s.cache)
+}
+
+// matchLiteral is used to test literal subjects, those that do not have any
+// wildcards, with a target subject. This is used in the cache layer.
+func matchLiteral(literal, subject string) bool {
+	li := 0
+	ll := len(literal)
+	for i := 0; i < len(subject); i++ {
+		if li >= ll {
+			return false
+		}
+		b := subject[i]
+		switch b {
+		case pwc:
+			// Skip token in literal
+			ll := len(literal)
+			for {
+				if li >= ll || literal[li] == btsep {
+					li--
+					break
+				}
+				li++
+			}
+		case fwc:
+			return true
+		default:
+			if b != literal[li] {
+				return false
+			}
+		}
+		li++
+	}
+	// Make sure we have processed all of the literal's chars..
+	return li >= ll
+}
+
+// NumLevels returns the maximum number of levels in the sublist.
+func (s *Sublist) NumLevels() int {
+	return visitLevel(s.root, 0)
+}
+
+// visitLevel is used to descend the Sublist tree structure
+// recursively.
+func visitLevel(l *level, depth int) int {
+	if l == nil || l.numNodes() == 0 {
+		return depth
+	}
+
+	depth++
+	maxDepth := depth
+
+	for _, n := range l.nodes {
+		if n == nil {
+			continue
+		}
+		newDepth := visitLevel(n.next, depth)
+		if newDepth > maxDepth {
+			maxDepth = newDepth
+		}
+	}
+	if l.pwc != nil {
+		pwcDepth := visitLevel(l.pwc.next, depth)
+		if pwcDepth > maxDepth {
+			maxDepth = pwcDepth
+		}
+	}
+	if l.fwc != nil {
+		fwcDepth := visitLevel(l.fwc.next, depth)
+		if fwcDepth > maxDepth {
+			maxDepth = fwcDepth
+		}
+	}
+	return maxDepth
+}
+
+// Subjects returns an array of all subjects in this sublist
+// ordered from the widest to the narrowest of subjects.
+// Order between non wildcard tokens in a given level is
+// random though.
+//
+// For instance, if the sublist contains (in any inserted order):
+//
+// *.*, foo.>, *.>, foo.*.>, >, bar.>, foo.bar.>, bar.baz
+//
+// the returned array will be one of the two possibilities:
+//
+// >, *.>, *.*, foo.>, foo.*.>, foo.bar.>, bar.>, bar.baz
+//
+// or
+//
+// >, *.>, *.*, bar.>, bar.baz, foo.>, foo.*.>, foo.bar.>
+//
+// For a given level, the order will still always be from
+// wider to narrower, that is, foo.> comes before foo.*.>
+// which comes before foo.bar.>, and bar.> always comes
+// before bar.baz, but all the "bar" subjects may be
+// before or after all the "foo" subjects.
+func (s *Sublist) Subjects() []string {
+	s.RLock()
+	defer s.RUnlock()
+	subjects := make([]string, 0, s.count)
+	getSubjects(s.root, "", &subjects)
+	return subjects
+}
+
+func getSubjects(l *level, subject string, res *[]string) {
+	if l == nil || l.numNodes() == 0 {
+		*res = append(*res, subject)
+		return
+	}
+	var fs string
+	if l.fwc != nil {
+		if subject != "" {
+			fs = subject + tsep + sfwc
+		} else {
+			fs = sfwc
+		}
+		getSubjects(l.fwc.next, fs, res)
+	}
+	if l.pwc != nil {
+		if subject != "" {
+			fs = subject + tsep + spwc
+		} else {
+			fs = spwc
+		}
+		getSubjects(l.pwc.next, fs, res)
+	}
+	for s, n := range l.nodes {
+		if subject != "" {
+			fs = subject + tsep + s
+		} else {
+			fs = s
+		}
+		getSubjects(n.next, fs, res)
+	}
+}

--- a/util/sublist_test.go
+++ b/util/sublist_test.go
@@ -1,0 +1,397 @@
+// Copyright 2017 Apcera Inc. All rights reserved.
+
+package util
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// This is taken from NATS Server's sublist tests and adapted
+// to the generic implementation.
+
+func verifyCount(s *Sublist, count uint32, t *testing.T) {
+	if s.Count() != count {
+		stackFatalf(t, "Count is %d, should be %d", s.Count(), count)
+	}
+}
+
+func verifyLen(r []interface{}, l int, t *testing.T) {
+	if len(r) != l {
+		stackFatalf(t, "Results len is %d, should be %d", len(r), l)
+	}
+}
+
+func verifyMember(r []interface{}, val interface{}, t *testing.T) {
+	for _, v := range r {
+		if v == nil {
+			continue
+		}
+		if v == val {
+			return
+		}
+	}
+	stackFatalf(t, "Value '%+v' not found in results", val)
+}
+
+func verifyNumLevels(s *Sublist, expected int, t *testing.T) {
+	dl := s.NumLevels()
+	if dl != expected {
+		stackFatalf(t, "NumLevels is %d, should be %d", dl, expected)
+	}
+}
+
+func checkOrder(t *testing.T, r []interface{}, expectedVals ...interface{}) {
+	if len(expectedVals) != len(r) {
+		stackFatalf(t, "Expected %v values, got %v", len(expectedVals), len(r))
+	}
+	for i := 0; i < len(r); i++ {
+		if !reflect.DeepEqual(r[i], expectedVals[i]) {
+			stackFatalf(t, "Expected %v, got %v", expectedVals, r)
+		}
+	}
+}
+
+func TestSublistInit(t *testing.T) {
+	s := NewSublist()
+	verifyCount(s, 0, t)
+}
+
+func TestSublistInsertCount(t *testing.T) {
+	s := NewSublist()
+	s.Insert("foo", "fooval")
+	s.Insert("bar", "barval")
+	s.Insert("foo.bar", "foobarval")
+	verifyCount(s, 3, t)
+}
+
+func TestSublistSimple(t *testing.T) {
+	s := NewSublist()
+	subject := "foo"
+	val := "foo value"
+	s.Insert(subject, val)
+	verifyCount(s, 1, t)
+	r := s.Match(subject)
+	verifyLen(r, 1, t)
+	verifyMember(r, val, t)
+}
+
+func TestSublistSimpleMultiTokens(t *testing.T) {
+	s := NewSublist()
+	subject := "foo.bar.baz"
+	val := "value"
+	s.Insert(subject, val)
+	r := s.Match(subject)
+	verifyLen(r, 1, t)
+	verifyMember(r, val, t)
+}
+
+func TestSublistPartialWildcard(t *testing.T) {
+	s := NewSublist()
+	literalSubj := "a.b.c"
+	val1 := "val1"
+	wildcardSubj := "a.*.c"
+	val2 := "val2"
+	s.Insert(literalSubj, val1)
+	s.Insert(wildcardSubj, val2)
+	r := s.Match(literalSubj)
+	checkOrder(t, r, val2, val1)
+}
+
+func TestSublistPartialWildcardAtEnd(t *testing.T) {
+	s := NewSublist()
+	literalSubj := "a.b.c"
+	val1 := "val1"
+	wildcardSubj := "a.b.*"
+	val2 := "val2"
+	s.Insert(literalSubj, val1)
+	s.Insert(wildcardSubj, val2)
+	r := s.Match("a.b.c")
+	checkOrder(t, r, val2, val1)
+}
+
+func TestSublistFullWildcard(t *testing.T) {
+	s := NewSublist()
+	literalSubj := "a.b.c"
+	val1 := "val1"
+	wildcardSubj := "a.>"
+	val2 := "val2"
+	s.Insert(literalSubj, val1)
+	s.Insert(wildcardSubj, val2)
+	r := s.Match("a.b.c")
+	checkOrder(t, r, val2, val1)
+}
+
+func TestSublistRemove(t *testing.T) {
+	s := NewSublist()
+	subject := "a.b.c.d"
+	val1 := "val1"
+	s.Insert(subject, val1)
+	verifyCount(s, 1, t)
+	r := s.Match(subject)
+	verifyLen(r, 1, t)
+	val2 := "val2"
+	s.Remove(subject, val2)
+	verifyCount(s, 1, t)
+	s.Remove(subject, val1)
+	verifyCount(s, 0, t)
+	r = s.Match(subject)
+	verifyLen(r, 0, t)
+}
+
+func TestSublistRemoveWildcard(t *testing.T) {
+	s := NewSublist()
+	subj1 := "a.b.c.d"
+	val1 := "val1"
+	subj2 := "a.b.*.d"
+	val2 := "val2"
+	subj3 := "a.b.>"
+	val3 := "val3"
+	s.Insert(subj1, val1)
+	s.Insert(subj2, val2)
+	s.Insert(subj3, val3)
+	verifyCount(s, 3, t)
+	r := s.Match(subj1)
+	verifyLen(r, 3, t)
+	s.Remove(subj1, val1)
+	verifyCount(s, 2, t)
+	s.Remove(subj3, val3)
+	verifyCount(s, 1, t)
+	s.Remove(subj2, val2)
+	verifyCount(s, 0, t)
+	r = s.Match(subj1)
+	verifyLen(r, 0, t)
+}
+
+func TestSublistRemoveCleanup(t *testing.T) {
+	s := NewSublist()
+	literal := "a.b.c.d.e.f"
+	depth := len(strings.Split(literal, tsep))
+	val := "val"
+	verifyNumLevels(s, 0, t)
+	s.Insert(literal, val)
+	verifyNumLevels(s, depth, t)
+	s.Remove(literal, val)
+	verifyNumLevels(s, 0, t)
+}
+
+func TestSublistRemoveCleanupWildcards(t *testing.T) {
+	s := NewSublist()
+	subject := "a.b.*.d.e.>"
+	depth := len(strings.Split(subject, tsep))
+	val := "val"
+	verifyNumLevels(s, 0, t)
+	s.Insert(subject, val)
+	verifyNumLevels(s, depth, t)
+	s.Remove(subject, val)
+	verifyNumLevels(s, 0, t)
+}
+
+func TestSublistInvalidSubjectsInsert(t *testing.T) {
+	s := NewSublist()
+
+	// Insert can have wildcards, but not empty tokens,
+	// and can not have a FWC that is not the terminal token.
+
+	val := "val"
+	// beginning empty token
+	if err := s.Insert(".foo", val); err != ErrInvalidSubject {
+		t.Fatal("Expected invalid subject error")
+	}
+
+	// trailing empty token
+	if err := s.Insert("foo.", val); err != ErrInvalidSubject {
+		t.Fatal("Expected invalid subject error")
+	}
+	// empty middle token
+	if err := s.Insert("foo..bar", val); err != ErrInvalidSubject {
+		t.Fatal("Expected invalid subject error")
+	}
+	// empty middle token #2
+	if err := s.Insert("foo.bar..baz", val); err != ErrInvalidSubject {
+		t.Fatal("Expected invalid subject error")
+	}
+	// fwc not terminal
+	if err := s.Insert("foo.>.bar", val); err != ErrInvalidSubject {
+		t.Fatal("Expected invalid subject error")
+	}
+}
+
+func TestSublistCache(t *testing.T) {
+	s := NewSublist()
+
+	// Test add a remove logistics
+	lsub := "a.b.c.d"
+	lsubVal := "val1"
+	psub := "a.b.*.d"
+	psubVal := "val2"
+	fsub := "a.b.>"
+	fsubVal := "val3"
+	s.Insert(lsub, lsubVal)
+	r := s.Match(lsub)
+	verifyLen(r, 1, t)
+	s.Insert(psub, psubVal)
+	s.Insert(fsub, fsubVal)
+	verifyCount(s, 3, t)
+	r = s.Match(lsub)
+	verifyLen(r, 3, t)
+	s.Remove(lsub, lsubVal)
+	verifyCount(s, 2, t)
+	s.Remove(fsub, fsubVal)
+	verifyCount(s, 1, t)
+	s.Remove(psub, psubVal)
+	verifyCount(s, 0, t)
+
+	// Check that cache is now empty
+	if cc := s.CacheCount(); cc != 0 {
+		t.Fatalf("Cache should be zero, got %d\n", cc)
+	}
+
+	r = s.Match(lsub)
+	verifyLen(r, 0, t)
+
+	for i := 0; i < 2*slCacheMax; i++ {
+		s.Match(fmt.Sprintf("foo-%d\n", i))
+	}
+
+	if cc := s.CacheCount(); cc > slCacheMax {
+		t.Fatalf("Cache should be constrained by cacheMax, got %d for current count\n", cc)
+	}
+}
+
+func checkBool(b, expected bool, t *testing.T) {
+	if b != expected {
+		stackFatalf(t, "Expected %v, but got %v\n", expected, b)
+	}
+}
+
+func TestSublistMatchLiterals(t *testing.T) {
+	checkBool(matchLiteral("foo", "foo"), true, t)
+	checkBool(matchLiteral("foo", "bar"), false, t)
+	checkBool(matchLiteral("foo", "*"), true, t)
+	checkBool(matchLiteral("foo", ">"), true, t)
+	checkBool(matchLiteral("foo.bar", ">"), true, t)
+	checkBool(matchLiteral("foo.bar", "foo.>"), true, t)
+	checkBool(matchLiteral("foo.bar", "bar.>"), false, t)
+	checkBool(matchLiteral("stats.test.22", "stats.>"), true, t)
+	checkBool(matchLiteral("stats.test.22", "stats.*.*"), true, t)
+	checkBool(matchLiteral("foo.bar", "foo"), false, t)
+	checkBool(matchLiteral("stats.test.foos", "stats.test.foos"), true, t)
+	checkBool(matchLiteral("stats.test.foos", "stats.test.foo"), false, t)
+}
+
+func TestSublistBadSubjectOnRemove(t *testing.T) {
+	bad := "a.b..d"
+	val := "bad"
+
+	s := NewSublist()
+	if err := s.Insert(bad, val); err != ErrInvalidSubject {
+		t.Fatalf("Expected ErrInvalidSubject, got %v\n", err)
+	}
+
+	if err := s.Remove(bad, val); err != ErrInvalidSubject {
+		t.Fatalf("Expected ErrInvalidSubject, got %v\n", err)
+	}
+
+	badfwc := "a.>.b"
+	if err := s.Remove(badfwc, val); err != ErrInvalidSubject {
+		t.Fatalf("Expected ErrInvalidSubject, got %v\n", err)
+	}
+}
+
+func TestSublistTwoTokenDontMatchSingleToken(t *testing.T) {
+	s := NewSublist()
+	val := "val"
+	s.Insert("foo", val)
+	r := s.Match("foo")
+	verifyLen(r, 1, t)
+	verifyMember(r, val, t)
+	r = s.Match("foo.bar")
+	verifyLen(r, 0, t)
+}
+
+func TestSublistStoreSameValue(t *testing.T) {
+	s := NewSublist()
+	val := "val"
+	lsub1 := "foo"
+	lsub2 := "bar"
+	s.Insert(lsub1, val)
+	s.Insert(lsub2, val)
+	verifyCount(s, 2, t)
+	r := s.Match(lsub1)
+	verifyLen(r, 1, t)
+	verifyMember(r, val, t)
+	r = s.Match(lsub2)
+	verifyLen(r, 1, t)
+	verifyMember(r, val, t)
+	s.Remove(lsub2, val)
+	verifyCount(s, 1, t)
+	r = s.Match(lsub1)
+	verifyLen(r, 1, t)
+	verifyMember(r, val, t)
+	r = s.Match(lsub2)
+	verifyLen(r, 0, t)
+	s.Insert(lsub1, val)
+	verifyCount(s, 2, t)
+	r = s.Match(lsub1)
+	verifyLen(r, 2, t)
+	for _, v := range r {
+		if v != val {
+			t.Fatalf("Unexpected value: %v", v)
+		}
+	}
+}
+
+func TestSublistShrink(t *testing.T) {
+	s := NewSublist()
+	for i := 0; i < 10; i++ {
+		s.Insert("foo", 1)
+	}
+	verifyCount(s, 10, t)
+	s.RLock()
+	capacity := cap(s.root.nodes["foo"].elements)
+	s.RUnlock()
+	if capacity < 10 {
+		t.Fatalf("Capacity should be at least 10, got %v", capacity)
+	}
+	for i := 0; i < 9; i++ {
+		s.Remove("foo", 1)
+	}
+	verifyCount(s, 1, t)
+	s.RLock()
+	newCapacity := cap(s.root.nodes["foo"].elements)
+	s.RUnlock()
+	if newCapacity >= capacity {
+		t.Fatalf("Capacity should have decreased, got %v", newCapacity)
+	}
+}
+
+func TestSublistSubjects(t *testing.T) {
+	subjects := []string{"*.*", "foo.>", "*.>", ">", "foo.*.>", "bar.>", "foo.bar.>", "bar.baz"}
+	pOne := []string{">", "*.>", "*.*", "foo.>", "foo.*.>", "foo.bar.>", "bar.>", "bar.baz"}
+	pTwo := []string{">", "*.>", "*.*", "bar.>", "bar.baz", "foo.>", "foo.*.>", "foo.bar.>"}
+
+	for i := 0; i < 1000; i++ {
+		randomized := rand.Perm(len(subjects))
+		randSubjects := make([]string, len(subjects))
+		for j := 0; j < len(subjects); j++ {
+			randSubjects[j] = subjects[randomized[j]]
+		}
+		s := NewSublist()
+		for _, subj := range randSubjects {
+			if err := s.Insert(subj, subj); err != nil {
+				t.Fatalf("Error inserting in sublist: %v", err)
+			}
+		}
+		r := s.Subjects()
+		if len(r) != len(subjects) {
+			t.Fatalf("Expected Subjects to return %v subjects, got %v", len(subjects), len(r))
+		}
+		if !reflect.DeepEqual(r, pOne) && !reflect.DeepEqual(r, pTwo) {
+			t.Fatalf("Result expected to be either %v or %v, got %v", pOne, pTwo, r)
+		}
+	}
+}


### PR DESCRIPTION
This feature allows to have multiple server instances on the
same cluster ID but each instance handling a list of channels.
A given channel must not be defined on more than one instance.
Servers on the same cluster ID try to ensure that this is the case.

This feature also allows to prevent creation of unwanted channels.
A similar feature was proposed by @maxatome in PR #265 that was
not accepted because there were plans for FT and Channels Partitioning.

Resolves #271