### PR TITLE
[FIXED] Unable to set a per-channel limit if global limit set to 0

### DIFF
--- a/stores/limits.go
+++ b/stores/limits.go
@@ -36,7 +36,7 @@ func (sl *StoreLimits) Build() error {
 	if len(sl.PerChannel) == 0 {
 		return nil
 	}
-	if len(sl.PerChannel) > sl.MaxChannels {
+	if sl.MaxChannels > 0 && len(sl.PerChannel) > sl.MaxChannels {
 		return fmt.Errorf("too many channels defined (%v). The max channels limit is set to %v",
 			len(sl.PerChannel), sl.MaxChannels)
 	}
@@ -107,9 +107,9 @@ func verifyLimit(errText, channelName string, limit, globalLimit int64) error {
 		return fmt.Errorf("max %s for channel %q cannot be negative. "+
 			"Set it to 0 to be equal to the global limit of %v", errText, channelName, globalLimit)
 	}
-	if limit > globalLimit {
-		return fmt.Errorf("max %s for channel %q cannot be higher than global limit "+
-			"of %v", errText, channelName, globalLimit)
+	if globalLimit > 0 && limit > globalLimit {
+		return fmt.Errorf("max %s for channel %q cannot be higher than global limit of %v",
+			errText, channelName, globalLimit)
 	}
 	return nil
 }

--- a/stores/limits_test.go
+++ b/stores/limits_test.go
@@ -3,6 +3,7 @@
 package stores
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -201,4 +202,22 @@ func TestAppliedInheritance(t *testing.T) {
 	checkPerChannel(0, 10, 0, 0)
 	checkPerChannel(0, 0, 10, 0)
 	checkPerChannel(0, 0, 0, 10)
+}
+
+func TestLimitsUnlimited(t *testing.T) {
+	sl := &StoreLimits{}
+	// All global are unlimited. We should be able to set any other
+	// value for a Per-Channel limit
+	cl := &ChannelLimits{}
+	cl.MaxMsgs = 1000000
+	cl.MaxBytes = int64(cl.MaxMsgs * 1024)
+	cl.MaxSubscriptions = 1000000
+	cl.MaxAge = time.Duration(1000000) * time.Hour
+	// Add 10 channels
+	for i := 0; i < 10; i++ {
+		sl.AddPerChannel(fmt.Sprintf("foo.%d", i), cl)
+	}
+	if err := sl.Build(); err != nil {
+		t.Fatalf("Unexpected error on build: %v", err)
+	}
 }


### PR DESCRIPTION
This was introduced in v0.4.0 when fixing an issue where server
would not report negative values. Basically, prior to v0.4.0, the
limit check preventing a per-channel to be lower than the global
limit was not enforced (but was meant to be).
In v0.4.0 the rule is enforced and with this fix it will be possible
to set a global limit to 0 (unlimited) and lower the limit of a
specific channel.

In future release, we are going to remvoe the check that enforces
a channel limit to be lower than the corresponding global limit.

Resolves #292