### PR TITLE
Added misspell check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,13 @@ install:
 - go get github.com/wadey/gocovmerge
 - go get -u honnef.co/go/tools/cmd/staticcheck
 - go get -u honnef.co/go/tools/cmd/gosimple
+- go get -u github.com/client9/misspell/cmd/misspell
 before_script:
 - EXCLUDE_VENDOR=$(go list ./... | grep -v "/vendor/")
 - go build
 - go fmt ./...
 - go vet $EXCLUDE_VENDOR
+- misspell -error -locale US README.md nats-streaming-server.go server/ stores/ test/ util/
 - gosimple $EXCLUDE_VENDOR
 - staticcheck -ignore "$(cat staticcheck.ignore)" $EXCLUDE_VENDOR
 script:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ NATS Streaming provides the following high-level feature set.
         * [File Store](#file-store)
             * [File Store Options](#file-store-options)
 - [Clients](#clients)
-- [Licence](#license)
+- [License](#license)
 
 # Important Changes
 
@@ -142,7 +142,7 @@ maintain the state for this subscription even after the client connection is clo
 
 ***Note: The starting position given by the client when restarting a durable subscription is ignored.***
 
-When the application wants to stop receving messages on a durable subscription, it should close - but *not unsubscribe*- this subscription.
+When the application wants to stop receiving messages on a durable subscription, it should close - but *not unsubscribe*- this subscription.
 If a given client library does not have the option to close a subscription, the application should close the connection instead.
 
 When the application wants to delete the subscription, it must unsubscribe it. Once unsubscribed, the state is removed and it is then
@@ -585,7 +585,7 @@ file: {
     # Define the location and name of a script to be invoked when the
     # server discards a file slice due to limits. The script is invoked
     # with the name of the channel, the name of data and index files.
-    # It is the responsability of the script to then remove the unused
+    # It is the responsibility of the script to then remove the unused
     # files.
     # Can be slice_archive_script, slice_archive, slice_script
     slice_archive_script: "/home/nats-streaming/archive/script.sh"

--- a/stores/filestore_test.go
+++ b/stores/filestore_test.go
@@ -2964,7 +2964,7 @@ func TestFSWriteRecord(t *testing.T) {
 		t.Fatalf("Unexpected content: %v", retBuf[recordHeaderSize:])
 	}
 
-	// Check for marshalling error
+	// Check for marshaling error
 	w.reset()
 	errReturned := fmt.Errorf("Fake error")
 	corruptRec := &recordProduceErrorOnMarshal{errToReturn: errReturned}
@@ -3602,7 +3602,7 @@ func TestFSSubStoreVariousBufferSizes(t *testing.T) {
 			}
 			// Cause buffer to expand again
 			fillBuffer()
-			// Check that request should have been cancelled.
+			// Check that request should have been canceled.
 			ss.RLock()
 			shrinkReq = ss.bw.shrinkReq
 			ss.RUnlock()
@@ -3763,7 +3763,7 @@ func TestFSMsgStoreVariousBufferSizes(t *testing.T) {
 			}
 			// Cause buffer to expand again
 			fillBuffer()
-			// Check that request should have been cancelled.
+			// Check that request should have been canceled.
 			ms.RLock()
 			shrinkReq = ms.bw.shrinkReq
 			ms.RUnlock()


### PR DESCRIPTION
Explicitly specify files and directory to check since we don't want the tool to report failure for `vendor/` or `spb/` (protobuf directory) for which we don't have control.