### PR TITLE
Cross compile only on new tag [ci skip]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,8 @@ before_script:
 - ./misspell.sh
 - gosimple $EXCLUDE_VENDOR
 - staticcheck -ignore "$(cat staticcheck.ignore)" $EXCLUDE_VENDOR
-- ./scripts/cross_compile.sh $TRAVIS_TAG
 script:
 - go test -i -race $EXCLUDE_VENDOR
 - if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]]; then ./scripts/cov.sh TRAVIS; else go test -race -v -p=1 $EXCLUDE_VENDOR; fi
 after_success:
-- if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]] && [ "$TRAVIS_TAG" != "" ]; then ghr --owner nats-io --token $GITHUB_TOKEN --draft --replace $TRAVIS_TAG pkg/; fi
+- if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]] && [ "$TRAVIS_TAG" != "" ]; then ./scripts/cross_compile.sh $TRAVIS_TAG; ghr --owner nats-io --token $GITHUB_TOKEN --draft --replace $TRAVIS_TAG pkg/; fi


### PR DESCRIPTION
Doing cross compile for every build takes too long (minimum 35 secs).
Reverting some recent changes and move it back to only when a new
tag is pushed. Dev should ensure cross compile works before getting
ready for a new release.