### PR TITLE
Fixed coverage script

### DIFF
--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -3,13 +3,14 @@
 
 rm -rf ./cov
 mkdir cov
-go test -v -covermode=count -coverprofile=./cov/server.out ./server
+go test -v -covermode=count -coverprofile=./cov/server.out -run=Test[^Signal] ./server
+go test -v -covermode=count -coverprofile=./cov/server2.out -run=TestSignal ./server
 # repeat these server FT tests but focus on stores package
-go test -v -covermode=count -coverprofile=./cov/ft_stores.out -run=TestFTPartition -coverpkg=./stores ./server
-go test -v -covermode=count -coverprofile=./cov/stores.out ./stores
-go test -v -covermode=count -coverprofile=./cov/stores_no_buffer.out -run=TestFS ./stores -no_buffer
-go test -v -covermode=count -coverprofile=./cov/stores_fds_limit.out -run=TestFS ./stores -set_fds_limit
-go test -v -covermode=count -coverprofile=./cov/stores_no_buffer_and_fds_limit.out -run=TestFS ./stores -no_buffer -set_fds_limit
+go test -v -covermode=count -coverprofile=./cov/stores1.out -run=TestFTPartition -coverpkg=./stores ./server
+go test -v -covermode=count -coverprofile=./cov/stores2.out ./stores
+go test -v -covermode=count -coverprofile=./cov/stores3.out -run=TestFS ./stores -no_buffer
+go test -v -covermode=count -coverprofile=./cov/stores4.out -run=TestFS ./stores -set_fds_limit
+go test -v -covermode=count -coverprofile=./cov/stores5.out -run=TestFS ./stores -no_buffer -set_fds_limit
 go test -v -covermode=count -coverprofile=./cov/util.out ./util
 gocovmerge ./cov/*.out > acc.out
 rm -rf ./cov


### PR DESCRIPTION
When adding test for signal handling, this caused the coverage
script to be interrupted and therefore not report code coverage
for server package.
By excluding TestSignal* tests and running then separately
apparently solves the issue.