### PR TITLE
Refactor CtrlMsg processing

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -158,11 +158,6 @@ type ioPendingMsg struct {
 const ioChannelSize = 64 * 1024
 
 const (
-	useLocking     = true
-	dontUseLocking = false
-)
-
-const (
 	scheduleRequest = true
 	processRequest  = false
 )
@@ -349,11 +344,13 @@ type StanServer struct {
 	ioChannelQuit chan struct{}
 	ioChannelWG   sync.WaitGroup
 
-	// Used to fix out-of-order processing of subUnsub/subClose/connClose
-	// requests due to use of different NATS subscribers for various
-	// protocols.
-	closeProtosMu sync.Mutex     // Mutex used for unsub/close requests.
-	connCloseReqs map[string]int // Key: clientID Value: ref count
+	// Used to fix out-of-order processing of requests due to use of
+	// different internal NATS subscriptions.
+	ctrlMsgMu  sync.Mutex
+	ctrlMsgIDs map[string]int // Key: CtrlMsg's ID, Value: ref count
+
+	// To protect some close related requests
+	closeMu sync.Mutex
 
 	tmpBuf []byte // Used to marshal protocols (right now, only PubAck)
 
@@ -1018,7 +1015,7 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (newServer *
 		dupMaxCIDRoutines: defaultMaxDupCIDRoutines,
 		dupCIDTimeout:     defaultCheckDupCIDTimeout,
 		ioChannelQuit:     make(chan struct{}, 1),
-		connCloseReqs:     make(map[string]int),
+		ctrlMsgIDs:        make(map[string]int),
 		trace:             sOpts.Trace,
 		debug:             sOpts.Debug,
 		subStartCh:        make(chan *subStartInfo, defaultSubStartChanLen),
@@ -1869,7 +1866,7 @@ func (s *StanServer) processConnectRequestWithDupID(c *client, req *pb.ConnectRe
 	// running by sending a ping to that inbox.
 	if _, err := s.nc.Request(hbInbox, nil, s.dupCIDTimeout); err != nil {
 		// The old client didn't reply, assume it is dead, close it and continue.
-		s.closeClient(useLocking, clientID)
+		s.closeClient(clientID)
 
 		// Between the close and the new registration below, it is possible
 		// that a connection request came in (in connectCB) and since the
@@ -1937,9 +1934,7 @@ func (s *StanServer) checkClientHealth(clientID string) {
 			// close the client (connection). This locks the
 			// client object internally so unlock here.
 			client.Unlock()
-			// useLocking is not for client.Lock but for the
-			// use closeProtosMu mutex.
-			s.closeClient(useLocking, clientID)
+			s.closeClient(clientID)
 			return
 		}
 	} else {
@@ -1965,11 +1960,9 @@ func (s *StanServer) checkClientHealth(clientID string) {
 }
 
 // Close a client
-func (s *StanServer) closeClient(lock bool, clientID string) bool {
-	if lock {
-		s.closeProtosMu.Lock()
-		defer s.closeProtosMu.Unlock()
-	}
+func (s *StanServer) closeClient(clientID string) bool {
+	s.closeMu.Lock()
+	defer s.closeMu.Unlock()
 	// Remove from our clientStore.
 	client, err := s.clients.unregister(clientID)
 	// The above call may return an error (due to storage) but still return
@@ -2006,12 +1999,11 @@ func (s *StanServer) processCloseRequest(m *nats.Msg) {
 	}
 
 	// Lock for the remainder of the function
-	s.closeProtosMu.Lock()
-	defer s.closeProtosMu.Unlock()
-
+	s.ctrlMsgMu.Lock()
 	ctrlMsg := &spb.CtrlMsg{
 		MsgType:  spb.CtrlMsg_ConnClose,
 		ServerID: s.serverID,
+		MsgID:    nuid.Next(),
 		Data:     []byte(req.ClientID),
 	}
 	ctrlBytes, _ := ctrlMsg.Marshal()
@@ -2051,39 +2043,25 @@ func (s *StanServer) processCloseRequest(m *nats.Msg) {
 			sub.Unlock()
 		}
 	}
+	if refs > 0 {
+		// Store our reference count and wait for performConnClose to
+		// be invoked...
+		s.ctrlMsgIDs[ctrlMsg.MsgID] = refs
+	}
+	s.ctrlMsgMu.Unlock()
 	// If were unable to schedule a single proto, then execute
 	// performConnClose from here.
 	if refs == 0 {
-		s.connCloseReqs[req.ClientID] = 1
-		s.performConnClose(dontUseLocking, m, req.ClientID)
-	} else {
-		// Store our reference count and wait for performConnClose to
-		// be invoked...
-		s.connCloseReqs[req.ClientID] = refs
+		s.performConnClose(m, req.ClientID)
 	}
 }
 
 // performConnClose performs a connection close operation after all
 // client's pubMsg or client acks have been processed.
-func (s *StanServer) performConnClose(locking bool, m *nats.Msg, clientID string) {
-	if locking {
-		s.closeProtosMu.Lock()
-		defer s.closeProtosMu.Unlock()
-	}
-
-	refs := s.connCloseReqs[clientID]
-	refs--
-	if refs > 0 {
-		// Not done yet, update reference count
-		s.connCloseReqs[clientID] = refs
-		return
-	}
-	// Perform the connection close here...
-	delete(s.connCloseReqs, clientID)
-
+func (s *StanServer) performConnClose(m *nats.Msg, clientID string) {
 	// The function or the caller is already locking, so do not use
 	// locking in that function.
-	if !s.closeClient(dontUseLocking, clientID) {
+	if !s.closeClient(clientID) {
 		s.log.Errorf("Unknown client %q in close request", clientID)
 		s.sendCloseErr(m.Reply, ErrUnknownClient.Error())
 		return
@@ -2106,8 +2084,7 @@ func (s *StanServer) processClientPublish(m *nats.Msg) {
 	iopm := &ioPendingMsg{m: m}
 	pm := &iopm.pm
 	if pm.Unmarshal(m.Data) != nil {
-		// Expecting only a connection close request...
-		if s.processInternalCloseRequest(m, true) {
+		if s.processCtrlMsg(m) {
 			return
 		}
 		// else we will report an error below...
@@ -2123,13 +2100,13 @@ func (s *StanServer) processClientPublish(m *nats.Msg) {
 	s.ioChannel <- iopm
 }
 
-// processInternalCloseRequest processes the incoming message has
-// a CtrlMsg. If this is not a CtrlMsg, returns false to indicate an error.
+// processCtrlMsg processes the incoming message has a CtrlMsg.
+// If this is not a CtrlMsg, returns false to indicate an error.
 // If the CtrlMsg's ServerID is not this server, the request is simply
 // ignored and this function returns true (so the caller does not fail).
 // Based on the CtrlMsg type, invokes appropriate function to
-// do final processing of unsub/subclose/conn close request.
-func (s *StanServer) processInternalCloseRequest(m *nats.Msg, onlyConnClose bool) bool {
+// do final processing of unsub/subclose/conn close/etc requests.
+func (s *StanServer) processCtrlMsg(m *nats.Msg) bool {
 	cm := &spb.CtrlMsg{}
 	if cm.Unmarshal(m.Data) != nil {
 		return false
@@ -2139,10 +2116,24 @@ func (s *StanServer) processInternalCloseRequest(m *nats.Msg, onlyConnClose bool
 	if cm.ServerID != s.serverID {
 		return true
 	}
-	// If we expect only a connection close request but get
-	// something else, report as a failure.
-	if onlyConnClose && cm.MsgType != spb.CtrlMsg_ConnClose {
-		return false
+	var process bool
+	s.ctrlMsgMu.Lock()
+	// If present, the ref count should be > 0 at this stage.
+	// If not present, ignore the request, there is a bug somewhere.
+	if refs := s.ctrlMsgIDs[cm.MsgID]; refs > 0 {
+		refs--
+		if refs == 0 {
+			delete(s.ctrlMsgIDs, cm.MsgID)
+			process = true
+		} else {
+			s.ctrlMsgIDs[cm.MsgID] = refs
+		}
+	} else {
+		s.log.Errorf("Unexpected ref count for CtrlMsg %q", cm.MsgType.String())
+	}
+	s.ctrlMsgMu.Unlock()
+	if !process {
+		return true
 	}
 	switch cm.MsgType {
 	case spb.CtrlMsg_SubUnsubscribe:
@@ -2155,7 +2146,7 @@ func (s *StanServer) processInternalCloseRequest(m *nats.Msg, onlyConnClose bool
 		s.performSubUnsubOrClose(cm.MsgType, processRequest, m, req)
 	case spb.CtrlMsg_ConnClose:
 		clientID := string(cm.Data)
-		s.performConnClose(useLocking, m, clientID)
+		s.performConnClose(m, clientID)
 	default:
 		return false // Valid ctrl message, but unexpected type, return failure.
 	}
@@ -2853,17 +2844,15 @@ func (s *StanServer) performSubUnsubOrClose(reqType spb.CtrlMsg_Type, schedule b
 		return
 	}
 
-	// Lock for the remainder of the function
-	s.closeProtosMu.Lock()
-	defer s.closeProtosMu.Unlock()
-
 	if schedule {
 		processInPlace := true
+		s.ctrlMsgMu.Lock()
 		sub.Lock()
 		if !sub.removed {
 			ctrlMsg := &spb.CtrlMsg{
 				MsgType:  reqType,
 				ServerID: s.serverID,
+				MsgID:    nuid.Next(),
 				Data:     m.Data,
 			}
 			ctrlBytes, _ := ctrlMsg.Marshal()
@@ -2874,17 +2863,24 @@ func (s *StanServer) performSubUnsubOrClose(reqType spb.CtrlMsg_Type, schedule b
 				Reply:   m.Reply,
 				Data:    ctrlBytes,
 			}
+			// If we publish the ctrlMsg, we are not going to process this
+			// in place. Instead, we are going to be called back from
+			// processAckMsg with reqType == processRequest.
 			if s.ncs.PublishMsg(ctrlMsgNatsMsg) == nil {
-				// This function will be called from processAckMsg with
-				// internal == true.
 				processInPlace = false
+				s.ctrlMsgIDs[ctrlMsg.MsgID] = 1
 			}
 		}
 		sub.Unlock()
+		s.ctrlMsgMu.Unlock()
 		if !processInPlace {
 			return
 		}
 	}
+
+	// Lock for the remainder of the function
+	s.closeMu.Lock()
+	defer s.closeMu.Unlock()
 
 	// Remove from Client
 	if !s.clients.removeSub(req.ClientID, sub) {
@@ -3224,9 +3220,9 @@ func (s *StanServer) processSubscriptionRequest(m *nats.Msg) {
 	}
 	if err != nil {
 		// Try to undo what has been done.
-		s.closeProtosMu.Lock()
+		s.closeMu.Lock()
 		ss.Remove(c, sub, false)
-		s.closeProtosMu.Unlock()
+		s.closeMu.Unlock()
 		s.log.Errorf("Unable to add subscription for %s: %v", sr.Subject, err)
 		s.sendSubscriptionResponseErr(m.Reply, err)
 		return
@@ -3397,8 +3393,7 @@ func (s *StanServer) processSubscriptionsStart() {
 func (s *StanServer) processAckMsg(m *nats.Msg) {
 	ack := &pb.Ack{}
 	if ack.Unmarshal(m.Data) != nil {
-		// Expecting the full range of "close" requests: subUnsub, subClose, or connClose
-		if s.processInternalCloseRequest(m, false) {
+		if s.processCtrlMsg(m) {
 			return
 		}
 	}

--- a/spb/protocol.pb.go
+++ b/spb/protocol.pb.go
@@ -135,6 +135,7 @@ type CtrlMsg struct {
 	MsgType  CtrlMsg_Type `protobuf:"varint,1,opt,name=MsgType,proto3,enum=spb.CtrlMsg_Type" json:"MsgType,omitempty"`
 	ServerID string       `protobuf:"bytes,2,opt,name=ServerID,proto3" json:"ServerID,omitempty"`
 	Data     []byte       `protobuf:"bytes,3,opt,name=Data,proto3" json:"Data,omitempty"`
+	MsgID    string       `protobuf:"bytes,4,opt,name=MsgID,proto3" json:"MsgID,omitempty"`
 }
 
 func (m *CtrlMsg) Reset()         { *m = CtrlMsg{} }
@@ -434,6 +435,12 @@ func (m *CtrlMsg) MarshalTo(data []byte) (int, error) {
 			i += copy(data[i:], m.Data)
 		}
 	}
+	if len(m.MsgID) > 0 {
+		data[i] = 0x22
+		i++
+		i = encodeVarintProtocol(data, i, uint64(len(m.MsgID)))
+		i += copy(data[i:], m.MsgID)
+	}
 	return i, nil
 }
 
@@ -603,6 +610,10 @@ func (m *CtrlMsg) Size() (n int) {
 		if l > 0 {
 			n += 1 + l + sovProtocol(uint64(l))
 		}
+	}
+	l = len(m.MsgID)
+	if l > 0 {
+		n += 1 + l + sovProtocol(uint64(l))
 	}
 	return n
 }
@@ -1644,6 +1655,35 @@ func (m *CtrlMsg) Unmarshal(data []byte) error {
 			if m.Data == nil {
 				m.Data = []byte{}
 			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MsgID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowProtocol
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthProtocol
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MsgID = string(data[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/spb/protocol.proto
+++ b/spb/protocol.proto
@@ -70,5 +70,7 @@ message CtrlMsg {
   }
   Type    MsgType  = 1; // Type of the control message.
   string  ServerID = 2; // Allows a server to detect if it is the intended receipient.
-  bytes   Data     = 3; // Optional bytes that carries context information.
+  bytes   Data     = 3; // Optional bytes that carries context information.    
+  string  MsgID    = 4; // A control message may be sent multiple times (to different internal subscriptions).
+                        // It is used by the server to reference count all messages with same MsgID.
 }


### PR DESCRIPTION
Make it more generic since this may be use more in the future
for any kind of actions that require ordering or gating across
the multiple internal NATS subscriptions.