### PR TITLE
Fixed timers and flapping test

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1921,6 +1921,12 @@ func (s *StanServer) checkClientHealth(clientID string) {
 	_, err := s.nc.Request(hbInbox, nil, s.opts.ClientHBTimeout)
 	// Grab the lock now.
 	client.Lock()
+	// Client could have been unregistered, in which case
+	// client.hbt will be nil.
+	if client.hbt == nil {
+		client.Unlock()
+		return
+	}
 	// If we did not get the reply, increase the number of
 	// failed heartbeats.
 	if err != nil {

--- a/stores/filestore_sub_test.go
+++ b/stores/filestore_sub_test.go
@@ -952,7 +952,7 @@ func TestFSSubStoreVariousBufferSizes(t *testing.T) {
 			// Invoke the timer callback manually (so we don't have to wait)
 			// Call many times and make sure size never goes down too low.
 			for i := 0; i < 14; i++ {
-				ss.shrinkBuffer()
+				ss.shrinkBuffer(false)
 			}
 			// Now check
 			ss.RLock()
@@ -971,7 +971,7 @@ func TestFSSubStoreVariousBufferSizes(t *testing.T) {
 			// Flush to empty it
 			ss.Flush()
 			// Invoke shrink
-			ss.shrinkBuffer()
+			ss.shrinkBuffer(false)
 			// Check that request is set
 			ss.RLock()
 			shrinkReq := ss.bw.shrinkReq


### PR DESCRIPTION
Timer.Reset() should not be called concurrently with a timer
actually expiring. In one of the test, the timer's callback was
invoked directly, with a call to Reset() inside that callback
while the timer may have been firing. This caused the call to
Timer.Stop() to return `true` and yet have the callback firing,
which would cause a panic when calling WaitGroup.Done().

Tweaked a flapping test.