### PR TITLE
Update travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ before_script:
 - ./misspell.sh
 - gosimple $EXCLUDE_VENDOR
 - staticcheck -ignore "$(cat staticcheck.ignore)" $EXCLUDE_VENDOR
+- ./scripts/cross_compile.sh $TRAVIS_TAG
 script:
 - go test -i -race $EXCLUDE_VENDOR
-- go test -race -v -p=1 $EXCLUDE_VENDOR
+- if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]]; then ./scripts/cov.sh TRAVIS; else go test -race -v -p=1 $EXCLUDE_VENDOR; fi
 after_success:
-- if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]]; then ./scripts/cov.sh TRAVIS; fi
-- if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]] && [ "$TRAVIS_TAG" != "" ]; then ./scripts/cross_compile.sh $TRAVIS_TAG; ghr --owner nats-io --token $GITHUB_TOKEN --draft --replace $TRAVIS_TAG pkg/; fi
+- if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]] && [ "$TRAVIS_TAG" != "" ]; then ghr --owner nats-io --token $GITHUB_TOKEN --draft --replace $TRAVIS_TAG pkg/; fi

--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -3,14 +3,14 @@
 
 rm -rf ./cov
 mkdir cov
-go test -v -covermode=count -coverprofile=./cov/server.out ./server
+go test -v -covermode=atomic -coverprofile=./cov/server.out ./server
 # repeat these server FT tests but focus on stores package
-go test -v -covermode=count -coverprofile=./cov/stores1.out -run=TestFTPartition -coverpkg=./stores ./server
-go test -v -covermode=count -coverprofile=./cov/stores2.out ./stores
-go test -v -covermode=count -coverprofile=./cov/stores3.out -run=TestFS ./stores -no_buffer
-go test -v -covermode=count -coverprofile=./cov/stores4.out -run=TestFS ./stores -set_fds_limit
-go test -v -covermode=count -coverprofile=./cov/stores5.out -run=TestFS ./stores -no_buffer -set_fds_limit
-go test -v -covermode=count -coverprofile=./cov/util.out ./util
+go test -v -covermode=atomic -coverprofile=./cov/stores1.out -run=TestFTPartition -coverpkg=./stores ./server
+go test -v -covermode=atomic -coverprofile=./cov/stores2.out ./stores
+go test -v -covermode=atomic -coverprofile=./cov/stores3.out -run=TestFS ./stores -no_buffer
+go test -v -covermode=atomic -coverprofile=./cov/stores4.out -run=TestFS ./stores -set_fds_limit
+go test -v -covermode=atomic -coverprofile=./cov/stores5.out -run=TestFS ./stores -no_buffer -set_fds_limit
+go test -v -covermode=atomic -coverprofile=./cov/util.out ./util
 gocovmerge ./cov/*.out > acc.out
 rm -rf ./cov
 

--- a/scripts/cross_compile.sh
+++ b/scripts/cross_compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 go get github.com/mitchellh/gox
 go get github.com/tcnksm/ghr
 


### PR DESCRIPTION
- Run cross compile in before_script to capture possible platform
  dependent build issues.
- Run code coverage for a given Go version in script instead of
  after_success.
- Changed code coverage mode from count to atomic since
  `go test -race` is now not running for the Go version for which
  the code coverage is run.