### PR TITLE
Allow configuring fsync for Raft log

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -41,6 +41,7 @@ Streaming Server Clustering Options:
     --cluster_log_cache_size <int>    Number of log entries to cache in memory to reduce disk IO. (default:512)
     --cluster_num_log_snapshots <int> Number of log snapshots to retain. (default: 2)
     --cluster_trailing_logs <int>     Number of log entries to leave after a snapshot and compaction.
+    --cluster_sync <bool>             Do a file sync after every write to the replication log and message store.
 
 Streaming Server File Store Options:
     --file_compact_enabled <bool>        Enable file compaction

--- a/server/clustering.go
+++ b/server/clustering.go
@@ -24,6 +24,7 @@ type ClusteringOptions struct {
 	LogCacheSize int      // Number of Raft log entries to cache in memory to reduce disk IO.
 	LogSnapshots int      // Number of Raft log snapshots to retain.
 	TrailingLogs int64    // Number of logs left after a snapshot.
+	Sync         bool     // Do a file sync after every write to the Raft log and message store.
 }
 
 // raftNode is a handle to a member in a Raft consensus group.
@@ -59,7 +60,7 @@ func (s *StanServer) createRaftNode(name string, fsm raft.FSM) (*raftNode, error
 	}
 	store, err := raftboltdb.New(raftboltdb.Options{
 		Path:   filepath.Join(path, raftLogFile),
-		NoSync: !s.opts.FileStoreOpts.DoSync,
+		NoSync: !s.opts.Clustering.Sync,
 	})
 	if err != nil {
 		return nil, err

--- a/server/clustering.go
+++ b/server/clustering.go
@@ -47,7 +47,10 @@ func (s *StanServer) createRaftNode(name string, fsm raft.FSM) (*raftNode, error
 			return nil, err
 		}
 	}
