### PR TITLE
[FIXED] Missing return in message expiration if clock drifts backward

### DIFF
--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -2420,10 +2420,12 @@ func (ms *FileMsgStore) expireMsgs(now, maxAge int64) int64 {
 		elapsed := now - m.timestamp
 		if elapsed >= maxAge {
 			ms.removeFirstMsg(m, false)
-		} else if elapsed < 0 {
-			ms.expiration = m.timestamp + maxAge
 		} else {
-			ms.expiration = now + (maxAge - elapsed)
+			if elapsed < 0 {
+				ms.expiration = m.timestamp + maxAge
+			} else {
+				ms.expiration = now + (maxAge - elapsed)
+			}
 			break
 		}
 	}

--- a/stores/memstore.go
+++ b/stores/memstore.go
@@ -190,10 +190,12 @@ func (ms *MemoryMsgStore) expireMsgs() {
 		elapsed := now - m.Timestamp
 		if elapsed >= maxAge {
 			ms.removeFirstMsg()
-		} else if elapsed < 0 {
-			ms.ageTimer.Reset(time.Duration(m.Timestamp - now + maxAge))
 		} else {
-			ms.ageTimer.Reset(time.Duration(maxAge - elapsed))
+			if elapsed < 0 {
+				ms.ageTimer.Reset(time.Duration(m.Timestamp - now + maxAge))
+			} else {
+				ms.ageTimer.Reset(time.Duration(maxAge - elapsed))
+			}
 			return
 		}
 	}


### PR DESCRIPTION
Although it does not look like I can reproduce the issue by moving
the clock backward, there was a missing return when the current
time is lower than the first message's timestamp in the message
expiration code (both MemStore and FileStore).

Resolves #318