### PR TITLE
[CHANGED] FileStore.Recover() closing store on error.

### DIFF
--- a/stores/bench_test.go
+++ b/stores/bench_test.go
@@ -26,12 +26,14 @@ func benchCreateDefaultFileStore(t *testing.B) (*FileStore, *RecoveredState) {
 	}
 	state, err := fs.Recover()
 	if err != nil {
+		fs.Close()
 		stackFatalf(t, "Unable to restore the state: %v", err)
 	}
 	if state == nil {
 		info := testDefaultServerInfo
 
 		if err := fs.Init(&info); err != nil {
+			fs.Close()
 			stackFatalf(t, "Unexpected error durint Init: %v", err)
 		}
 	}

--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -1156,9 +1156,6 @@ func (fs *FileStore) Recover() (*RecoveredState, error) {
 		if fs.clientsFile != nil {
 			fs.fm.unlockFile(fs.clientsFile)
 		}
-		if err != nil {
-			fs.Close()
-		}
 	}()
 
 	// Open/Create the server file (note that this file must not be opened,

--- a/stores/filestore_test.go
+++ b/stores/filestore_test.go
@@ -386,6 +386,7 @@ func newFileStore(t *testing.T, dataStore string, limits *StoreLimits, options .
 	}
 	state, err := fs.Recover()
 	if err != nil {
+		fs.Close()
 		return nil, nil, err
 	}
 	return fs, state, nil


### PR DESCRIPTION
Added locking to this function and removed auto-close on error
condition. Caller is likely to close the store if recovery fails.