### PR TITLE
[ADDED] FileStore can now recover channels in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ Streaming Server File Store Options:
     --file_slice_max_age <duration>      Maximum file slice duration starting when the first message is stored (subject to channel limits)
     --file_slice_archive_script <string> Path to script to use if you want to archive a file slice being removed
     --file_fds_limit <int>               Store will try to use no more file descriptors than this given limit
+    --file_parallel_recovery <int>       On startup, number of channels that can be recovered in parallel
 
 Streaming Server TLS Options:
     -secure <bool>                   Use a TLS connection to the NATS server without
@@ -600,6 +601,12 @@ file: {
     # a performance impact.
     # Can be file_descriptors_limit, fds_limit
     fds_limit: 100
+
+    # When the server starts, the recovery of channels (directories) is
+    # done sequentially. However, when using SSDs, it may be worth
+    # setting this value to something higher than 1 to perform channels
+    # recovery in parallel.
+    parallel_recovery: 4
 }
 ```
 

--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -52,6 +52,7 @@ Streaming Server File Store Options:
     --file_slice_max_age <duration>      Maximum file slice duration starting when the first message is stored (subject to channel limits)
     --file_slice_archive_script <string> Path to script to use if you want to archive a file slice being removed
     --file_fds_limit <int>               Store will try to use no more file descriptors than this given limit
+    --file_parallel_recovery <int>       On startup, number of channels that can be recovered in parallel
 
 Streaming Server TLS Options:
     -secure <bool>                   Use a TLS connection to the NATS server without
@@ -195,6 +196,7 @@ func parseFlags() (*stand.Options, *natsd.Options) {
 	flag.String("file_slice_max_age", "0s", "FileStoreOpts.SliceMaxAge")
 	flag.String("file_slice_archive_script", "", "FileStoreOpts.SliceArchiveScript")
 	flag.Int64("file_fds_limit", stores.DefaultFileStoreOptions.FileDescriptorsLimit, "FileStoreOpts.FileDescriptorsLimit")
+	flag.Int("file_parallel_recovery", stores.DefaultFileStoreOptions.ParallelRecovery, "FileStoreOpts.ParallelRecovery")
 	flag.Int("io_batch_size", stand.DefaultIOBatchSize, "IOBatchSize")
 	flag.Int64("io_sleep_time", stand.DefaultIOSleepTime, "IOSleepTime")
 	flag.String("ft_group", "", "FTGroupName")

--- a/server/conf.go
+++ b/server/conf.go
@@ -339,6 +339,11 @@ func parseFileOptions(itf interface{}, opts *Options) error {
 				return err
 			}
 			opts.FileStoreOpts.FileDescriptorsLimit = v.(int64)
+		case "parallel_recovery":
+			if err := checkType(k, reflect.Int64, v); err != nil {
+				return err
+			}
+			opts.FileStoreOpts.ParallelRecovery = int(v.(int64))
 		}
 	}
 	return nil

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -100,6 +100,9 @@ func TestParseConfig(t *testing.T) {
 	if opts.FileStoreOpts.FileDescriptorsLimit != 8 {
 		t.Fatalf("Expected FileDescriptorsLimit to be 8, got %v", opts.FileStoreOpts.FileDescriptorsLimit)
 	}
+	if opts.FileStoreOpts.ParallelRecovery != 9 {
+		t.Fatalf("Expected ParallelRecovery to be 9, got %v", opts.FileStoreOpts.ParallelRecovery)
+	}
 	if opts.MaxChannels != 11 {
 		t.Fatalf("Expected MaxChannels to be 11, got %v", opts.MaxChannels)
 	}
@@ -313,6 +316,7 @@ func TestParseWrongTypes(t *testing.T) {
 	expectFailureFor(t, "file:{slice_max_age:\"1h:0m\"}", wrongTimeErr)
 	expectFailureFor(t, "file:{slice_archive_script:123}", wrongTypeErr)
 	expectFailureFor(t, "file:{fds_limit:false}", wrongTypeErr)
+	expectFailureFor(t, "file:{parallel_recovery:false}", wrongTypeErr)
 }
 
 func expectFailureFor(t *testing.T, content, errorMatch string) {

--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -293,9 +293,9 @@ func FileDescriptorsLimit(limit int64) FileStoreOption {
 }
 
 // ParallelRecovery is a FileStore option that allows the parallel
-// recovery of channels. If running with SSDs, try to use a higher
-// value than the default number of 1. If running with HDDs,
-// performance will be better if it stays at 1.
+// recovery of channels. When running with SSDs, try to use a higher
+// value than the default number of 1. When running with HDDs,
+// performance may be better if it stays at 1.
 func ParallelRecovery(count int) FileStoreOption {
 	return func(o *FileStoreOptions) error {
 		if count <= 0 {

--- a/test/configs/test_parse.conf
+++ b/test/configs/test_parse.conf
@@ -56,4 +56,5 @@ file: {
     slice_max_age: "8s"
     slice_archive_script: "myArchiveScript"
     fds_limit: 8
+    parallel_recovery: 9
 }


### PR DESCRIPTION
By default each channel is recovered sequentially. With SSDs, it
may be faster to do parallel recovery. A FileStoreOptions allows
to specify the number of go routines performing recovery.