### PR TITLE
Extract common store tests

### DIFF
--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -8,9 +8,10 @@ go test -v -covermode=atomic -coverprofile=./cov/logger.out ./logger
 # repeat these server FT tests but focus on stores package
 go test -v -covermode=atomic -coverprofile=./cov/stores1.out -run=TestFTPartition -coverpkg=./stores ./server
 go test -v -covermode=atomic -coverprofile=./cov/stores2.out ./stores
-go test -v -covermode=atomic -coverprofile=./cov/stores3.out -run=TestFS ./stores -no_buffer
-go test -v -covermode=atomic -coverprofile=./cov/stores4.out -run=TestFS ./stores -set_fds_limit
-go test -v -covermode=atomic -coverprofile=./cov/stores5.out -run=TestFS ./stores -no_buffer -set_fds_limit
+go test -v -covermode=atomic -coverprofile=./cov/stores3.out -run=TestCS ./stores -store file
+go test -v -covermode=atomic -coverprofile=./cov/stores4.out -run=TestFS ./stores -store file -no_buffer
+go test -v -covermode=atomic -coverprofile=./cov/stores5.out -run=TestFS ./stores -store file -set_fds_limit
+go test -v -covermode=atomic -coverprofile=./cov/stores6.out -run=TestFS ./stores -store file -no_buffer -set_fds_limit
 go test -v -covermode=atomic -coverprofile=./cov/util.out ./util
 gocovmerge ./cov/*.out > acc.out
 rm -rf ./cov

--- a/stores/common_test.go
+++ b/stores/common_test.go
@@ -829,7 +829,18 @@ func testGetSeqFromStartTime(t *testing.T, s Store) {
 		t.Fatalf("Expected seq to be %v, got %v", msgs[count-1].Sequence+1, seq)
 	}
 	// Wait for all messages to expire
-	time.Sleep(600 * time.Millisecond)
+	deadline := time.Now().Add(2 * time.Second)
+	var n int
+	for time.Now().Before(deadline) {
+		n, _ = msgStoreState(t, cs.Msgs)
+		if n == 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if n > 0 {
+		stackFatalf(t, "Messages should have all expired by now")
+	}
 	// Now these calls should all return the lastSeq + 1
 	seq1 := msgStoreGetSequenceFromTimestamp(t, cs.Msgs, time.Now().UnixNano()-int64(time.Hour))
 	seq2 := msgStoreGetSequenceFromTimestamp(t, cs.Msgs, time.Now().UnixNano()+int64(time.Hour))

--- a/stores/filestore_msg_test.go
+++ b/stores/filestore_msg_test.go
@@ -32,36 +32,6 @@ func init() {
 	sliceCloseInterval = testDefaultSliceCLoseInterval
 }
 
-func TestFSBasicMsgStore(t *testing.T) {
-	cleanupDatastore(t)
-	defer cleanupDatastore(t)
-
-	fs := createDefaultFileStore(t)
-	defer fs.Close()
-
-	testBasicMsgStore(t, fs)
-}
-
-func TestFSMsgsState(t *testing.T) {
-	cleanupDatastore(t)
-	defer cleanupDatastore(t)
-
-	fs := createDefaultFileStore(t)
-	defer fs.Close()
-
-	testMsgsState(t, fs)
-}
-
-func TestFSMaxMsgs(t *testing.T) {
-	cleanupDatastore(t)
-	defer cleanupDatastore(t)
-
-	fs := createDefaultFileStore(t)
-	defer fs.Close()
-
-	testMaxMsgs(t, fs)
-}
-
 func TestFSMaxAge(t *testing.T) {
 	cleanupDatastore(t)
 	defer cleanupDatastore(t)
@@ -1143,12 +1113,12 @@ func TestFSRecoverSlicesOutOfOrder(t *testing.T) {
 	}
 }
 
-func TestFirstAndLastMsg(t *testing.T) {
+func TestFSFirstAndLastMsg(t *testing.T) {
 	cleanupDatastore(t)
 	defer cleanupDatastore(t)
 
 	limit := testDefaultStoreLimits
-	limit.MaxAge = time.Second
+	limit.MaxAge = 100 * time.Millisecond
 	fs, _, err := newFileStore(t, defaultDataStore, &limit)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -1174,7 +1144,7 @@ func TestFirstAndLastMsg(t *testing.T) {
 			ok = true
 			break
 		}
-		time.Sleep(250 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 	}
 	if !ok {
 		t.Fatal("Timed-out waiting for messages to expire")
@@ -1207,7 +1177,7 @@ func TestFirstAndLastMsg(t *testing.T) {
 	}
 }
 
-func TestBufShrink(t *testing.T) {
+func TestFSBufShrink(t *testing.T) {
 	if disableBufferWriters {
 		t.SkipNow()
 	}

--- a/stores/filestore_sub_test.go
+++ b/stores/filestore_sub_test.go
@@ -14,44 +14,6 @@ import (
 	"github.com/nats-io/nats-streaming-server/util"
 )
 
-func TestFSMaxSubs(t *testing.T) {
-	cleanupDatastore(t)
-	defer cleanupDatastore(t)
-
-	fs := createDefaultFileStore(t)
-	defer fs.Close()
-
-	limitCount := 2
-
-	limits := testDefaultStoreLimits
-	limits.MaxSubscriptions = limitCount
-
-	if err := fs.SetLimits(&limits); err != nil {
-		t.Fatalf("Unexpected error setting limits: %v", err)
-	}
-
-	testMaxSubs(t, fs, "foo", limitCount)
-
-	// Set the limit to 0
-	limits.MaxSubscriptions = 0
-	if err := fs.SetLimits(&limits); err != nil {
-		t.Fatalf("Unexpected error setting limits: %v", err)
-	}
-	// Now try to test the limit against
-	// any value, it should not fail
-	testMaxSubs(t, fs, "bar", 0)
-}
-
-func TestFSBasicSubStore(t *testing.T) {
-	cleanupDatastore(t)
-	defer cleanupDatastore(t)
-
-	fs := createDefaultFileStore(t)
-	defer fs.Close()
-
-	testBasicSubStore(t, fs)
-}
-
 func TestFSRecoverSubUpdatesForDeleteSubOK(t *testing.T) {
 	cleanupDatastore(t)
 	defer cleanupDatastore(t)


### PR DESCRIPTION
We use to have some common tests defined in common_test.go that
would be called from memory_test.go and filestore_test.go. In
memory and file store, we would simply create a specific instance
of the store and then call the function corresponding to the
common test.
These tests now become real tests (start with Test instead of test)
and they invoke startTest() that will return a memory or file based
store based on command line parameter (-store). The default is
memory store.