### PR TITLE
[CHANGED] Channel limit can now be higher than global limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,8 @@ The `store_limits` section in the configuration file (or the command line parame
 These limits somewhat offer some upper bound on the size of the storage. By multiplying
 the limits per channel with the maximum number of channels, you will get a total limit.
 
-It is also possible to define specific limits per channel. Here is how:
+It is not the case, though, if you override limits of some channels. Indeed, it is possible
+to define specific limits per channel. Here is how:
 
 ```
 ...
@@ -619,64 +620,91 @@ store_limits: {
     # Override some global limits
     max_channels: 10
     max_msgs: 10000
-    max_bytes: 10485760
+    max_bytes: 10MB
     max_age: "1h"
 
     # Per channel configuration.
     # Can be channels, channels_limits, per_channel, per_channel_limits or ChannelsLimits
     channels: {
-        # Configuration for channel "foo"
         "foo": {
-            # Possible options are the same than in the store_limits section
-            # except for max_channels.
+            # Possible options are the same than in the store_limits section, except
+            # for max_channels. Not all limits need to be specified.
             max_msgs: 300
             max_subs: 50
         }
         "bar": {
             max_msgs:50
-            max_bytes:1000
+            max_bytes:1KB
+        }
+        "baz": {
+            # Set to 0 for ignored (or unlimited)
+            max_msgs: 0
+            # Override with a lower limit
+            max_bytes: 1MB
+            # Override with a higher limit
+            max_age: "2h"
         }
     }
 }
 ...
 ```
 
-Note the following restrictions:
-- The total of channels configured must be less than the store's maximum number of channels.
-- No limit can be negative.
-- No limit can be greater than its corresponding global limit.
+Note that the number of defined channels cannot be greater than the stores' maximum number
+of channels.
+
+Channels limits can override global limits by being either higher, lower or even set to
+unlimited.
+
+***An unlimited value applies to the specified limit, not to the whole channel***
+
+That is, in the configuration above, `baz` has the maximum number of messages set
+to 0, which means ignored or unlimited. Yet, other limits such as max bytes, max age
+and max subscriptions (inherited in this case) still apply. What that means is that
+the store will not check the number of messages but still check the other limits.
+
+For a truly unlimited channel *all* limits need to be set to 0.
 
 ### Limits inheritance
 
-Global limits that are not specified (configuration file or command line parameters)
-are inherited from default limits selected by the server.
+When starting the server from the command line, global limits that are not specified
+(configuration file or command line parameters) are inherited from default limits
+selected by the server.
 
 Per-channel limits that are not explicitly configured inherit from the corresponding
 global limit (which can itself be inherited from default limit).
+
+If a per-channel limit is set to 0 in the configuration file (or negative value
+programmatically), then it becomes unlimited, regardless of the corresponding
+global limit.
 
 On startup the server displays the store limits. Notice the `*` at the right of a
 limit to indicate that the limit was inherited (either from global or default limits).
 This is what would be displayed with the above store limits configuration:
 
 ```
-[59872] 2017/04/01 10:25:18.747822 [INF] STREAM: --------- Store Limits ---------
-[59872] 2017/04/01 10:25:18.747830 [INF] STREAM: Channels:                   10
-[59872] 2017/04/01 10:25:18.747834 [INF] STREAM: -------- channels limits -------
-[59872] 2017/04/01 10:25:18.747839 [INF] STREAM:   Subscriptions:          1000 *
-[59872] 2017/04/01 10:25:18.747845 [INF] STREAM:   Messages     :         10000
-[59872] 2017/04/01 10:25:18.747863 [INF] STREAM:   Bytes        :      10.00 MB
-[59872] 2017/04/01 10:25:18.747887 [INF] STREAM:   Age          :        1h0m0s
-[59872] 2017/04/01 10:25:18.747904 [INF] STREAM: Channel: "foo"
-[59872] 2017/04/01 10:25:18.747908 [INF] STREAM:   Subscriptions:            50
-[59872] 2017/04/01 10:25:18.747924 [INF] STREAM:   Messages     :           300
-[59872] 2017/04/01 10:25:18.747927 [INF] STREAM:   Bytes        :      10.00 MB *
-[59872] 2017/04/01 10:25:18.747930 [INF] STREAM:   Age          :        1h0m0s *
-[59872] 2017/04/01 10:25:18.747932 [INF] STREAM: Channel: "bar"
-[59872] 2017/04/01 10:25:18.747935 [INF] STREAM:   Subscriptions:          1000 *
-[59872] 2017/04/01 10:25:18.747937 [INF] STREAM:   Messages     :            50
-[59872] 2017/04/01 10:25:18.747941 [INF] STREAM:   Bytes        :        1000 B
-[59872] 2017/04/01 10:25:18.747944 [INF] STREAM:   Age          :        1h0m0s *
-[59872] 2017/04/01 10:25:18.747946 [INF] STREAM: --------------------------------
+[94641] 2017/04/14 18:20:10.836191 [INF] STREAM: --------- Store Limits ---------
+[94641] 2017/04/14 18:20:10.836200 [INF] STREAM: Channels:                   10
+[94641] 2017/04/14 18:20:10.836203 [INF] STREAM: -------- channels limits -------
+[94641] 2017/04/14 18:20:10.836208 [INF] STREAM:   Subscriptions:          1000 *
+[94641] 2017/04/14 18:20:10.836213 [INF] STREAM:   Messages     :         10000
+[94641] 2017/04/14 18:20:10.836235 [INF] STREAM:   Bytes        :      10.00 MB
+[94641] 2017/04/14 18:20:10.836251 [INF] STREAM:   Age          :        1h0m0s
+[94641] 2017/04/14 18:20:10.836257 [INF] STREAM: Channel: "foo"
+[94641] 2017/04/14 18:20:10.836262 [INF] STREAM:   Subscriptions:            50
+[94641] 2017/04/14 18:20:10.836266 [INF] STREAM:   Messages     :           300
+[94641] 2017/04/14 18:20:10.836272 [INF] STREAM:   Bytes        :      10.00 MB *
+[94641] 2017/04/14 18:20:10.836280 [INF] STREAM:   Age          :        1h0m0s *
+[94641] 2017/04/14 18:20:10.836284 [INF] STREAM: Channel: "bar"
+[94641] 2017/04/14 18:20:10.836288 [INF] STREAM:   Subscriptions:          1000 *
+[94641] 2017/04/14 18:20:10.836293 [INF] STREAM:   Messages     :            50
+[94641] 2017/04/14 18:20:10.836298 [INF] STREAM:   Bytes        :       1.00 KB
+[94641] 2017/04/14 18:20:10.836311 [INF] STREAM:   Age          :        1h0m0s *
+[94641] 2017/04/14 18:20:10.836315 [INF] STREAM: Channel: "baz"
+[94641] 2017/04/14 18:20:10.836319 [INF] STREAM:   Subscriptions:          1000 *
+[94641] 2017/04/14 18:20:10.836324 [INF] STREAM:   Messages     :     unlimited
+[94641] 2017/04/14 18:20:10.836329 [INF] STREAM:   Bytes        :       1.00 MB
+[94641] 2017/04/14 18:20:10.836334 [INF] STREAM:   Age          :        2h0m0s
+[94641] 2017/04/14 18:20:10.836338 [INF] STREAM: --------------------------------
 ```
 
 

--- a/server/server.go
+++ b/server/server.go
@@ -1087,15 +1087,15 @@ func (s *StanServer) start(runningState State) error {
 	Noticef("Message store is %s", s.store.Name())
 	Noticef("--------- Store Limits ---------")
 	Noticef("Channels:        %s",
-		getLimitStr(true, int64(limits.MaxChannels),
+		getLimitStr(int64(limits.MaxChannels),
 			int64(stores.DefaultStoreLimits.MaxChannels),
 			limitCount))
 	Noticef("-------- channels limits -------")
-	printLimits(true, &limits.ChannelLimits,
+	printLimits(&limits.ChannelLimits,
 		&stores.DefaultStoreLimits.ChannelLimits)
 	for cn, cl := range limits.PerChannel {
 		Noticef("Channel: %q", cn)
-		printLimits(false, cl, &limits.ChannelLimits)
+		printLimits(cl, &limits.ChannelLimits)
 	}
 	Noticef("--------------------------------")
 
@@ -1107,23 +1107,20 @@ func (s *StanServer) start(runningState State) error {
 	return nil
 }
 
-func printLimits(isGlobal bool, limits, parentLimits *stores.ChannelLimits) {
+func printLimits(limits, parentLimits *stores.ChannelLimits) {
 	plMaxSubs := int64(parentLimits.MaxSubscriptions)
 	plMaxMsgs := int64(parentLimits.MaxMsgs)
 	plMaxBytes := parentLimits.MaxBytes
 	plMaxAge := parentLimits.MaxAge
-	Noticef("  Subscriptions: %s", getLimitStr(isGlobal, int64(limits.MaxSubscriptions), plMaxSubs, limitCount))
-	Noticef("  Messages     : %s", getLimitStr(isGlobal, int64(limits.MaxMsgs), plMaxMsgs, limitCount))
-	Noticef("  Bytes        : %s", getLimitStr(isGlobal, limits.MaxBytes, plMaxBytes, limitBytes))
-	Noticef("  Age          : %s", getLimitStr(isGlobal, int64(limits.MaxAge), int64(plMaxAge), limitDuration))
+	Noticef("  Subscriptions: %s", getLimitStr(int64(limits.MaxSubscriptions), plMaxSubs, limitCount))
+	Noticef("  Messages     : %s", getLimitStr(int64(limits.MaxMsgs), plMaxMsgs, limitCount))
+	Noticef("  Bytes        : %s", getLimitStr(limits.MaxBytes, plMaxBytes, limitBytes))
+	Noticef("  Age          : %s", getLimitStr(int64(limits.MaxAge), int64(plMaxAge), limitDuration))
 }
 
-func getLimitStr(isGlobal bool, val, parentVal int64, limitType int) string {
+func getLimitStr(val, parentVal int64, limitType int) string {
 	valStr := ""
 	inherited := ""
-	if !isGlobal && val == 0 {
-		val = parentVal
-	}
 	if val == parentVal {
 		inherited = " *"
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -6136,3 +6136,78 @@ func TestNewOnHoldSetOnDurableRestart(t *testing.T) {
 		t.Fatal("Did not receive the redelivered messages first")
 	}
 }
+
+func TestUnlimitedPerChannelLimits(t *testing.T) {
+	opts := GetDefaultOptions()
+	opts.StoreLimits.MaxChannels = 2
+	// Set very small global limits
+	opts.StoreLimits.MaxMsgs = 1
+	opts.StoreLimits.MaxBytes = 1
+	opts.StoreLimits.MaxAge = time.Millisecond
+	opts.StoreLimits.MaxSubscriptions = 1
+	// Add a channel that has all unlimited values
+	cl := &stores.ChannelLimits{}
+	cl.MaxMsgs = -1
+	cl.MaxBytes = -1
+	cl.MaxAge = -1
+	cl.MaxSubscriptions = -1
+	opts.StoreLimits.AddPerChannel("foo", cl)
+	s := runServerWithOpts(t, opts, nil)
+	defer s.Shutdown()
+	sc := NewDefaultConnection(t)
+	defer sc.Close()
+	// Check that we can send more than 1 message of more than 1 byte
+	total := 10
+	for i := 0; i < total; i++ {
+		if err := sc.Publish("foo", []byte("hello")); err != nil {
+			t.Fatalf("Unexpected error on publish: %v", err)
+		}
+	}
+	count := int32(0)
+	ch := make(chan bool)
+	cb := func(_ *stan.Msg) {
+		if c := atomic.AddInt32(&count, 1); c == int32(2*total) {
+			ch <- true
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := sc.Subscribe("foo", cb, stan.DeliverAllAvailable()); err != nil {
+			t.Fatalf("Unexpected error on subscribe: %v", err)
+		}
+	}
+	if err := Wait(ch); err != nil {
+		t.Fatal("Did not get our messages")
+	}
+	// Wait for more than the global limit MaxAge and verify messages
+	// are still there
+	time.Sleep(15 * time.Millisecond)
+	s.mu.RLock()
+	n, _, _ := s.store.MsgsState("foo")
+	s.mu.RUnlock()
+	if n != total {
+		t.Fatalf("Should be %v messages, store reports %v", total, n)
+	}
+	// Now use a channel not defined in PerChannel and we should be subject
+	// to global limits.
+	for i := 0; i < total; i++ {
+		if err := sc.Publish("bar", []byte("hello")); err != nil {
+			t.Fatalf("Unexpected error on publish: %v", err)
+		}
+	}
+	if _, err := sc.Subscribe("bar", func(_ *stan.Msg) {}); err != nil {
+		t.Fatalf("Unexpected error on subscribe: %v", err)
+	}
+	// This one should fail
+	if _, err := sc.Subscribe("bar", func(_ *stan.Msg) {}); err == nil {
+		t.Fatal("Expected to fail to subscribe, did not")
+	}
+	// Wait more than MaxAge
+	time.Sleep(15 * time.Millisecond)
+	// Messages should have all disappear
+	s.mu.RLock()
+	n, _, _ = s.store.MsgsState("bar")
+	s.mu.RUnlock()
+	if n != 0 {
+		t.Fatalf("Expected 0 messages, store reports %v", n)
+	}
+}

--- a/stores/limits_test.go
+++ b/stores/limits_test.go
@@ -84,70 +84,14 @@ func TestBuildErrors(t *testing.T) {
 	sl.MaxBytes = 1
 	sl.MaxAge = 1
 
-	// Check per-channel negative values
-	cl := &ChannelLimits{}
-	cl.MaxSubscriptions = -1
-	sl.AddPerChannel("foo", cl)
-	expectError("Max subscriptions")
-
-	cl = &ChannelLimits{}
-	cl.MaxMsgs = -1
-	sl.AddPerChannel("foo", cl)
-	expectError("Max messages")
-
-	cl = &ChannelLimits{}
-	cl.MaxAge = -1
-	sl.AddPerChannel("foo", cl)
-	expectError("Max age")
-
-	sl.MaxChannels = 1
 	// Adding a second channel should cause build failures, AddPerChannel itself
 	// does not fail.
-	cl = &ChannelLimits{}
+	cl := &ChannelLimits{}
 	cl.MaxMsgs = 10
 	cl.MaxAge = 2 * time.Hour
 	sl.AddPerChannel("foo", cl)
 	sl.AddPerChannel("bar", cl)
 	expectError("Too many channels")
-
-	// Check per-channel values are below global limits.
-	sl.MaxChannels = 2
-	sl.MaxMsgs = 10
-	sl.MaxBytes = 20
-	sl.MaxSubscriptions = 30
-	sl.MaxAge = time.Second
-
-	cl = &ChannelLimits{}
-	cl.MaxMsgs = 5
-	sl.AddPerChannel("foo", cl)
-	cl2 := *cl
-	cl2.MaxMsgs = 12
-	sl.AddPerChannel("bar", &cl2)
-	expectError("Max messages for channel \"bar\"")
-
-	cl = &ChannelLimits{}
-	cl.MaxBytes = 25
-	cl2 = *cl
-	cl2.MaxBytes = 18
-	sl.AddPerChannel("foo", cl)
-	sl.AddPerChannel("bar", &cl2)
-	expectError("Max bytes for channel \"foo\"")
-
-	cl = &ChannelLimits{}
-	cl.MaxAge = time.Second
-	cl2 = *cl
-	cl2.MaxAge = time.Hour
-	sl.AddPerChannel("foo", cl)
-	sl.AddPerChannel("bar", &cl2)
-	expectError("Max age for channel \"bar\"")
-
-	cl = &ChannelLimits{}
-	cl.MaxSubscriptions = 35
-	cl2 = *cl
-	cl2.MaxSubscriptions = 10
-	sl.AddPerChannel("foo", cl)
-	sl.AddPerChannel("bar", &cl2)
-	expectError("Max subscriptions for channel \"foo\"")
 
 	// Reset sl
 	sl = testDefaultStoreLimits
@@ -219,5 +163,30 @@ func TestLimitsUnlimited(t *testing.T) {
 	}
 	if err := sl.Build(); err != nil {
 		t.Fatalf("Unexpected error on build: %v", err)
+	}
+	// Use non unlimited global limits, check that we can have
+	// unlimited values for per-channel
+	sl = &StoreLimits{}
+	sl.MaxChannels = 1000
+	sl.MaxMsgs = 1
+	sl.MaxBytes = 1
+	sl.MaxAge = 1
+	sl.MaxSubscriptions = 1
+	// Set all limit for this channel to -1
+	cl = &ChannelLimits{}
+	cl.MaxMsgs = -1
+	cl.MaxBytes = -1
+	cl.MaxAge = -1
+	cl.MaxSubscriptions = -1
+	sl.AddPerChannel("foo", cl)
+	if err := sl.Build(); err != nil {
+		t.Fatalf("Unexpected error on build: %v", err)
+	}
+	builtCl := sl.PerChannel["foo"]
+	// the result should be that all values are set to 0.
+	// So compare with this empty structure
+	expected := ChannelLimits{}
+	if !reflect.DeepEqual(*builtCl, expected) {
+		t.Fatalf("Expected limits to be %v, got %v", expected, *builtCl)
 	}
 }

--- a/stores/store.go
+++ b/stores/store.go
@@ -41,8 +41,9 @@ type StoreLimits struct {
 	MaxChannels int
 	// Global limits. Any 0 value means that the limit is ignored (unlimited).
 	ChannelLimits
-	// Per-channel limits. If a limit for a channel in this map is 0,
-	// the corresponding global limit (specified above) is used.
+	// Per-channel limits. Special values for limits in this map:
+	// - == 0 means that the corresponding global limit is used.
+	// -  < 0 means that limit is ignored (unlimited).
 	PerChannel map[string]*ChannelLimits
 }
 


### PR DESCRIPTION
When configuring a channel limits, we can now set its limits to
higher values than the global limits, even set them to unlimited.

Resolves #296