### PR TITLE
Allow AckWait to be specified in ms for tests and some other tweaks

### DIFF
--- a/server/ft_test.go
+++ b/server/ft_test.go
@@ -113,7 +113,7 @@ func getFTActiveServer(t *testing.T, servers ...*StanServer) *StanServer {
 		if active != nil {
 			break
 		}
-		time.Sleep(time.Second)
+		time.Sleep(ftHBMissedInterval)
 	}
 	if active == nil {
 		stackFatalf(t, "Unable to find the active server")
@@ -639,7 +639,7 @@ func TestFTSteppingDown(t *testing.T) {
 	ns = natsdTest.RunDefaultServer()
 	// Make sure that streaming has time to reconnect and wait for HBs
 	// exchange to realize that there are 2 actives.
-	time.Sleep(time.Second)
+	time.Sleep(2 * ftHBMissedInterval)
 	// Since s1 activated before s2, we want s1 to stay and s2 to exit.
 	checkState(t, s1, FTActive)
 	checkState(t, s2, Failed)
@@ -708,7 +708,7 @@ func TestFTActiveSendsHB(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	// Shutdown the NATS server
 	ns.Shutdown()
-	time.Sleep(time.Second)
+	time.Sleep(2 * ftHBMissedInterval)
 	// Start again
 	ns = natsdTest.RunDefaultServer()
 	atomic.StoreInt32(&reconnected, 1)

--- a/server/server_clients_test.go
+++ b/server/server_clients_test.go
@@ -437,14 +437,15 @@ func TestPersistentStoreCheckClientHealthAfterRestart(t *testing.T) {
 	defer shutdownRestartedServerOnTestExit(&s)
 
 	// Create 2 clients
-	sc1, nc1 := createConnectionWithNatsOpts(t, "c1",
-		nats.ReconnectWait(10*time.Second))
-	defer nc1.Close()
+	sc1, err := stan.Connect(clusterName, "c1", stan.ConnectWait(500*time.Millisecond))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
 	defer sc1.Close()
-
-	sc2, nc2 := createConnectionWithNatsOpts(t, "c2",
-		nats.ReconnectWait(10*time.Second))
-	defer nc2.Close()
+	sc2, err := stan.Connect(clusterName, "c2", stan.ConnectWait(500*time.Millisecond))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
 	defer sc2.Close()
 
 	// Make sure they are registered
@@ -458,7 +459,7 @@ func TestPersistentStoreCheckClientHealthAfterRestart(t *testing.T) {
 	s = runServerWithOpts(t, opts, nil)
 	// Check that there are 2 clients
 	checkClients(t, s, 2)
-	// Tweak their hbTimer interval to make the test short
+	// Check their hbTimer is set
 	clients := s.clients.getClients()
 	for cID, c := range clients {
 		c.Lock()

--- a/server/server_delivery_test.go
+++ b/server/server_delivery_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/go-nats"
 	"github.com/nats-io/go-nats-streaming"
 )
 
@@ -121,7 +122,9 @@ func TestPersistentStoreAutomaticDeliveryOnRestart(t *testing.T) {
 	msg := []byte("msg")
 
 	// Get our STAN connection
-	sc := NewDefaultConnection(t)
+	sc, nc := createConnectionWithNatsOpts(t, clientName, nats.ReconnectWait(50*time.Millisecond))
+	defer nc.Close()
+	defer sc.Close()
 
 	// Send messages
 	for i := int32(0); i < toSend; i++ {

--- a/server/server_durable_test.go
+++ b/server/server_durable_test.go
@@ -549,7 +549,7 @@ func TestPersistentStoreDontSendToOfflineDurablesOnRestart(t *testing.T) {
 	s = runServerWithOpts(t, opts, nil)
 
 	// We should not get any message, if we do, this is an error
-	if err := WaitTime(failCh, time.Second); err == nil {
+	if err := WaitTime(failCh, 250*time.Millisecond); err == nil {
 		t.Fatal("Consumer got a message")
 	}
 }

--- a/server/server_limits_test.go
+++ b/server/server_limits_test.go
@@ -260,6 +260,10 @@ func TestPerChannelLimits(t *testing.T) {
 			defer cleanupDatastore(t)
 
 			opts = getTestDefaultOptsForPersistentStore()
+			if opts.StoreType == stores.TypeFile {
+				stores.FileStoreTestSetBackgroundTaskInterval(15 * time.Millisecond)
+				defer stores.FileStoreTestResetBackgroundTaskInterval()
+			}
 		}
 		opts.MaxMsgs = 10
 		opts.MaxAge = time.Hour
@@ -269,7 +273,7 @@ func TestPerChannelLimits(t *testing.T) {
 		clbar.MaxBytes = 1000
 		clbaz := stores.ChannelLimits{}
 		clbaz.MaxSubscriptions = 1
-		clbaz.MaxAge = time.Second
+		clbaz.MaxAge = 15 * time.Millisecond
 		sl := &opts.StoreLimits
 		sl.AddPerChannel("foo", &clfoo)
 		sl.AddPerChannel("bar", &clbar)
@@ -335,7 +339,7 @@ func TestPerChannelLimits(t *testing.T) {
 			t.Fatalf("Unexpected error on publish: %v", err)
 		}
 		// Wait more than max age
-		time.Sleep(1500 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 		// Check state
 		s.mu.RLock()
 		n, _, err = s.channels.msgsState("baz")

--- a/server/server_req_test.go
+++ b/server/server_req_test.go
@@ -138,6 +138,8 @@ func TestInvalidSubRequest(t *testing.T) {
 	req.ClientID = clientName
 
 	// Test invalid AckWait values
+	// For these tests, we need to disable testAckWaitIsInMillisecond
+	testAckWaitIsInMillisecond = false
 	req.AckWaitInSecs = 0
 	if err := sendInvalidSubRequest(s, nc, req, ErrInvalidAckWait); err != nil {
 		t.Fatalf("%v", err)
@@ -146,6 +148,7 @@ func TestInvalidSubRequest(t *testing.T) {
 	if err := sendInvalidSubRequest(s, nc, req, ErrInvalidAckWait); err != nil {
 		t.Fatalf("%v", err)
 	}
+	testAckWaitIsInMillisecond = true
 
 	// Test invalid MaxInflight values
 	req.AckWaitInSecs = 1

--- a/server/server_run_test.go
+++ b/server/server_run_test.go
@@ -107,7 +107,7 @@ func TestServerLoggerDebugAndTrace(t *testing.T) {
 	// trace and debug. May need to be adjusted.
 	str := string(out)
 	if !strings.Contains(str, "NATS conn opts") || !strings.Contains(str, "Publish subject") {
-		t.Fatalf("Expected tracing to include debug and trace, got %v", out)
+		t.Fatalf("Expected tracing to include debug and trace, got %v", str)
 	}
 }
 

--- a/server/server_storefailures_test.go
+++ b/server/server_storefailures_test.go
@@ -186,7 +186,7 @@ func TestMsgLookupFailures(t *testing.T) {
 	select {
 	case <-rcvCh:
 		t.Fatal("Should not have received the message")
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 		// we waited "long enoug" and did not receive anything, which is good
 	}
 	logger.Lock()
@@ -203,7 +203,7 @@ func TestMsgLookupFailures(t *testing.T) {
 	// Create subscription, manual ack mode, don't ack, wait for redelivery
 	sub, err = sc.Subscribe("foo", func(_ *stan.Msg) {
 		rcvCh <- true
-	}, stan.DeliverAllAvailable(), stan.SetManualAckMode(), stan.AckWait(time.Second))
+	}, stan.DeliverAllAvailable(), stan.SetManualAckMode(), stan.AckWait(ackWaitInMs(15)))
 	if err != nil {
 		t.Fatalf("Error on subscribe: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestMsgLookupFailures(t *testing.T) {
 	select {
 	case <-rcvCh:
 		t.Fatal("Should not have received the message")
-	case <-time.After(1500 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 		// we waited more than redelivery time and did not receive anything, which is good
 	}
 	logger.Lock()
@@ -245,7 +245,7 @@ func TestMsgLookupFailures(t *testing.T) {
 	// Another member does not ack.
 	qsub2, err := sc.QueueSubscribe("bar", "queue", func(_ *stan.Msg) {
 		rcvCh <- true
-	}, stan.SetManualAckMode(), stan.AckWait(time.Second))
+	}, stan.SetManualAckMode(), stan.AckWait(ackWaitInMs(15)))
 	if err != nil {
 		t.Fatalf("Error on subscribe: %v", err)
 	}

--- a/server/server_sub_test.go
+++ b/server/server_sub_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/go-nats"
 	"github.com/nats-io/go-nats-streaming"
 	"github.com/nats-io/go-nats-streaming/pb"
 	"github.com/nats-io/nats-streaming-server/stores"
@@ -770,7 +771,8 @@ func TestPersistentStoreIgnoreRecoveredSubForUnknownClientID(t *testing.T) {
 	s := runServerWithOpts(t, opts, nil)
 	defer shutdownRestartedServerOnTestExit(&s)
 
-	sc := NewDefaultConnection(t)
+	sc, nc := createConnectionWithNatsOpts(t, clientName, nats.ReconnectWait(50*time.Millisecond))
+	defer nc.Close()
 	defer sc.Close()
 
 	if _, err := sc.Subscribe("foo", func(_ *stan.Msg) {}); err != nil {


### PR DESCRIPTION
- When a subscription is created, it can specify an AckWait() which
is a duration, but the library sends the value as a number of
seconds. For tests, this can lengthen the time the test suite takes.
Making a change that allows to specify a negative value that means
that server interprets as milliseconds. The global boolean is
used to trigger this behavior.
- Changed tests to use smaller AckWait().
- Some FT tests sleep times have been reduced.
- Create explicit NATS connection with nats.ReconnectWait() for
  some tests where server is restarted. It shorten the test time
  because the client can reconnect faster.

(Note: On Travis, the benefit is not as great as running locally. It looks
like the gain there is about 30%).