### PR TITLE
Fixed SubStore handling of subscriptions count

### DIFF
--- a/stores/common.go
+++ b/stores/common.go
@@ -33,14 +33,16 @@ type genericStore struct {
 	channels map[string]*Channel
 }
 
+// Used as the value for the genericSubStore's subs map.
+var emptySub = struct{}{}
+
 // genericSubStore is the generic store implementation that manages subscriptions
 // for a given channel.
 type genericSubStore struct {
 	commonStore
-	limits    SubStoreLimits
-	subject   string // Can't be wildcard
-	subsCount int
-	maxSubID  uint64
+	limits   SubStoreLimits
+	subs     map[uint64]interface{}
+	maxSubID uint64
 }
 
 // genericMsgStore is the generic store implementation that manages messages
@@ -304,10 +306,10 @@ func (gms *genericMsgStore) Close() error {
 ////////////////////////////////////////////////////////////////////////////
 
 // init initializes the structure of a generic sub store
-func (gss *genericSubStore) init(channel string, log logger.Logger, limits *SubStoreLimits) {
-	gss.subject = channel
+func (gss *genericSubStore) init(log logger.Logger, limits *SubStoreLimits) {
 	gss.limits = *limits
 	gss.log = log
+	gss.subs = make(map[uint64]interface{})
 }
 
 // CreateSub records a new subscription represented by SubState. On success,
@@ -315,7 +317,7 @@ func (gss *genericSubStore) init(channel string, log logger.Logger, limits *SubS
 // by the other SubStore methods.
 func (gss *genericSubStore) CreateSub(sub *spb.SubState) error {
 	gss.Lock()
-	err := gss.createSub(sub)
+	err := gss.createSubLocked(sub)
 	gss.Unlock()
 	return err
 }
@@ -325,19 +327,22 @@ func (gss *genericSubStore) UpdateSub(sub *spb.SubState) error {
 	return nil
 }
 
-// createSub is the unlocked version of CreateSub that can be used by
-// non-generic implementations.
-func (gss *genericSubStore) createSub(sub *spb.SubState) error {
-	if gss.limits.MaxSubscriptions > 0 && gss.subsCount >= gss.limits.MaxSubscriptions {
+// createSubLocked checks that the number of subscriptions is below the max
+// and if so, assigns a new subscription ID and keep track of it in a map.
+// Lock is assumed to be held on entry.
+func (gss *genericSubStore) createSubLocked(sub *spb.SubState) error {
+	if gss.limits.MaxSubscriptions > 0 && len(gss.subs) >= gss.limits.MaxSubscriptions {
 		return ErrTooManySubs
 	}
 
 	// Bump the max value before assigning it to the new subscription.
 	gss.maxSubID++
-	gss.subsCount++
 
 	// This new subscription has the max value.
 	sub.ID = gss.maxSubID
+	// Store anything. Some implementations may replace with specific
+	// object.
+	gss.subs[sub.ID] = emptySub
 
 	return nil
 }
@@ -345,7 +350,7 @@ func (gss *genericSubStore) createSub(sub *spb.SubState) error {
 // DeleteSub invalidates this subscription.
 func (gss *genericSubStore) DeleteSub(subid uint64) error {
 	gss.Lock()
-	gss.subsCount--
+	delete(gss.subs, subid)
 	gss.Unlock()
 	return nil
 }

--- a/stores/common_test.go
+++ b/stores/common_test.go
@@ -331,7 +331,7 @@ func TestGSNoOps(t *testing.T) {
 
 	gss := &genericSubStore{}
 	defer gss.Close()
-	gss.init("foo", testLogger, &limits.SubStoreLimits)
+	gss.init(testLogger, &limits.SubStoreLimits)
 	if gss.UpdateSub(&spb.SubState{}) != nil ||
 		gss.AddSeqPending(1, 1) != nil ||
 		gss.AckSeqPending(1, 1) != nil ||

--- a/stores/memstore.go
+++ b/stores/memstore.go
@@ -61,7 +61,7 @@ func (ms *MemoryStore) CreateChannel(channel string) (*Channel, error) {
 	msgStore.init(channel, ms.log, &channelLimits.MsgStoreLimits)
 
 	subStore := &MemorySubStore{}
-	subStore.init(channel, ms.log, &channelLimits.SubStoreLimits)
+	subStore.init(ms.log, &channelLimits.SubStoreLimits)
 
 	c := &Channel{
 		Subs: subStore,


### PR DESCRIPTION
The `genericSubStore` was keep track of the subscriptions count
using a simple integer. The problem is that on DeleteSub(), the
count would be decreased, regardless if this subscription either
existed or had been already deleted or never existed.
This was not really a problem since the server should not delete
the same subscription twice.
However, it is safer to make the DeleteSub() store operation
idempotent. To that effect, the count is replaced with a map
in the genericSubStore. The test for max number of subscriptions
now relies on the length of the map. If a subscription is deleted
twice, it will be removed from the map only once and again, the
count is based on size of map, not a separate counter.
Since FileSubStore used a map due to the need during compaction
of the subscriptions file, the field has been removed and instead
the FileSubStore is now using the map from the genericSubStore.
That map uses interface{} for the values. The FileSubStore therefore
type cast the value to (*subscription).