-	store, err := raftboltdb.NewBoltStore(filepath.Join(path, raftLogFile))
+	store, err := raftboltdb.New(raftboltdb.Options{
+		Path:   filepath.Join(path, raftLogFile),
+		NoSync: !s.opts.FileStoreOpts.DoSync,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/server/clustering_test.go
+++ b/server/clustering_test.go
@@ -46,11 +46,11 @@ func getTestDefaultOptsForClustering(id string, peers []string) *Options {
 	opts.StoreType = stores.TypeFile
 	opts.FilestoreDir = filepath.Join(defaultDataStore, id)
 	opts.FileStoreOpts.BufferSize = 1024
-	opts.ClusterPeers = peers
-	opts.ClusterNodeID = id
-	opts.RaftLogPath = filepath.Join(defaultRaftLog, id)
-	opts.LogCacheSize = DefaultLogCacheSize
-	opts.LogSnapshots = 1
+	opts.Clustering.Peers = peers
+	opts.Clustering.NodeID = id
+	opts.Clustering.RaftLogPath = filepath.Join(defaultRaftLog, id)
+	opts.Clustering.LogCacheSize = DefaultLogCacheSize
+	opts.Clustering.LogSnapshots = 1
 	opts.NATSServerURL = "nats://localhost:4222"
 	return opts
 }
@@ -225,7 +225,7 @@ func TestClusteringConfig(t *testing.T) {
 	defer cleanupRaftLog(t)
 
 	opts := GetDefaultOptions()
-	opts.ClusterPeers = []string{"a", "b"}
+	opts.Clustering.Peers = []string{"a", "b"}
 	s, err := RunServerWithOpts(opts, nil)
 	if s != nil || err == nil {
 		if s != nil {
@@ -536,19 +536,19 @@ func TestClusteringLogSnapshotCatchup(t *testing.T) {
 
 	// Configure first server
 	s1sOpts := getTestDefaultOptsForClustering("a", []string{"b", "c"})
-	s1sOpts.TrailingLogs = 0
+	s1sOpts.Clustering.TrailingLogs = 0
 	s1 := runServerWithOpts(t, s1sOpts, nil)
 	defer s1.Shutdown()
 
 	// Configure second server.
 	s2sOpts := getTestDefaultOptsForClustering("b", []string{"a", "c"})
-	s2sOpts.TrailingLogs = 0
+	s2sOpts.Clustering.TrailingLogs = 0
 	s2 := runServerWithOpts(t, s2sOpts, nil)
 	defer s2.Shutdown()
 
 	// Configure third server.
 	s3sOpts := getTestDefaultOptsForClustering("c", []string{"a", "b"})
-	s3sOpts.TrailingLogs = 0
+	s3sOpts.Clustering.TrailingLogs = 0
 	s3 := runServerWithOpts(t, s3sOpts, nil)
 	defer s3.Shutdown()
 
@@ -607,7 +607,7 @@ func TestClusteringLogSnapshotCatchup(t *testing.T) {
 	follower = runServerWithOpts(t, follower.opts, nil)
 	defer follower.Shutdown()
 	for i, server := range servers {
-		if server.opts.ClusterNodeID == follower.opts.ClusterNodeID {
+		if server.opts.Clustering.NodeID == follower.opts.Clustering.NodeID {
 			servers[i] = follower
 			break
 		}

--- a/server/conf.go
+++ b/server/conf.go
@@ -480,9 +480,6 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 		for i, peer := range sopts.Clustering.Peers {
 			sopts.Clustering.Peers[i] = strings.TrimSpace(peer)
 		}
-
-		// If clustered, override store sync configuration with cluster sync.
-		sopts.FileStoreOpts.DoSync = sopts.Clustering.Sync
 	}
 
 	if sopts.Clustering.RaftLogPath == "" {

--- a/server/conf.go
+++ b/server/conf.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"

--- a/server/conf.go
+++ b/server/conf.go
@@ -437,6 +437,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.IntVar(&sopts.Clustering.LogCacheSize, "cluster_log_cache_size", DefaultLogCacheSize, "stan.Clustering.LogCacheSize")
 	fs.IntVar(&sopts.Clustering.LogSnapshots, "cluster_log_snapshots", DefaultLogSnapshots, "stan.Clustering.LogSnapshots")
 	fs.Int64Var(&sopts.Clustering.TrailingLogs, "cluster_trailing_logs", DefaultTrailingLogs, "stan.Clustering.TrailingLogs")
+	fs.BoolVar(&sopts.Clustering.Sync, "cluster_sync", false, "stan.Clustering.Sync")
 
 	// First, we need to call NATS's ConfigureOptions() with above flag set.
 	// It will be augmented with NATS specific flags and call fs.Parse(args) for us.
@@ -479,6 +480,9 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 		for i, peer := range sopts.Clustering.Peers {
 			sopts.Clustering.Peers[i] = strings.TrimSpace(peer)
 		}
+
+		// If clustered, override store sync configuration with cluster sync.
+		sopts.FileStoreOpts.DoSync = sopts.Clustering.Sync
 	}
 
 	if sopts.Clustering.RaftLogPath == "" {

--- a/server/conf.go
+++ b/server/conf.go
@@ -482,10 +482,6 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 		}
 	}
 
-	if sopts.Clustering.RaftLogPath == "" {
-		sopts.Clustering.RaftLogPath = filepath.Join(sopts.ID, sopts.Clustering.NodeID)
-	}
-
 	// Special handling for some command line params
 	var flagErr error
 	fs.Visit(func(f *flag.Flag) {

--- a/server/conf.go
+++ b/server/conf.go
@@ -431,12 +431,12 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.IntVar(&sopts.IOBatchSize, "io_batch_size", DefaultIOBatchSize, "stan.IOBatchSize")
 	fs.Int64Var(&sopts.IOSleepTime, "io_sleep_time", DefaultIOSleepTime, "stan.IOSleepTime")
 	fs.StringVar(&sopts.FTGroupName, "ft_group", "", "stan.FTGroupName")
-	fs.StringVar(&sopts.ClusterNodeID, "cluster_node_id", "", "stan.ClusterNodeID")
+	fs.StringVar(&sopts.Clustering.NodeID, "cluster_node_id", "", "stan.Clustering.NodeID")
 	fs.StringVar(&stanClusterPeers, "cluster_peers", "", "")
-	fs.StringVar(&sopts.RaftLogPath, "cluster_log_path", "", "stan.RaftLogPath")
-	fs.IntVar(&sopts.LogCacheSize, "cluster_log_cache_size", DefaultLogCacheSize, "stan.LogCacheSize")
-	fs.IntVar(&sopts.LogSnapshots, "cluster_log_snapshots", DefaultLogSnapshots, "stan.LogSnapshots")
-	fs.Int64Var(&sopts.TrailingLogs, "cluster_trailing_logs", DefaultTrailingLogs, "stan.TrailingLogs")
+	fs.StringVar(&sopts.Clustering.RaftLogPath, "cluster_log_path", "", "stan.Clustering.RaftLogPath")
+	fs.IntVar(&sopts.Clustering.LogCacheSize, "cluster_log_cache_size", DefaultLogCacheSize, "stan.Clustering.LogCacheSize")
+	fs.IntVar(&sopts.Clustering.LogSnapshots, "cluster_log_snapshots", DefaultLogSnapshots, "stan.Clustering.LogSnapshots")
+	fs.Int64Var(&sopts.Clustering.TrailingLogs, "cluster_trailing_logs", DefaultTrailingLogs, "stan.Clustering.TrailingLogs")
 
 	// First, we need to call NATS's ConfigureOptions() with above flag set.
 	// It will be augmented with NATS specific flags and call fs.Parse(args) for us.
@@ -475,14 +475,14 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	}
 
 	if len(stanClusterPeers) > 0 {
-		sopts.ClusterPeers = strings.Split(stanClusterPeers, ",")
-		for i, peer := range sopts.ClusterPeers {
-			sopts.ClusterPeers[i] = strings.TrimSpace(peer)
+		sopts.Clustering.Peers = strings.Split(stanClusterPeers, ",")
+		for i, peer := range sopts.Clustering.Peers {
+			sopts.Clustering.Peers[i] = strings.TrimSpace(peer)
 		}
 	}
 
-	if sopts.RaftLogPath == "" {
-		sopts.RaftLogPath = filepath.Join(sopts.ID, sopts.ClusterNodeID)
+	if sopts.Clustering.RaftLogPath == "" {
+		sopts.Clustering.RaftLogPath = filepath.Join(sopts.ID, sopts.Clustering.NodeID)
 	}
 
 	// Special handling for some command line params

--- a/server/server.go
+++ b/server/server.go
@@ -1405,6 +1405,11 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (newServer *
 	// Ensure store type option is in upper-case
 	sOpts.StoreType = strings.ToUpper(sOpts.StoreType)
 
+	// If clustered, override store sync configuration with cluster sync.
+	if s.isClustered() {
+		sOpts.FileStoreOpts.DoSync = sOpts.Clustering.Sync
+	}
+
 	// Create the store. So far either memory or file-based.
 	switch sOpts.StoreType {
 	case stores.TypeFile:

--- a/server/server.go
+++ b/server/server.go
@@ -1345,9 +1345,14 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (newServer *
 		nOpts = natsOpts.Clone()
 	}
 
-	// Default cluster Raft log path to ./<cluster-id>/<node-id> if not set.
-	if sOpts.Clustering.RaftLogPath == "" {
-		sOpts.Clustering.RaftLogPath = filepath.Join(sOpts.ID, sOpts.Clustering.NodeID)
+	if len(sOpts.Clustering.Peers) > 0 {
+		// If clustered, override store sync configuration with cluster sync.
+		sOpts.FileStoreOpts.DoSync = sOpts.Clustering.Sync
+
+		// Default cluster Raft log path to ./<cluster-id>/<node-id> if not set.
+		if sOpts.Clustering.RaftLogPath == "" {
+			sOpts.Clustering.RaftLogPath = filepath.Join(sOpts.ID, sOpts.Clustering.NodeID)
+		}
 	}
 
 	s := StanServer{
@@ -1410,11 +1415,6 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (newServer *
 
 	// Ensure store type option is in upper-case
 	sOpts.StoreType = strings.ToUpper(sOpts.StoreType)
-
-	// If clustered, override store sync configuration with cluster sync.
-	if s.isClustered() {
-		sOpts.FileStoreOpts.DoSync = sOpts.Clustering.Sync
-	}
 
 	// Create the store. So far either memory or file-based.
 	switch sOpts.StoreType {

--- a/server/server.go
+++ b/server/server.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"sort"
@@ -1342,6 +1343,11 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (newServer *
 		nOpts = &no
 	} else {
 		nOpts = natsOpts.Clone()
+	}
+
+	// Default cluster Raft log path to ./<cluster-id>/<node-id> if not set.
+	if sOpts.Clustering.RaftLogPath == "" {
+		sOpts.Clustering.RaftLogPath = filepath.Join(sOpts.ID, sOpts.Clustering.NodeID)
 	}
 
 	s := StanServer{

--- a/server/server.go
+++ b/server/server.go
@@ -452,14 +452,14 @@ func (c *channel) Apply(l *raft.Log) interface{} {
 	case spb.RaftOperation_Ack:
 		// If we proposed the ack, do nothing since we already processed it as
 		// leader.
-		if op.Leader == c.stan.opts.ClusterNodeID {
+		if op.Leader == c.stan.opts.Clustering.NodeID {
 			return nil
 		}
 		c.stan.processReplicatedAck(c, op.AckMsg.AckInbox, op.AckMsg.Sequence)
 	case spb.RaftOperation_Send:
 		// If we proposed the message sent update, do nothing since we already
 		// processed it as leader.
-		if op.Leader == c.stan.opts.ClusterNodeID {
+		if op.Leader == c.stan.opts.Clustering.NodeID {
 			return nil
 		}
 		c.stan.processReplicatedSentMsg(c, op.SendMsg.AckInbox, op.SendMsg.Sequence)
@@ -690,7 +690,7 @@ type StanServer struct {
 }
 
 func (s *StanServer) isClustered() bool {
-	return len(s.opts.ClusterPeers) > 0
+	return len(s.opts.Clustering.Peers) > 0
 }
 
 func (s *StanServer) isMetadataLeader() bool {
@@ -1126,14 +1126,7 @@ type Options struct {
 	ClientHBFailCount  int           // Number of failed heartbeats before server closes client connection.
 	FTGroupName        string        // Name of the FT Group. A group can be 2 or more servers with a single active server and all sharing the same datastore.
 	Partitioning       bool          // Specify if server only accepts messages/subscriptions on channels defined in StoreLimits.
-
-	// Clustering options
-	ClusterNodeID string   // ID of the node within the cluster.
-	ClusterPeers  []string // Cluster peer IDs.
-	RaftLogPath   string   // Path to Raft log store directory.
-	LogCacheSize  int      // Number of Raft log entries to cache in memory to reduce disk IO.
-	LogSnapshots  int      // Number of Raft log snapshots to retain.
-	TrailingLogs  int64    // Number of logs left after a snapshot.
+	Clustering         ClusteringOptions
 }
 
 // Clone returns a deep copy of the Options object.
@@ -1320,7 +1313,7 @@ func (s *StanServer) createNatsConnections(sOpts *Options, nOpts *server.Options
 	if err == nil && sOpts.FTGroupName != "" {
 		s.ftnc, err = s.createNatsClientConn("ft", sOpts, nOpts)
 	}
-	if err == nil && len(sOpts.ClusterPeers) > 0 {
+	if err == nil && s.isClustered() {
 		s.ncr, err = s.createNatsClientConn("raft", sOpts, nOpts)
 	}
 	return err
@@ -1477,8 +1470,8 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (newServer *
 		}()
 	} else {
 		state := Standalone
-		if len(s.opts.ClusterPeers) > 0 {
-			if s.opts.ClusterNodeID == "" {
+		if s.isClustered() {
+			if s.opts.Clustering.NodeID == "" {
 				return nil, errors.New("cluster node id not provided")
 			}
 			state = Clustered
@@ -2211,7 +2204,7 @@ func (s *StanServer) isDuplicateConnect(client *client) bool {
 func (s *StanServer) replicateConnect(clientID, heartbeatInbox string, refresh bool) error {
 	op := &spb.RaftOperation{
 		OpType: spb.RaftOperation_Connect,
-		Leader: s.opts.ClusterNodeID,
+		Leader: s.opts.Clustering.NodeID,
 		ClientConnect: &spb.AddClient{
 			ClientID:       clientID,
 			HeartbeatInbox: heartbeatInbox,
@@ -2522,7 +2515,7 @@ func (s *StanServer) performConnClose(clientID, reply string) {
 func (s *StanServer) replicateConnClose(clientID, reply string, schedule bool) error {
 	op := &spb.RaftOperation{
 		OpType:           spb.RaftOperation_Disconnect,
-		Leader:           s.opts.ClusterNodeID,
+		Leader:           s.opts.Clustering.NodeID,
 		ClientDisconnect: &spb.RemoveClient{ClientID: clientID, Reply: reply, Schedule: schedule},
 	}
 	data, err := op.Marshal()
@@ -2965,7 +2958,7 @@ func (s *StanServer) getMsgForRedelivery(c *channel, sub *subState, seq uint64) 
 func (s *StanServer) replicateUpdateSentMsg(c *channel, sub *subState, sequence uint64) {
 	op := &spb.RaftOperation{
 		OpType: spb.RaftOperation_Send,
-		Leader: s.opts.ClusterNodeID,
+		Leader: s.opts.Clustering.NodeID,
 		SendMsg: &spb.AckMessage{
 			AckInbox: sub.AckInbox,
 			Sequence: sequence,
@@ -3341,7 +3334,7 @@ func (s *StanServer) replicate(iopms []*ioPendingMsg) (map[*channel]raft.Future,
 		op := &spb.RaftOperation{
 			OpType:       spb.RaftOperation_Publish,
 			PublishBatch: batch,
-			Leader:       s.opts.ClusterNodeID,
+			Leader:       s.opts.Clustering.NodeID,
 		}
 		data, err := op.Marshal()
 		if err != nil {
@@ -3559,7 +3552,7 @@ func (s *StanServer) replicateCloseSubscription(c *channel, clientID, ackInbox s
 func (s *StanServer) replicateUnsubscribe(c *channel, clientID, ackInbox string, opType spb.RaftOperation_Type) error {
 	op := &spb.RaftOperation{
 		OpType: opType,
-		Leader: s.opts.ClusterNodeID,
+		Leader: s.opts.Clustering.NodeID,
 		Unsub: &spb.RemoveSubscription{
 			AckInbox: ackInbox,
 			ClientID: clientID,
@@ -3671,7 +3664,7 @@ func durableKey(sr *pb.SubscriptionRequest) string {
 func (s *StanServer) replicateSub(sr *pb.SubscriptionRequest, ackInbox string, c *channel) (*subState, error) {
 	op := &spb.RaftOperation{
 		OpType: spb.RaftOperation_Subscribe,
-		Leader: s.opts.ClusterNodeID,
+		Leader: s.opts.Clustering.NodeID,
 		Sub: &spb.AddSubscription{
 			Request:  sr,
 			AckInbox: ackInbox,
@@ -4093,7 +4086,7 @@ func (s *StanServer) processAckMsg(m *nats.Msg) {
 func (s *StanServer) replicateAck(c *channel, ackInbox string, sequence uint64) {
 	op := &spb.RaftOperation{
 		OpType: spb.RaftOperation_Ack,
-		Leader: s.opts.ClusterNodeID,
+		Leader: s.opts.Clustering.NodeID,
 		AckMsg: &spb.AckMessage{
 			AckInbox: ackInbox,
 			Sequence: sequence,
@@ -4530,7 +4523,7 @@ func (s *StanServer) Apply(l *raft.Log) interface{} {
 			reply := op.ClientDisconnect.Reply
 			// Only send a reply if we are the server that proposed the
 			// disconnect.
-			if op.Leader != s.opts.ClusterNodeID {
+			if op.Leader != s.opts.Clustering.NodeID {
 				reply = ""
 			}
 			s.scheduleConnClose(op.ClientDisconnect.ClientID, reply)

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -124,7 +124,7 @@
 			"importpath": "github.com/hashicorp/raft-boltdb",
 			"repository": "https://github.com/hashicorp/raft-boltdb",
 			"vcs": "git",
-			"revision": "df631556b57507bd5d0ed4f87468fd93ab025bef",
+			"revision": "6e5ba93211eaf8d9a2ad7e41ffad8c6f160f9fe3",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
Apply the fsync configuration from the file store to the Raft log
backend. This allows disabling disk syncing on every write to the
Raft log which improves performance. While this creates some risk,
the thought is if we are replicating to enough nodes, the replication
itself is sufficient for HA of data since the likelihood of more than a
quorum of nodes failing is low.

Note: we may want to consider disabling fsync as the default in
clustered mode for performance reasons, similar to what Kafka
does.

@kozlovic 