### PR TITLE
[IMPROVED] Error returned to client for invalid client ID

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -428,7 +428,7 @@ func TestClientIDIsValid(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected response object: %v", err)
 		}
-		if r.Error == "" {
+		if r.Error != ErrInvalidClientID.Error() {
 			t.Fatal("Expected error, got none")
 		}
 	}


### PR DESCRIPTION
Report errors (as opposed to debug tracing) when something goes
wrong during the processing of the connect request.
For invalid client ID, returns an explicit error to clients.