### PR TITLE
Fixed code coverage

### DIFF
--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -3,8 +3,7 @@
 
 rm -rf ./cov
 mkdir cov
-go test -v -covermode=count -coverprofile=./cov/server.out -run=Test[^Signal] ./server
-go test -v -covermode=count -coverprofile=./cov/server2.out -run=TestSignal ./server
+go test -v -covermode=count -coverprofile=./cov/server.out ./server
 # repeat these server FT tests but focus on stores package
 go test -v -covermode=count -coverprofile=./cov/stores1.out -run=TestFTPartition -coverpkg=./stores ./server
 go test -v -covermode=count -coverprofile=./cov/stores2.out ./stores

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/nats-io/nats-streaming-server/stores"
 	"github.com/nats-io/nuid"
-	"sync/atomic"
 )
 
 func createClientStore() *clientStore {

--- a/server/server.go
+++ b/server/server.go
@@ -136,18 +136,6 @@ func init() {
 	}
 }
 
-// For testing of signal handling
-var (
-	signalMu     = sync.RWMutex{}
-	signalNoExit = false
-)
-
-func setSignalNoExit(noExit bool) {
-	signalMu.Lock()
-	signalNoExit = noExit
-	signalMu.Unlock()
-}
-
 // ioPendingMsg is a record that embeds the pointer to the incoming
 // NATS Message, the PubMsg and PubAck structures so we reduce the
 // number of memory allocations to 1 when processing a message from

--- a/server/signal.go
+++ b/server/signal.go
@@ -21,12 +21,6 @@ func (s *StanServer) handleSignals() {
 			switch sig {
 			case syscall.SIGINT:
 				s.Shutdown()
-				signalMu.RLock()
-				noExit := signalNoExit
-				signalMu.RUnlock()
-				if noExit {
-					return
-				}
 				os.Exit(0)
 			case syscall.SIGUSR1:
 				// File log re-open for rotating file logs.

--- a/server/signal_test.go
+++ b/server/signal_test.go
@@ -14,22 +14,6 @@ import (
 	natsd "github.com/nats-io/gnatsd/server"
 )
 
-func TestSignalInterrupt(t *testing.T) {
-	defer setSignalNoExit(false)
-	setSignalNoExit(true)
-	opts := GetDefaultOptions()
-	opts.HandleSignals = true
-	s := runServerWithOpts(t, opts, nil)
-	defer s.Shutdown()
-	// Send Ctrl+C
-	syscall.Kill(syscall.Getpid(), syscall.SIGINT)
-	// Check server is Shutdown
-	time.Sleep(250 * time.Millisecond)
-	if state := s.State(); state != Shutdown {
-		t.Fatalf("Expected state to be %v, got %v", Shutdown.String(), state.String())
-	}
-}
-
 func TestSignalIgnoreUnknown(t *testing.T) {
 	opts := GetDefaultOptions()
 	opts.HandleSignals = true

--- a/server/signal_windows.go
+++ b/server/signal_windows.go
@@ -17,12 +17,6 @@ func (s *StanServer) handleSignals() {
 		// only the ones that are registered.
 		<-c
 		s.Shutdown()
-		signalMu.RLock()
-		noExit := signalNoExit
-		signalMu.RUnlock()
-		if noExit {
-			return
-		}
 		os.Exit(0)
 	}()
 }


### PR DESCRIPTION
PR #305 attempted to fix an issue caused by one of the test
sending a SIGINT to test that server is exiting properly when
receiving that signal. My attempt to exclude those tests and run
them separately using a regex resulted in some tests actually
not running which brought the server.go code coverage down to 90%.
I am removing test that sends SIGINT, which brings the code coverage
for signal.go down to 75%.