### PR TITLE
[FIXED] Override of options from configuration files

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -6,15 +6,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"reflect"
 	"runtime"
-	"strings"
-	"time"
 
-	"github.com/nats-io/gnatsd/conf"
 	natsd "github.com/nats-io/gnatsd/server"
 	stand "github.com/nats-io/nats-streaming-server/server"
-	"github.com/nats-io/nats-streaming-server/stores"
 )
 
 var usageStr = `
@@ -128,261 +123,18 @@ func main() {
 }
 
 func parseFlags() (*stand.Options, *natsd.Options) {
+	fs := flag.NewFlagSet("streaming", flag.ExitOnError)
+	fs.Usage = usage
 
-	// STAN options
-	var stanDebugAndTrace bool
-	var stanConfigFile string
-
-	// Define the flags for STAN. We use the Usage (last field)
-	// as the actual Options name. We will then use reflection
-	// to apply any command line option to stanOpts, overriding
-	// defaults and options set during file parsing.
-	flag.String("cluster_id", stand.DefaultClusterID, "stan.ID")
-	flag.String("cid", stand.DefaultClusterID, "stan.ID")
-	flag.String("store", stores.TypeMemory, "stan.StoreType")
-	flag.String("st", stores.TypeMemory, "stan.StoreType")
-	flag.String("dir", "", "stan.FilestoreDir")
-	flag.Int("max_channels", stores.DefaultStoreLimits.MaxChannels, "stan.MaxChannels")
-	flag.Int("mc", stores.DefaultStoreLimits.MaxChannels, "stan.MaxChannels")
-	flag.Int("max_subs", stores.DefaultStoreLimits.MaxSubscriptions, "stan.MaxSubscriptions")
-	flag.Int("msu", stores.DefaultStoreLimits.MaxSubscriptions, "stan.MaxSubscriptions")
-	flag.Int("max_msgs", stores.DefaultStoreLimits.MaxMsgs, "stan.MaxMsgs")
-	flag.Int("mm", stores.DefaultStoreLimits.MaxMsgs, "stan.MaxMsgs")
-	flag.String("max_bytes", fmt.Sprintf("%v", stores.DefaultStoreLimits.MaxBytes), "stan.MaxBytes")
-	flag.String("mb", fmt.Sprintf("%v", stores.DefaultStoreLimits.MaxBytes), "stan.MaxBytes")
-	flag.String("max_age", "0s", "stan.MaxAge")
-	flag.String("ma", "0s", "stan.MaxAge")
-	flag.String("hbi", stand.DefaultHeartBeatInterval.String(), "stan.ClientHBInterval")
-	flag.String("hb_interval", stand.DefaultHeartBeatInterval.String(), "stan.ClientHBInterval")
-	flag.String("hbt", stand.DefaultClientHBTimeout.String(), "stan.ClientHBTimeout")
-	flag.String("hb_timeout", stand.DefaultClientHBTimeout.String(), "stan.ClientHBTimeout")
-	flag.Int("hbf", stand.DefaultMaxFailedHeartBeats, "stan.ClientHBFailCount")
-	flag.Int("hb_fail_count", stand.DefaultMaxFailedHeartBeats, "stan.ClientHBFailCount")
-	flag.Bool("SD", false, "stan.Debug")
-	flag.Bool("stan_debug", false, "stan.Debug")
-	flag.Bool("SV", false, "stan.Trace")
-	flag.Bool("stan_trace", false, "stan.Trace")
-	flag.BoolVar(&stanDebugAndTrace, "SDV", false, "")
-	flag.Bool("secure", false, "stan.Secure")
-	flag.String("tls_client_cert", "", "stan.ClientCert")
-	flag.String("tls_client_key", "", "stan.ClientKey")
-	flag.String("tls_client_cacert", "", "stan.ClientCA")
-	flag.String("nats_server", "", "stan.NATSServerURL")
-	flag.String("ns", "", "stan.NATSServerURL")
-	flag.StringVar(&stanConfigFile, "sc", "", "")
-	flag.StringVar(&stanConfigFile, "stan_config", "", "")
-	flag.Int("ack_subs", 0, "stan.AckSubsPoolSize")
-	flag.Bool("file_compact_enabled", stores.DefaultFileStoreOptions.CompactEnabled, "stan.FileStoreOpts.CompactEnabled")
-	flag.Int("file_compact_frag", stores.DefaultFileStoreOptions.CompactFragmentation, "stan.FileStoreOpts.CompactFragmentation")
-	flag.Int("file_compact_interval", stores.DefaultFileStoreOptions.CompactInterval, "stan.FileStoreOpts.CompactInterval")
-	flag.String("file_compact_min_size", fmt.Sprintf("%v", stores.DefaultFileStoreOptions.CompactMinFileSize), "stan.FileStoreOpts.CompactMinFileSize")
-	flag.String("file_buffer_size", fmt.Sprintf("%v", stores.DefaultFileStoreOptions.BufferSize), "stan.FileStoreOpts.BufferSize")
-	flag.Bool("file_crc", stores.DefaultFileStoreOptions.DoCRC, "stan.FileStoreOpts.DoCRC")
-	flag.Int64("file_crc_poly", stores.DefaultFileStoreOptions.CRCPolynomial, "stan.FileStoreOpts.CRCPolynomial")
-	flag.Bool("file_sync", stores.DefaultFileStoreOptions.DoSync, "stan.FileStoreOpts.DoSync")
-	flag.Int("file_slice_max_msgs", stores.DefaultFileStoreOptions.SliceMaxMsgs, "stan.FileStoreOpts.SliceMaxMsgs")
-	flag.String("file_slice_max_bytes", fmt.Sprintf("%v", stores.DefaultFileStoreOptions.SliceMaxBytes), "stan.FileStoreOpts.SliceMaxBytes")
-	flag.String("file_slice_max_age", "0s", "stan.FileStoreOpts.SliceMaxAge")
-	flag.String("file_slice_archive_script", "", "stan.FileStoreOpts.SliceArchiveScript")
-	flag.Int64("file_fds_limit", stores.DefaultFileStoreOptions.FileDescriptorsLimit, "stan.FileStoreOpts.FileDescriptorsLimit")
-	flag.Int("file_parallel_recovery", stores.DefaultFileStoreOptions.ParallelRecovery, "stan.FileStoreOpts.ParallelRecovery")
-	flag.Int("io_batch_size", stand.DefaultIOBatchSize, "stan.IOBatchSize")
-	flag.Int64("io_sleep_time", stand.DefaultIOSleepTime, "stan.IOSleepTime")
-	flag.String("ft_group", "", "stan.FTGroupName")
-
-	// NATS options
-	var showVersion bool
-	var natsDebugAndTrace bool
-	var showTLSHelp bool
-	var gnatsdConfigFile string
-
-	// TODO: Expose gnatsd parsing into server options
-	// (cls) This is a development placeholder until gnatsd
-	// options parsing is exposed, if we go that way.
-	//
-	// IMPORTANT: Do not use Usage field (last) since this is
-	// used to do reflection. Note that usage is defined in
-	// usageStr anyway.
-	flag.Int("port", 0, "nats.Port")
-	flag.Int("p", 0, "nats.Port")
-	flag.String("addr", "", "nats.Host")
-	flag.String("a", "", "nats.Host")
-	flag.String("net", "", "nats.Host")
-	flag.Bool("D", false, "nats.Debug")
-	flag.Bool("debug", false, "nats.Debug")
-	flag.Bool("V", false, "nats.Trace")
-	flag.Bool("trace", false, "nats.Trace")
-	flag.BoolVar(&natsDebugAndTrace, "DV", false, "")
-	flag.Bool("T", true, "nats.Logtime")
-	flag.Bool("logtime", true, "nats.Logtime")
-	flag.String("user", "", "nats.Username")
-	flag.String("pass", "", "nats.Password")
-	flag.String("auth", "", "nats.Authorization")
-	flag.Int("m", 0, "nats.HTTPPort")
-	flag.Int("http_port", 0, "nats.HTTPPort")
-	flag.Int("ms", 0, "nats.HTTPSPort")
-	flag.Int("https_port", 0, "nats.HTTPSPort")
-	flag.StringVar(&gnatsdConfigFile, "c", "", "")
-	flag.StringVar(&gnatsdConfigFile, "config", "", "")
-	flag.String("P", "", "nats.PidFile")
-	flag.String("pid", "", "nats.PidFile")
-	flag.String("l", "", "nats.LogFile")
-	flag.String("log", "", "nats.LogFile")
-	flag.Bool("s", false, "nats.Syslog")
-	flag.Bool("syslog", false, "nats.Syslog")
-	flag.String("r", "", "nats.RemoteSyslog")
-	flag.String("remote_syslog", "", "nats.RemoteSyslog")
-	flag.BoolVar(&showVersion, "version", false, "")
-	flag.BoolVar(&showVersion, "v", false, "")
-	flag.Int("profile", 0, "nats.ProfPort")
-	flag.String("routes", "", "nats.RoutesStr")
-	flag.String("cluster", "", "nats.Cluster.ListenStr")
-	flag.String("cluster_listen", "", "nats.Cluster.ListenStr")
-	flag.BoolVar(&showTLSHelp, "help_tls", false, "")
-	flag.Bool("tls", false, "nats.TLS")
-	flag.Bool("tlsverify", false, "nats.TLSVerify")
-	flag.String("tlscert", "", "nats.TLSCert")
-	flag.String("tlskey", "", "nats.TLSKey")
-	flag.String("tlscacert", "", "nats.TLSCaCert")
-
-	flag.Usage = func() {
-		fmt.Printf("%s\n", usageStr)
-	}
-	flag.Parse()
-
-	// Show version and exit
-	if showVersion {
-		fmt.Printf("nats-streaming-server version %s, ", stand.VERSION)
-		natsd.PrintServerAndExit()
-	}
-
-	//
-	// NATS server option special handling
-	//
-	if showTLSHelp {
-		natsd.PrintTLSHelpAndDie()
-	}
-
-	// Process args looking for non-flag options,
-	// 'version' and 'help' only for now
-	showVersion, showHelp, err := natsd.ProcessCommandLineArgs(flag.CommandLine)
+	stanOpts, natsOpts, err := stand.ConfigureOptions(fs, os.Args[1:],
+		func() {
+			fmt.Printf("nats-streaming-server version %s, ", stand.VERSION)
+			natsd.PrintServerAndExit()
+		},
+		fs.Usage,
+		natsd.PrintTLSHelpAndDie)
 	if err != nil {
-		natsd.PrintAndDie(err.Error() + usageStr)
-	} else if showVersion {
-		fmt.Printf("nats-streaming-server version %s, ", stand.VERSION)
-		natsd.PrintServerAndExit()
-	} else if showHelp {
-		usage()
+		natsd.PrintAndDie(err.Error() + "\n" + usageStr)
 	}
-
-	stanOpts, natsOpts, err := stand.ProcessConfigFiles(stanConfigFile, gnatsdConfigFile)
-	if err != nil {
-		natsd.PrintAndDie(fmt.Sprintf("Configuration error: %v", err.Error()))
-	}
-	// Now apply all parameters provided on the command line.
-	if err := overrideWithCmdLineParams(stanOpts, natsOpts); err != nil {
-		natsd.PrintAndDie(err.Error())
-	}
-
-	// One flag can set multiple options.
-	if natsDebugAndTrace {
-		natsOpts.Trace, natsOpts.Debug = true, true
-	}
-
-	// One flag can set multiple options.
-	if stanDebugAndTrace {
-		stanOpts.Trace, stanOpts.Debug = true, true
-	}
-
 	return stanOpts, natsOpts
-}
-
-// overrideWithCmdLineParams applies the flags passed in the command line
-// to the given options structure.
-func overrideWithCmdLineParams(sopts *stand.Options, nopts *natsd.Options) error {
-	var err error
-	flag.Visit(func(f *flag.Flag) {
-		if err != nil || f.Usage == "" {
-			return
-		}
-		root := f.Usage[0:5]
-		var t reflect.Value
-		if root == "stan." {
-			t = reflect.ValueOf(sopts).Elem()
-		} else if root == "nats." {
-			t = reflect.ValueOf(nopts).Elem()
-		} else {
-			err = fmt.Errorf("unknown options root: %s", root)
-			return
-		}
-		optName := f.Usage[5:]
-		var o reflect.Value
-		// Lookup for sub structures, ex: FileStoreOpts.CacheMsgs
-		if strings.Contains(optName, ".") {
-			strs := strings.Split(optName, ".")
-			obj := t.FieldByName(strs[0])
-			for i := 1; i < len(strs); i++ {
-				obj = obj.FieldByName(strs[i])
-			}
-			o = obj
-		} else {
-			o = t.FieldByName(optName)
-		}
-		if !o.IsValid() || !o.CanSet() {
-			return
-		}
-		v, ok := f.Value.(flag.Getter)
-		if !ok {
-			return
-		}
-		val := v.Get()
-		valKind := reflect.ValueOf(val).Kind()
-		switch valKind {
-		case reflect.String:
-			switch optName {
-			// Parameters that can be size are configured as string and we then use
-			// gnatsd's configuration parser to convert to a int64.
-			case "MaxBytes", "FileStoreOpts.CompactMinFileSize", "FileStoreOpts.BufferSize", "FileStoreOpts.SliceMaxBytes":
-				var res map[string]interface{}
-				res, err = conf.Parse(fmt.Sprintf("bytes: %v", val))
-				if err != nil {
-					return
-				}
-				resVal := res["bytes"]
-				if resVal == nil || reflect.TypeOf(resVal).Kind() != reflect.Int64 {
-					err = fmt.Errorf("%v should be a size, got '%v'", f.Name, resVal)
-					return
-				}
-				o.SetInt(int64(resVal.(int64)))
-			case "MaxAge", "ClientHBInterval", "ClientHBTimeout", "FileStoreOpts.SliceMaxAge":
-				var dur time.Duration
-				dur, err = time.ParseDuration(val.(string))
-				if err != nil {
-					return
-				}
-				o.SetInt(int64(dur))
-			case "RoutesStr":
-				routesStr := val.(string)
-				routesUrls := natsd.RoutesFromStr(routesStr)
-				if routesUrls != nil {
-					nopts.Routes = routesUrls
-					nopts.RoutesStr = routesStr
-				}
-			default:
-				o.SetString(val.(string))
-			}
-		case reflect.Int:
-			o.SetInt(int64(val.(int)))
-		case reflect.Int64:
-			o.SetInt(val.(int64))
-		case reflect.Uint64:
-			o.SetUint(val.(uint64))
-		case reflect.Bool:
-			o.SetBool(val.(bool))
-		default:
-			panic(fmt.Errorf("Add support for type %v (command line parameter %q)",
-				valKind.String(), f.Name))
-		}
-	})
-	return err
 }

--- a/server/conf.go
+++ b/server/conf.go
@@ -3,9 +3,11 @@
 package server
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -368,47 +370,147 @@ func parseFileOptions(itf interface{}, opts *Options) error {
 	return nil
 }
 
-// ProcessConfigFiles parses the configuration files for both Streaming and NATS.
-// If both are specified, each configuration is applied individually.
-// If only one is specified, the configuration file is applied to
-// Streaming and NATS. This allows to have a consolidated configuration
-// file contanining both Streaming and NATS parameters.
-func ProcessConfigFiles(stanConfig, natsdConfig string) (*Options, *natsd.Options, error) {
-	stanOpts := GetDefaultOptions()
-	if stanConfig == "" && natsdConfig == "" {
-		// Apply default values that we would have set in flag.XXXVar() here...
-		return stanOpts, &natsd.Options{Logtime: true}, nil
-	}
+// ConfigureOptions accepts a flag set and augment it with NATS Streaming Server
+// specific flags. It then invokes the corresponding function from NATS Server.
+// On success, Streaming and NATS options structures are returned configured
+// based on the selected flags and/or configuration files.
+// The command line options take precedence to the ones in the configuration files.
+func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, printTLSHelp func()) (*Options, *natsd.Options, error) {
+	sopts := GetDefaultOptions()
 
-	// If stan config (-sc or --stan_config) file is provided, uses this one,
-	// otherwise, take the one given with -c (or --config) command line param.
-	cfgFile := stanConfig
-	if cfgFile == "" && natsdConfig != "" {
-		cfgFile = natsdConfig
-	}
-	if err := ProcessConfigFile(cfgFile, stanOpts); err != nil {
-		return nil, nil, err
-	}
-	// If NATS config (-c or --config) file is provided, uses this one,
-	// otherwise, take the one given with the -sc (or --stan_config) command line param.
-	cfgFile = natsdConfig
-	if cfgFile == "" && stanConfig != "" {
-		cfgFile = stanConfig
-	}
-	natsOpts, err := natsd.ProcessConfigFile(cfgFile)
+	var (
+		stanConfigFile string
+		natsConfigFile string
+	)
+
+	fs.StringVar(&sopts.ID, "cluster_id", DefaultClusterID, "stan.ID")
+	fs.StringVar(&sopts.ID, "cid", DefaultClusterID, "stan.ID")
+	fs.StringVar(&sopts.StoreType, "store", stores.TypeMemory, "stan.StoreType")
+	fs.StringVar(&sopts.StoreType, "st", stores.TypeMemory, "stan.StoreType")
+	fs.StringVar(&sopts.FilestoreDir, "dir", "", "stan.FilestoreDir")
+	fs.IntVar(&sopts.MaxChannels, "max_channels", stores.DefaultStoreLimits.MaxChannels, "stan.MaxChannels")
+	fs.IntVar(&sopts.MaxChannels, "mc", stores.DefaultStoreLimits.MaxChannels, "stan.MaxChannels")
+	fs.IntVar(&sopts.MaxSubscriptions, "max_subs", stores.DefaultStoreLimits.MaxSubscriptions, "stan.MaxSubscriptions")
+	fs.IntVar(&sopts.MaxSubscriptions, "msu", stores.DefaultStoreLimits.MaxSubscriptions, "stan.MaxSubscriptions")
+	fs.IntVar(&sopts.MaxMsgs, "max_msgs", stores.DefaultStoreLimits.MaxMsgs, "stan.MaxMsgs")
+	fs.IntVar(&sopts.MaxMsgs, "mm", stores.DefaultStoreLimits.MaxMsgs, "stan.MaxMsgs")
+	fs.String("max_bytes", fmt.Sprintf("%v", stores.DefaultStoreLimits.MaxBytes), "stan.MaxBytes")
+	fs.String("mb", fmt.Sprintf("%v", stores.DefaultStoreLimits.MaxBytes), "stan.MaxBytes")
+	fs.DurationVar(&sopts.MaxAge, "max_age", stores.DefaultStoreLimits.MaxAge, "stan.MaxAge")
+	fs.DurationVar(&sopts.MaxAge, "ma", stores.DefaultStoreLimits.MaxAge, "stan.MaxAge")
+	fs.DurationVar(&sopts.ClientHBInterval, "hbi", DefaultHeartBeatInterval, "stan.ClientHBInterval")
+	fs.DurationVar(&sopts.ClientHBInterval, "hb_interval", DefaultHeartBeatInterval, "stan.ClientHBInterval")
+	fs.DurationVar(&sopts.ClientHBTimeout, "hbt", DefaultClientHBTimeout, "stan.ClientHBTimeout")
+	fs.DurationVar(&sopts.ClientHBTimeout, "hb_timeout", DefaultClientHBTimeout, "stan.ClientHBTimeout")
+	fs.IntVar(&sopts.ClientHBFailCount, "hbf", DefaultMaxFailedHeartBeats, "stan.ClientHBFailCount")
+	fs.IntVar(&sopts.ClientHBFailCount, "hb_fail_count", DefaultMaxFailedHeartBeats, "stan.ClientHBFailCount")
+	fs.BoolVar(&sopts.Debug, "SD", false, "stan.Debug")
+	fs.BoolVar(&sopts.Debug, "stan_debug", false, "stan.Debug")
+	fs.BoolVar(&sopts.Trace, "SV", false, "stan.Trace")
+	fs.BoolVar(&sopts.Trace, "stan_trace", false, "stan.Trace")
+	fs.Bool("SDV", false, "")
+	fs.BoolVar(&sopts.Secure, "secure", false, "stan.Secure")
+	fs.StringVar(&sopts.ClientCert, "tls_client_cert", "", "stan.ClientCert")
+	fs.StringVar(&sopts.ClientKey, "tls_client_key", "", "stan.ClientKey")
+	fs.StringVar(&sopts.ClientCA, "tls_client_cacert", "", "stan.ClientCA")
+	fs.StringVar(&sopts.NATSServerURL, "nats_server", "", "stan.NATSServerURL")
+	fs.StringVar(&sopts.NATSServerURL, "ns", "", "stan.NATSServerURL")
+	fs.StringVar(&stanConfigFile, "sc", "", "")
+	fs.StringVar(&stanConfigFile, "stan_config", "", "")
+	fs.IntVar(&sopts.AckSubsPoolSize, "ack_subs", 0, "stan.AckSubsPoolSize")
+	fs.BoolVar(&sopts.FileStoreOpts.CompactEnabled, "file_compact_enabled", stores.DefaultFileStoreOptions.CompactEnabled, "stan.FileStoreOpts.CompactEnabled")
+	fs.IntVar(&sopts.FileStoreOpts.CompactFragmentation, "file_compact_frag", stores.DefaultFileStoreOptions.CompactFragmentation, "stan.FileStoreOpts.CompactFragmentation")
+	fs.IntVar(&sopts.FileStoreOpts.CompactInterval, "file_compact_interval", stores.DefaultFileStoreOptions.CompactInterval, "stan.FileStoreOpts.CompactInterval")
+	fs.String("file_compact_min_size", fmt.Sprintf("%v", stores.DefaultFileStoreOptions.CompactMinFileSize), "stan.FileStoreOpts.CompactMinFileSize")
+	fs.String("file_buffer_size", fmt.Sprintf("%v", stores.DefaultFileStoreOptions.BufferSize), "stan.FileStoreOpts.BufferSize")
+	fs.BoolVar(&sopts.FileStoreOpts.DoCRC, "file_crc", stores.DefaultFileStoreOptions.DoCRC, "stan.FileStoreOpts.DoCRC")
+	fs.Int64Var(&sopts.FileStoreOpts.CRCPolynomial, "file_crc_poly", stores.DefaultFileStoreOptions.CRCPolynomial, "stan.FileStoreOpts.CRCPolynomial")
+	fs.BoolVar(&sopts.FileStoreOpts.DoSync, "file_sync", stores.DefaultFileStoreOptions.DoSync, "stan.FileStoreOpts.DoSync")
+	fs.IntVar(&sopts.FileStoreOpts.SliceMaxMsgs, "file_slice_max_msgs", stores.DefaultFileStoreOptions.SliceMaxMsgs, "stan.FileStoreOpts.SliceMaxMsgs")
+	fs.String("file_slice_max_bytes", fmt.Sprintf("%v", stores.DefaultFileStoreOptions.SliceMaxBytes), "stan.FileStoreOpts.SliceMaxBytes")
+	fs.DurationVar(&sopts.FileStoreOpts.SliceMaxAge, "file_slice_max_age", stores.DefaultFileStoreOptions.SliceMaxAge, "stan.FileStoreOpts.SliceMaxAge")
+	fs.StringVar(&sopts.FileStoreOpts.SliceArchiveScript, "file_slice_archive_script", "", "stan.FileStoreOpts.SliceArchiveScript")
+	fs.Int64Var(&sopts.FileStoreOpts.FileDescriptorsLimit, "file_fds_limit", stores.DefaultFileStoreOptions.FileDescriptorsLimit, "stan.FileStoreOpts.FileDescriptorsLimit")
+	fs.IntVar(&sopts.FileStoreOpts.ParallelRecovery, "file_parallel_recovery", stores.DefaultFileStoreOptions.ParallelRecovery, "stan.FileStoreOpts.ParallelRecovery")
+	fs.IntVar(&sopts.IOBatchSize, "io_batch_size", DefaultIOBatchSize, "stan.IOBatchSize")
+	fs.Int64Var(&sopts.IOSleepTime, "io_sleep_time", DefaultIOSleepTime, "stan.IOSleepTime")
+	fs.StringVar(&sopts.FTGroupName, "ft_group", "", "stan.FTGroupName")
+
+	// First, we need to call NATS's ConfigureOptions() with above flag set.
+	// It will be augmented with NATS specific flags and call fs.Parse(args) for us.
+	nopts, err := natsd.ConfigureOptions(fs, args, printVersion, printHelp, printTLSHelp)
 	if err != nil {
 		return nil, nil, err
 	}
-	// Hack for now to know if Logtime was explicitly set to `false` in config file.
-	if !natsOpts.Logtime {
-		m, err := conf.ParseFile(cfgFile)
-		if err != nil {
+	// At this point, if NATS config file was specified in the command line (-c of -config)
+	// nopts.ConfigFile will not be empty.
+	natsConfigFile = nopts.ConfigFile
+
+	// If both nats and streaming configuration files are used, then
+	// we only use the config file for the corresponding module.
+	// However, if only one command line parameter was specified,
+	// we use the same config file for both modules.
+	if stanConfigFile != "" || natsConfigFile != "" {
+		// If NATS config file was not specified, but streaming was, use
+		// streaming config file for NATS too.
+		if natsConfigFile == "" {
+			if err := nopts.ProcessConfigFile(stanConfigFile); err != nil {
+				return nil, nil, err
+			}
+		}
+		// If NATS config file was specified, but not the streaming one,
+		// use nats config file for streaming too.
+		if stanConfigFile == "" {
+			stanConfigFile = natsConfigFile
+		}
+		if err := ProcessConfigFile(stanConfigFile, sopts); err != nil {
 			return nil, nil, err
 		}
-		// If the option is not set in the file, set it to our default of `true`.
-		if _, present := m["logtime"]; !present {
-			natsOpts.Logtime = true
-		}
+		// Need to call Parse() again to override with command line params.
+		// No need to check for errors since this has already been called
+		// in natsd.ConfigureOptions()
+		fs.Parse(args)
 	}
-	return stanOpts, natsOpts, nil
+
+	// Special handling for some command line params
+	var flagErr error
+	fs.Visit(func(f *flag.Flag) {
+		if flagErr != nil {
+			return
+		}
+		switch f.Name {
+		case "SDV":
+			// Check value to support -SDV=false
+			boolValue, _ := strconv.ParseBool(f.Value.String())
+			sopts.Trace, sopts.Debug = boolValue, boolValue
+		case "max_bytes", "mb":
+			sopts.MaxBytes, flagErr = getBytes(f)
+		case "file_compact_min_size":
+			sopts.FileStoreOpts.CompactMinFileSize, flagErr = getBytes(f)
+		case "file_buffer_size":
+			var i64 int64
+			i64, flagErr = getBytes(f)
+			sopts.FileStoreOpts.BufferSize = int(i64)
+		}
+	})
+	if flagErr != nil {
+		return nil, nil, flagErr
+	}
+	return sopts, nopts, nil
+}
+
+// getBytes returns the number of bytes from the flag's String size.
+// For instance, 1KB would return 1024.
+func getBytes(f *flag.Flag) (int64, error) {
+	var res map[string]interface{}
+	// Use NATS parser to do the conversion for us.
+	res, err := conf.Parse(fmt.Sprintf("bytes: %v", f.Value.String()))
+	if err != nil {
+		return 0, err
+	}
+	resVal := res["bytes"]
+	if resVal == nil || reflect.TypeOf(resVal).Kind() != reflect.Int64 {
+		return 0, fmt.Errorf("%v should be a size, got '%v'", f.Name, resVal)
+	}
+	return resVal.(int64), nil
 }

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -3,6 +3,8 @@
 package server
 
 import (
+	"bytes"
+	"flag"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -340,19 +342,82 @@ func expectFailureFor(t *testing.T, content, errorMatch string) {
 	}
 }
 
-func TestParseProcessConfigFiles(t *testing.T) {
-	// Calling ProcessConfigFiles with no file should return default stan options
-	// and empty nats options.
-	sopts, nopts, err := ProcessConfigFiles("", "")
-	if err != nil {
-		t.Fatalf("Error processing config files: %v", err)
+func TestParseConfigureOptions(t *testing.T) {
+	// We are not testing some of the flags that are handled directly by NATS.
+	// Provide a no-op print version/help/help tls function.
+	noPrint := func() {}
+	// Helper function that expect parsing with given args to not produce an error.
+	mustNotFail := func(args []string) (*Options, *natsd.Options) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		sopts, nopts, err := ConfigureOptions(fs, args, noPrint, noPrint, noPrint)
+		if err != nil {
+			stackFatalf(t, "Error on configure: %v", err)
+		}
+		return sopts, nopts
 	}
-	if !reflect.DeepEqual(sopts, GetDefaultOptions()) {
-		t.Fatalf("Did not get default options: %v", sopts)
+
+	// Helper function that expect configuration to fail.
+	expectToFail := func(args []string, errContent ...string) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		// Silence the flagSet so that on failure nothing is printed.
+		// (flag.FlagSet internally would print error message about unknown flags, etc..)
+		silenceOuput := &bytes.Buffer{}
+		fs.SetOutput(silenceOuput)
+		sopts, nopts, err := ConfigureOptions(fs, args, noPrint, noPrint, noPrint)
+		if sopts != nil || nopts != nil || err == nil {
+			stackFatalf(t, "Expected no option and an error, got sopts=%v and nopts=%v and err=%v", sopts, nopts, err)
+		}
+		for _, testErr := range errContent {
+			if strings.Contains(err.Error(), testErr) {
+				// We got the error we wanted.
+				return
+			}
+		}
+		stackFatalf(t, "Expected errors containing any of those %v, got %v", errContent, err)
 	}
-	if !reflect.DeepEqual(nopts, &natsd.Options{Logtime: true}) {
-		t.Fatalf("Did not get empty NATS options: %v", nopts)
+
+	// Basic test with cluster id
+	sopts, _ := mustNotFail([]string{"-cid", "me"})
+	if sopts.ID != "me" {
+		t.Fatalf("Expected cid to be me, got %v", sopts.ID)
 	}
+
+	// Should fail because flag is not defined
+	expectToFail([]string{"-xxx", "foo"}, "flag")
+
+	// Should fail because of config files missing
+	expectToFail([]string{"-sc", "xxx.conf", "-c", "../test/configs/test_parse.conf"}, "file")
+	expectToFail([]string{"-sc", "../test/configs/test_parse.conf", "-c", "xxx.conf"}, "file")
+	expectToFail([]string{"-sc", "xxx.conf"}, "file")
+	expectToFail([]string{"-c", "xxx.conf"}, "file")
+
+	// The config set both debug and trace to true
+	sopts, _ = mustNotFail([]string{"-sc", "../test/configs/test_parse.conf"})
+	if !sopts.Debug || !sopts.Trace {
+		t.Fatal("Debug and Trace should have been set to true")
+	}
+	// The config set both debug and trace to true, override with -SDV=false
+	sopts, _ = mustNotFail([]string{"-sc", "../test/configs/test_parse.conf", "-SDV=false"})
+	if sopts.Debug || sopts.Trace {
+		t.Fatal("Debug and Trace should have been set to false")
+	}
+
+	// Test bytes values
+	sopts, _ = mustNotFail([]string{"-max_bytes", "100KB", "-mb", "100KB", "-file_compact_min_size", "200KB", "-file_buffer_size", "300KB"})
+	if sopts.MaxBytes != 100*1024 {
+		t.Fatalf("Expected max_bytes to be 100KB, got %v", sopts.MaxBytes)
+	}
+	if sopts.FileStoreOpts.CompactMinFileSize != 200*1024 {
+		t.Fatalf("Expected file_compact_min_size to be 200KB, got %v", sopts.FileStoreOpts.CompactMinFileSize)
+	}
+	if sopts.FileStoreOpts.BufferSize != 300*1024 {
+		t.Fatalf("Expected file_buffer_size to be 300KB, got %v", sopts.FileStoreOpts.BufferSize)
+	}
+
+	// Failures with bytes
+	expectToFail([]string{"-max_bytes", "12abc"}, "error")
+	expectToFail([]string{"-max_bytes", "x1x"}, "size")
+	expectToFail([]string{"-max_bytes", "100a", "-mb", "100a", "-file_compact_min_size", "200a", "-file_buffer_size", "300a"}, "error")
 
 	sconf := "s.conf"
 	nconf := "n.conf"
@@ -363,25 +428,22 @@ func TestParseProcessConfigFiles(t *testing.T) {
 	// files, each having configuration elements for the other module
 	// that should be ignored since they will be processed individually.
 	scontent := []byte(`
