### PR TITLE
Refactor CtrlMsg processing

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1076,7 +1076,7 @@ func TestPersistentStoreAcksPool(t *testing.T) {
 	}
 	// Create 10 subs
 	for i := 0; i < int(totalSubs); i++ {
-		sub, err := sc.Subscribe("foo", cb, stan.AckWait(ackWaitInMs(15)))
+		sub, err := sc.Subscribe("foo", cb, stan.AckWait(ackWaitInMs(100)))
 		if err != nil {
 			t.Fatalf("Unexpected error on subscribe: %v", err)
 		}
@@ -1094,7 +1094,7 @@ func TestPersistentStoreAcksPool(t *testing.T) {
 			stackFatalf(t, "Did not get our messages")
 		}
 		// Wait for more than redelivery time
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(115 * time.Millisecond)
 		// Check that there was no error
 		select {
 		case e := <-errCh:

--- a/spb/protocol.pb.go
+++ b/spb/protocol.pb.go
@@ -135,6 +135,7 @@ type CtrlMsg struct {
 	MsgType  CtrlMsg_Type `protobuf:"varint,1,opt,name=MsgType,proto3,enum=spb.CtrlMsg_Type" json:"MsgType,omitempty"`
 	ServerID string       `protobuf:"bytes,2,opt,name=ServerID,proto3" json:"ServerID,omitempty"`
 	Data     []byte       `protobuf:"bytes,3,opt,name=Data,proto3" json:"Data,omitempty"`
+	MsgID    string       `protobuf:"bytes,4,opt,name=MsgID,proto3" json:"MsgID,omitempty"`
 }
 
 func (m *CtrlMsg) Reset()         { *m = CtrlMsg{} }
@@ -434,6 +435,12 @@ func (m *CtrlMsg) MarshalTo(data []byte) (int, error) {
 			i += copy(data[i:], m.Data)
 		}
 	}
+	if len(m.MsgID) > 0 {
+		data[i] = 0x22
+		i++
+		i = encodeVarintProtocol(data, i, uint64(len(m.MsgID)))
+		i += copy(data[i:], m.MsgID)
+	}
 	return i, nil
 }
 
@@ -603,6 +610,10 @@ func (m *CtrlMsg) Size() (n int) {
 		if l > 0 {
 			n += 1 + l + sovProtocol(uint64(l))
 		}
+	}
+	l = len(m.MsgID)
+	if l > 0 {
+		n += 1 + l + sovProtocol(uint64(l))
 	}
 	return n
 }
@@ -1644,6 +1655,35 @@ func (m *CtrlMsg) Unmarshal(data []byte) error {
 			if m.Data == nil {
 				m.Data = []byte{}
 			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MsgID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowProtocol
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthProtocol
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MsgID = string(data[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/spb/protocol.proto
+++ b/spb/protocol.proto
@@ -70,5 +70,7 @@ message CtrlMsg {
   }
   Type    MsgType  = 1; // Type of the control message.
   string  ServerID = 2; // Allows a server to detect if it is the intended receipient.
-  bytes   Data     = 3; // Optional bytes that carries context information.
+  bytes   Data     = 3; // Optional bytes that carries context information.    
+  string  MsgID    = 4; // A control message may be sent multiple times (to different internal subscriptions).
+                        // It is used by the server to reference count all messages with same MsgID.
 }


### PR DESCRIPTION
Make it more generic since this may be use more in the future
for any kind of actions that require ordering or gating across
the multiple internal NATS subscriptions.