### PR TITLE
[ADDED] Ability to combine NATS and Streaming options in same config

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,10 @@ You can use a configuration file to configure the options specific to the NATS S
 
 Use the `-sc` or `-stan_config` command line parameter to specify the file to use.
 
+For the embedded NATS Server, you can use another configuration file and pass it to the Streaming server using `-c` or `--config` command line parameters.
+
+However, since options do not overlap, it is possible to combine all options into a single file and specify this file using either the `-sc` or `-c` command line parameter.
+
 Note the order in which options are applied during the start of a NATS Streaming server:
 
 1. Start with some reasonable default options.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -6233,5 +6234,64 @@ func TestUnlimitedPerChannelLimits(t *testing.T) {
 	s.mu.RUnlock()
 	if n != 0 {
 		t.Fatalf("Expected 0 messages, store reports %v", n)
+	}
+}
+
+func TestSingleConfFileForBoth(t *testing.T) {
+	configFile := "config.cfg"
+	defer os.Remove(configFile)
+	content := []byte(`
+	port: 4223
+	store_limits: {
+		max_channels: 1
+	}`)
+	if err := ioutil.WriteFile(configFile, content, 0666); err != nil {
+		t.Fatalf("Error writing config file: %v", err)
+	}
+	var cmd *exec.Cmd
+	defer func() {
+		if cmd != nil {
+			cmd.Process.Kill()
+			cmd.Wait()
+		}
+	}()
+	param := []string{"-sc", "-c"}
+	for i := 0; i < 2; i++ {
+		cmd = exec.Command("nats-streaming-server", param[i], configFile)
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("Error starting process: %v", err)
+		}
+		var (
+			sc     stan.Conn
+			err    error
+			failed int
+		)
+		for {
+			sc, err = stan.Connect(clusterName, clientName,
+				stan.NatsURL("nats://localhost:4223"),
+				stan.ConnectWait(250*time.Millisecond))
+			if err != nil {
+				failed++
+				if failed < 10 {
+					time.Sleep(100 * time.Millisecond)
+					continue
+				}
+				t.Fatalf("Unable to connect: %v", err)
+			}
+			break
+		}
+		defer sc.Close()
+		// Should be able to create 1 channel
+		if err := sc.Publish("foo", []byte("hello")); err != nil {
+			t.Fatalf("Unexpected error on publish: %v", err)
+		}
+		// But not 2.
+		if err := sc.Publish("bar", []byte("hello")); err == nil {
+			t.Fatalf("Param %v, should have failed to create a 2nd channel", param[i])
+		}
+		sc.Close()
+		cmd.Process.Kill()
+		cmd.Wait()
+		cmd = nil
 	}
 }


### PR DESCRIPTION
NATS and NATS Streaming options do not overlap, so they can be
combine in the same configuration file. This was already the case
but users would have to pass the unified configuration file with
both `-sc` and `-c` command line parameters.
This PR simply makes the server tries to parse the configuration
file given by `-sc` or `-c` to both NATS and Streaming components.

Resolves #311