-	port: 4223
-	streaming: {
-		cluster_id: my_cluster
-	}`)
+		port: 4223
+		streaming: {
+			cluster_id: my_cluster
+		}`)
 	if err := ioutil.WriteFile(sconf, scontent, 0660); err != nil {
 		t.Fatalf("Error creating conf file: %v", err)
 	}
 	ncontent := []byte(`
-	port: 5223
-	streaming: {
-		cluster_id: my_cluster_2
-	}`)
+		port: 5223
+		streaming: {
+			cluster_id: my_cluster_2
+		}`)
 	if err := ioutil.WriteFile(nconf, ncontent, 0660); err != nil {
 		t.Fatalf("Error creating conf file: %v", err)
 	}
-	sopts, nopts, err = ProcessConfigFiles(sconf, nconf)
-	if err != nil {
-		t.Fatalf("Error processing config files: %v", err)
-	}
+	sopts, nopts := mustNotFail([]string{"-sc", sconf, "-c", nconf})
 	// Check that streaming and NATS options have been correctly loaded
 	if sopts.ID != "my_cluster" {
 		t.Fatalf("Unexpected cluster id: %v", sopts.ID)
@@ -396,50 +458,36 @@ func TestParseProcessConfigFiles(t *testing.T) {
 
 	// Now pass only one file, and verify that the single file is used
 	// for both streaming and nats.
-	for i := 0; i < 2; i++ {
-		if i == 0 {
-			sopts, nopts, err = ProcessConfigFiles(sconf, "")
-		} else {
-			sopts, nopts, err = ProcessConfigFiles("", sconf)
-		}
-		if err != nil {
-			t.Fatalf("Error processing config files: %v", err)
-		}
-		if sopts.ID != "my_cluster" {
-			t.Fatalf("Unexpected cluster id: %v", sopts.ID)
-		}
-		// This should be the port defined in scontent
-		if nopts.Port != 4223 {
-			t.Fatalf("Unexpected listen port: %v", nopts.Port)
-		}
-		// Since logtime is not defined, it should default to `true`
-		if !nopts.Logtime {
-			t.Fatalf("Unexpected logtime value: %v", nopts.Logtime)
-		}
+	sopts, nopts = mustNotFail([]string{"-sc", sconf})
+	if sopts.ID != "my_cluster" {
+		t.Fatalf("Unexpected cluster id: %v", sopts.ID)
+	}
+	// This should be the port defined in scontent
+	if nopts.Port != 4223 {
+		t.Fatalf("Unexpected listen port: %v", nopts.Port)
+	}
+	// Since logtime is not defined, it should default to `true`
+	if !nopts.Logtime {
+		t.Fatalf("Unexpected logtime value: %v", nopts.Logtime)
 	}
 	// Same with other conf file
-	for i := 0; i < 2; i++ {
-		if i == 0 {
-			sopts, nopts, err = ProcessConfigFiles(nconf, "")
-		} else {
-			sopts, nopts, err = ProcessConfigFiles("", nconf)
-		}
-		if err != nil {
-			t.Fatalf("Error processing config files: %v", err)
-		}
-		if sopts.ID != "my_cluster_2" {
-			t.Fatalf("Unexpected cluster id: %v", sopts.ID)
-		}
-		// This should be the port defined in scontent
-		if nopts.Port != 5223 {
-			t.Fatalf("Unexpected listen port: %v", nopts.Port)
-		}
-		// Since logtime is not defined, it should default to `true`
-		if !nopts.Logtime {
-			t.Fatalf("Unexpected logtime value: %v", nopts.Logtime)
-		}
+	sopts, nopts = mustNotFail([]string{"-c", nconf})
+	if sopts.ID != "my_cluster_2" {
+		t.Fatalf("Unexpected cluster id: %v", sopts.ID)
+	}
+	// This should be the port defined in scontent
+	if nopts.Port != 5223 {
+		t.Fatalf("Unexpected listen port: %v", nopts.Port)
+	}
+	// Since logtime is not defined, it should default to `true`
+	if !nopts.Logtime {
+		t.Fatalf("Unexpected logtime value: %v", nopts.Logtime)
 	}
 	// Ensure that if logtime is present in the config file, its value is used.
+	// This test belongs more in NATS, but this is an issue that surfaced
+	// in previous attempts to solve flags override. So keeping it here so
+	// that we catch such issue if we were to change the flag override code
+	// and break it.
 	for i := 0; i < 2; i++ {
 		os.Remove(nconf)
 		if i == 0 {
@@ -450,10 +498,7 @@ func TestParseProcessConfigFiles(t *testing.T) {
 		if err := ioutil.WriteFile(nconf, ncontent, 0660); err != nil {
 			t.Fatalf("Error creating conf file: %v", err)
 		}
-		_, nopts, err = ProcessConfigFiles(sconf, nconf)
-		if err != nil {
-			t.Fatalf("Error processing config files: %v", err)
-		}
+		_, nopts = mustNotFail([]string{"-c", nconf})
 		// Logtime is specified in the log, so it should be the value that is in
 		// the file.
 		if i == 0 && nopts.Logtime || i == 1 && !nopts.Logtime {

--- a/test/configs/test_parse.conf
+++ b/test/configs/test_parse.conf
@@ -1,61 +1,63 @@
-id: "me"
-discover_prefix: "discover"
-store: "file"
-dir: "/path/to/datastore"
-sd: true
-sv: true
-ns: "nats://localhost:4222"
-secure: true
-hb_interval: "10s"
-hb_timeout: "1s"
-hb_fail_count: 2
-ack_subs_pool_size: 3
-ft_group: "ft"
-partitioning: true
+streaming: {
+  id: "me"
+  discover_prefix: "discover"
+  store: "file"
+  dir: "/path/to/datastore"
+  sd: true
+  sv: true
+  ns: "nats://localhost:4222"
+  secure: true
+  hb_interval: "10s"
+  hb_timeout: "1s"
+  hb_fail_count: 2
+  ack_subs_pool_size: 3
+  ft_group: "ft"
+  partitioning: true
 
-store_limits: {
-    max_channels: 11
-    max_msgs: 12
-    max_bytes: 13
-    max_age: "14s"
-    max_subs: 15
-    
-    channels: {
-      "foo": {
-        max_msgs: 1
-        max_bytes: 2
-        max_age: "3s"
-        max_subs: 4
+  store_limits: {
+      max_channels: 11
+      max_msgs: 12
+      max_bytes: 13
+      max_age: "14s"
+      max_subs: 15
+
+      channels: {
+        "foo": {
+          max_msgs: 1
+          max_bytes: 2
+          max_age: "3s"
+          max_subs: 4
+        }
+        "bar": {
+          max_msgs: 5
+          max_bytes: 6
+          max_age: "7s"
+          max_subs: 8
+        }
       }
-      "bar": {
-        max_msgs: 5
-        max_bytes: 6
-        max_age: "7s"
-        max_subs: 8      
-      }
-    }
-}
+  }
 
-tls: {
-    client_cert: "/path/to/client/cert_file"
-    client_key: "/path/to/client/key_file"
-    client_ca: "/path/to/client/ca_file"
-}
+  tls: {
+      client_cert: "/path/to/client/cert_file"
+      client_key: "/path/to/client/key_file"
+      client_ca: "/path/to/client/ca_file"
+  }
 
-file: {
-    compact: true
-    compact_frag: 1
-    compact_interval: 2
-    compact_min_size: 3
-    buffer_size: 4
-    crc: true
-    crc_poly: 5
-    sync: true
-    cache: true
-    slice_max_msgs: 6
-    slice_max_bytes: 7
-    slice_max_age: "8s"
-    slice_archive_script: "myArchiveScript"
-    fds_limit: 8
-    parallel_recovery: 9
+  file: {
+      compact: true
+      compact_frag: 1
+      compact_interval: 2
+      compact_min_size: 3
+      buffer_size: 4
+      crc: true
+      crc_poly: 5
+      sync: true
+      cache: true
+      slice_max_msgs: 6
+      slice_max_bytes: 7
+      slice_max_age: "8s"
+      slice_archive_script: "myArchiveScript"
+      fds_limit: 8
+      parallel_recovery: 9
+  }
 }


### PR DESCRIPTION
After upgrading vendor directory for gnatsd, we can now use
natsd.ConfigureOptions() from PR https://github.com/nats-io/gnatsd/pull/578
We follow this model for NATS Streaming and chain the two
configuration of options.
This will solve any issue that we had with options override.