### PR TITLE
[FIXED] Monitoring of offline durable queue subscription

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -346,6 +346,11 @@ func getMonitorChannelSubs(ss *subStore) []*Subscriptionz {
 		for _, sub := range qsub.subs {
 			subsz = append(subsz, createSubscriptionz(sub))
 		}
+		// If this is a durable queue subscription and all members
+		// are offline, qsub.shadow will be not nil. Report this one.
+		if qsub.shadow != nil {
+			subsz = append(subsz, createSubscriptionz(qsub.shadow))
+		}
 		qsub.RUnlock()
 	}
 	return subsz

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -1057,60 +1057,65 @@ func TestMonitorDurableSubs(t *testing.T) {
 	sc := NewDefaultConnection(t)
 	defer sc.Close()
 
-	for iter := 0; iter < 2; iter++ {
-		// Create a durable
-		dur, err := sc.Subscribe("foo", func(_ *stan.Msg) {}, stan.DurableName("dur"))
-		if err != nil {
-			t.Fatalf("Unexpected error on subscribe: %v", err)
-		}
-		// Get the subs for this channel, check there is expected number of subs
-		getAndCheck := func(expectedOffline bool, expectedCount int) {
-			var channel *Channelz
-			if iter == 0 {
-				resp, body := getBody(t, ChannelsPath+"?subs=1", expectedJSON)
-				defer resp.Body.Close()
-				channels := &Channelsz{}
-				if err := json.Unmarshal(body, channels); err != nil {
-					stackFatalf(t, "Error unmarshalling: %v", err)
+	queueNames := []string{"", "queue"}
+	for _, queue := range queueNames {
+		for iter := 0; iter < 2; iter++ {
+			// Create a durable
+			// Make use of the fact that the API accepts an empty queue name, in which
+			// case it creates a regular durable subscription.
+			dur, err := sc.QueueSubscribe("foo", queue, func(_ *stan.Msg) {}, stan.DurableName("dur"))
+			if err != nil {
+				t.Fatalf("Unexpected error on subscribe: %v", err)
+			}
+			// Get the subs for this channel, check there is expected number of subs
+			getAndCheck := func(expectedOffline bool, expectedCount int) {
+				var channel *Channelz
+				if iter == 0 {
+					resp, body := getBody(t, ChannelsPath+"?subs=1", expectedJSON)
+					defer resp.Body.Close()
+					channels := &Channelsz{}
+					if err := json.Unmarshal(body, channels); err != nil {
+						stackFatalf(t, "Error unmarshalling: %v", err)
+					}
+					if len(channels.Channels) != 1 {
+						stackFatalf(t, "Expected a single channel, got %v", len(channels.Channels))
+					}
+					channel = channels.Channels[0]
+				} else {
+					resp, body := getBody(t, ChannelsPath+"?channel=foo&subs=1", expectedJSON)
+					defer resp.Body.Close()
+					channel = &Channelz{}
+					if err := json.Unmarshal(body, channel); err != nil {
+						stackFatalf(t, "Error unmarshalling: %v", err)
+					}
 				}
-				if len(channels.Channels) != 1 {
-					stackFatalf(t, "Expected a single channel, got %v", len(channels.Channels))
+				if numSubs := len(channel.Subscriptions); numSubs != expectedCount {
+					stackFatalf(t, "Expected %d subscription(s), got %v", expectedCount, numSubs)
 				}
-				channel = channels.Channels[0]
-			} else {
-				resp, body := getBody(t, ChannelsPath+"?channel=foo&subs=1", expectedJSON)
-				defer resp.Body.Close()
-				channel = &Channelz{}
-				if err := json.Unmarshal(body, channel); err != nil {
-					stackFatalf(t, "Error unmarshalling: %v", err)
+				if expectedCount == 1 {
+					sub := channel.Subscriptions[0]
+					if sub.IsOffline != expectedOffline {
+						stackFatalf(t, "Unexpected IsOffline, wants %v, got %v", expectedOffline, sub.IsOffline)
+					}
 				}
 			}
-			if numSubs := len(channel.Subscriptions); numSubs != expectedCount {
-				stackFatalf(t, "Expected %d subscription(s), got %v", expectedCount, numSubs)
+			// There should be 1 sub
+			getAndCheck(false, 1)
+			// Close durable
+			dur.Close()
+			// Check again
+			getAndCheck(true, 1)
+			// Restart durable
+			dur, err = sc.QueueSubscribe("foo", queue, func(_ *stan.Msg) {}, stan.DurableName("dur"))
+			if err != nil {
+				t.Fatalf("Unexpected error on subscribe: %v", err)
 			}
-			if expectedCount == 1 {
-				sub := channel.Subscriptions[0]
-				if sub.IsOffline != expectedOffline {
-					stackFatalf(t, "Unexpected IsOffline, wants %v, got %v", expectedOffline, sub.IsOffline)
-				}
-			}
+			// Check again
+			getAndCheck(false, 1)
+			// Now Unsubscribe
+			dur.Unsubscribe()
+			// There shouldn't be any sub now
+			getAndCheck(false, 0)
 		}
-		// There should be 1 sub
-		getAndCheck(false, 1)
-		// Close durable
-		dur.Close()
-		// Check again
-		getAndCheck(true, 1)
-		// Restart durable
-		dur, err = sc.Subscribe("foo", func(_ *stan.Msg) {}, stan.DurableName("dur"))
-		if err != nil {
-			t.Fatalf("Unexpected error on subscribe: %v", err)
-		}
-		// Check again
-		getAndCheck(false, 1)
-		// Now Unsubscribe
-		dur.Unsubscribe()
-		// There shouldn't be any sub now
-		getAndCheck(false, 0)
 	}
 }


### PR DESCRIPTION
When all members of a durable queue subscription were offline,
the monitoring page would not show the durable queue subscription
anymore.

Resolves #385