### PR TITLE
[FIXED] Server is not rejecting `/` in channel names

### DIFF
--- a/server/conf.go
+++ b/server/conf.go
@@ -267,7 +267,7 @@ func parsePerChannelLimits(itf interface{}, opts *Options) error {
 		if !ok {
 			return fmt.Errorf("expected channel limits to be a map/struct, got %v", limits)
 		}
-		if !util.IsSubjectValid(channelName, true) {
+		if !util.IsChannelNameValid(channelName, true) {
 			return fmt.Errorf("invalid channel name %q", channelName)
 		}
 		cl := &stores.ChannelLimits{}

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -308,6 +308,7 @@ func TestParseWrongTypes(t *testing.T) {
 	expectFailureFor(t, "store_limits:{channels:{\"foo.*bar\":{}}}", wrongSubjErr)
 	expectFailureFor(t, "store_limits:{channels:{\"foo.>.>\":{}}}", wrongSubjErr)
 	expectFailureFor(t, "store_limits:{channels:{\"foo..bar\":{}}}", wrongSubjErr)
+	expectFailureFor(t, "store_limits:{channels:{\"foo/bar\":{}}}", wrongSubjErr)
 	expectFailureFor(t, "tls:{client_cert:123}", wrongTypeErr)
 	expectFailureFor(t, "tls:{client_key:123}", wrongTypeErr)
 	expectFailureFor(t, "tls:{client_ca:123}", wrongTypeErr)

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -21,7 +21,7 @@ const (
 	mapStructErr = "map/struct"
 	wrongTypeErr = "value is expected to be"
 	wrongTimeErr = "time: "
-	wrongSubjErr = "invalid channel name"
+	wrongChanErr = "invalid channel name"
 )
 
 func TestParseConfig(t *testing.T) {
@@ -305,10 +305,10 @@ func TestParseWrongTypes(t *testing.T) {
 	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_age:\"1h:0m\"}}}", wrongTimeErr)
 	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_age:false}}}", wrongTypeErr)
 	expectFailureFor(t, "store_limits:{channels:{\"foo\":{max_subs:false}}}", wrongTypeErr)
-	expectFailureFor(t, "store_limits:{channels:{\"foo.*bar\":{}}}", wrongSubjErr)
-	expectFailureFor(t, "store_limits:{channels:{\"foo.>.>\":{}}}", wrongSubjErr)
-	expectFailureFor(t, "store_limits:{channels:{\"foo..bar\":{}}}", wrongSubjErr)
-	expectFailureFor(t, "store_limits:{channels:{\"foo/bar\":{}}}", wrongSubjErr)
+	expectFailureFor(t, "store_limits:{channels:{\"foo.*bar\":{}}}", wrongChanErr)
+	expectFailureFor(t, "store_limits:{channels:{\"foo.>.>\":{}}}", wrongChanErr)
+	expectFailureFor(t, "store_limits:{channels:{\"foo..bar\":{}}}", wrongChanErr)
+	expectFailureFor(t, "store_limits:{channels:{\"foo/bar\":{}}}", wrongChanErr)
 	expectFailureFor(t, "tls:{client_cert:123}", wrongTypeErr)
 	expectFailureFor(t, "tls:{client_key:123}", wrongTypeErr)
 	expectFailureFor(t, "tls:{client_ca:123}", wrongTypeErr)

--- a/server/partitions_test.go
+++ b/server/partitions_test.go
@@ -66,6 +66,7 @@ func TestPartitionsInvalidChannelName(t *testing.T) {
 	serverShouldFail("foo*")
 	serverShouldFail("foo.*.")
 	serverShouldFail("foo.>.bar")
+	serverShouldFail("foo/bar")
 }
 
 func TestPartitionsInvalidRequest(t *testing.T) {

--- a/server/partitions_test.go
+++ b/server/partitions_test.go
@@ -49,9 +49,9 @@ func TestPartitionsInvalidChannelName(t *testing.T) {
 
 	opts := GetDefaultOptions()
 	opts.Partitioning = true
-	serverShouldFail := func(subject string) {
+	serverShouldFail := func(channel string) {
 		opts.StoreLimits.PerChannel = nil
-		opts.StoreLimits.AddPerChannel(subject, &stores.ChannelLimits{})
+		opts.StoreLimits.AddPerChannel(channel, &stores.ChannelLimits{})
 		s, err := RunServerWithOpts(opts, nil)
 		if s != nil {
 			s.Shutdown()

--- a/server/server.go
+++ b/server/server.go
@@ -2155,7 +2155,7 @@ func (s *StanServer) processClientPublish(m *nats.Msg) {
 	}
 
 	// Make sure we have a clientID, guid, etc.
-	if pm.Guid == "" || !s.clients.isValid(pm.ClientID) || !util.IsSubjectValid(pm.Subject, false) {
+	if pm.Guid == "" || !s.clients.isValid(pm.ClientID) || !util.IsChannelNameValid(pm.Subject, false) {
 		s.log.Errorf("Received invalid client publish message %v", pm)
 		s.sendPublishErr(m.Reply, pm.Guid, ErrInvalidPubReq)
 		return
@@ -3115,8 +3115,8 @@ func (s *StanServer) processSubscriptionRequest(m *nats.Msg) {
 	}
 
 	// Make sure subject is valid
-	if !util.IsSubjectValid(sr.Subject, false) {
-		s.log.Errorf("[Client:%s] Invalid Subject %q in subscription request from %s",
+	if !util.IsChannelNameValid(sr.Subject, false) {
+		s.log.Errorf("[Client:%s] Invalid channel %q in subscription request from %s",
 			sr.ClientID, sr.Subject, m.Subject)
 		s.sendSubscriptionResponseErr(m.Reply, ErrInvalidSubject)
 		return

--- a/stores/limits.go
+++ b/stores/limits.go
@@ -74,7 +74,7 @@ func (sl *StoreLimits) Build() error {
 		if !util.IsChannelNameValid(cn, true) {
 			return fmt.Errorf("invalid channel name %q", cn)
 		}
-		isLiteral := util.IsSubjectLiteral(cn)
+		isLiteral := util.IsChannelNameLiteral(cn)
 		if isLiteral {
 			literals++
 			if sl.MaxChannels > 0 && literals > sl.MaxChannels {
@@ -172,7 +172,7 @@ func (sl *StoreLimits) Print() []string {
 		sublist.Insert(cn, &channelLimitInfo{
 			name:      cn,
 			limits:    cl,
-			isLiteral: util.IsSubjectLiteral(cn),
+			isLiteral: util.IsChannelNameLiteral(cn),
 		})
 	}
 	maxLevels := sublist.NumLevels()

--- a/stores/limits.go
+++ b/stores/limits.go
@@ -71,7 +71,7 @@ func (sl *StoreLimits) Build() error {
 	literals := 0
 	sublist := util.NewSublist()
 	for cn, cl := range sl.PerChannel {
-		if !util.IsSubjectValid(cn, true) {
+		if !util.IsChannelNameValid(cn, true) {
 			return fmt.Errorf("invalid channel name %q", cn)
 		}
 		isLiteral := util.IsSubjectLiteral(cn)

--- a/stores/limits_test.go
+++ b/stores/limits_test.go
@@ -117,6 +117,11 @@ func TestLimitsBuildErrors(t *testing.T) {
 	cl = &ChannelLimits{}
 	sl.AddPerChannel(".foo", cl)
 	expectError("invalid channel name")
+
+	sl = testDefaultStoreLimits
+	cl = &ChannelLimits{}
+	sl.AddPerChannel("foo/bar", cl)
+	expectError("invalid channel name")
 }
 
 func TestLimitsPerChannelOverride(t *testing.T) {

--- a/util/util.go
+++ b/util/util.go
@@ -137,8 +137,10 @@ func CloseFile(err error, f io.Closer) error {
 	return err
 }
 
-// IsChannelNameValid returns false if any of these conditions apply:
+// IsChannelNameValid returns false if any of these conditions for
+// the channel name apply:
 // - is empty
+// - contains the `/` character
 // - token separator `.` is first or last
 // - there are two consecutives token separators `.`
 // if wildcardsAllowed is false:
@@ -177,12 +179,12 @@ func IsChannelNameValid(channel string, wildcardsAllowed bool) bool {
 	return true
 }
 
-// IsSubjectLiteral returns true if the subject is a literal (that is,
+// IsChannelNameLiteral returns true if the channel name is a literal (that is,
 // it does not contain any wildcard).
-// The subject is assumed to be valid.
-func IsSubjectLiteral(subject string) bool {
-	for i := 0; i < len(subject); i++ {
-		if subject[i] == pwc || subject[i] == fwc {
+// The channel name is assumed to be valid.
+func IsChannelNameLiteral(channel string) bool {
+	for i := 0; i < len(channel); i++ {
+		if channel[i] == pwc || channel[i] == fwc {
 			return false
 		}
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -137,7 +137,7 @@ func CloseFile(err error, f io.Closer) error {
 	return err
 }
 
-// IsSubjectValid returns false if any of these conditions apply:
+// IsChannelNameValid returns false if any of these conditions apply:
 // - is empty
 // - token separator `.` is first or last
 // - there are two consecutives token separators `.`
@@ -146,13 +146,16 @@ func CloseFile(err error, f io.Closer) error {
 // if wildcardsAllowed is true:
 // - '*' or '>' are not a token in their own
 // - `>` is not the last token
-func IsSubjectValid(subject string, wildcardsAllowed bool) bool {
-	if subject == "" || subject[0] == btsep {
+func IsChannelNameValid(channel string, wildcardsAllowed bool) bool {
+	if channel == "" || channel[0] == btsep {
 		return false
 	}
-	for i := 0; i < len(subject); i++ {
-		c := subject[i]
-		if (c == btsep) && (i == len(subject)-1 || subject[i+1] == btsep) {
+	for i := 0; i < len(channel); i++ {
+		c := channel[i]
+		if c == '/' {
+			return false
+		}
+		if (c == btsep) && (i == len(channel)-1 || channel[i+1] == btsep) {
 			return false
 		}
 		if !wildcardsAllowed {
@@ -160,13 +163,13 @@ func IsSubjectValid(subject string, wildcardsAllowed bool) bool {
 				return false
 			}
 		} else if c == pwc || c == fwc {
-			if i > 0 && subject[i-1] != btsep {
+			if i > 0 && channel[i-1] != btsep {
 				return false
 			}
-			if c == fwc && i != len(subject)-1 {
+			if c == fwc && i != len(channel)-1 {
 				return false
 			}
-			if i < len(subject)-1 && subject[i+1] != btsep {
+			if i < len(channel)-1 && channel[i+1] != btsep {
 				return false
 			}
 		}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -194,16 +194,16 @@ func TestBackoffTimeCheck(t *testing.T) {
 	}
 }
 
-func TestIsSubjectValid(t *testing.T) {
-	subject := ""
+func TestIsChannelNameValid(t *testing.T) {
+	channel := ""
 	for i := 0; i < 100; i++ {
-		subject += "foo."
+		channel += "foo."
 	}
-	subject += "foo"
-	if !IsSubjectValid(subject, false) {
-		t.Fatalf("Subject %q should be valid", subject)
+	channel += "foo"
+	if !IsChannelNameValid(channel, false) {
+		t.Fatalf("Channel %q should be valid", channel)
 	}
-	subjects := []string{
+	channels := []string{
 		"foo.bar*",
 		"foo.bar>",
 		"foo.bar.*",
@@ -215,13 +215,14 @@ func TestIsSubjectValid(t *testing.T) {
 		"foo.bar.",
 		"..",
 		".",
+		"foo/bar",
 	}
-	for _, s := range subjects {
-		if IsSubjectValid(s, false) {
-			t.Fatalf("Subject %q expected to be invalid", s)
+	for _, s := range channels {
+		if IsChannelNameValid(s, false) {
+			t.Fatalf("Channel %q expected to be invalid", s)
 		}
 	}
-	subjects = []string{
+	channels = []string{
 		"foo.bar*",
 		"foo.bar>",
 		"foo*.bar",
@@ -237,14 +238,14 @@ func TestIsSubjectValid(t *testing.T) {
 		"..",
 		".",
 	}
-	for _, s := range subjects {
-		if IsSubjectValid(s, true) {
-			t.Fatalf("Subject %q expected to be invalid", s)
+	for _, s := range channels {
+		if IsChannelNameValid(s, true) {
+			t.Fatalf("Channel %q expected to be invalid", s)
 		}
 	}
 
-	// Test valid wildcard subjects
-	subjects = []string{
+	// Test valid wildcard channels
+	channels = []string{
 		"foo.*",
 		"foo.*.*",
 		"foo.>",
@@ -255,9 +256,9 @@ func TestIsSubjectValid(t *testing.T) {
 		"*.bar.>",
 		"*.>",
 	}
-	for _, s := range subjects {
-		if !IsSubjectValid(s, true) {
-			t.Fatalf("Subject %q expected to be valid", s)
+	for _, s := range channels {
+		if !IsChannelNameValid(s, true) {
+			t.Fatalf("Channel %q expected to be valid", s)
 		}
 	}
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -263,17 +263,17 @@ func TestIsChannelNameValid(t *testing.T) {
 	}
 }
 
-func TestIsSubjectLiteral(t *testing.T) {
-	subjects := []string{"foo.*", "foo.>", "foo.*.bar", "foo.bar.*"}
-	for _, s := range subjects {
-		if IsSubjectLiteral(s) {
-			t.Fatalf("IsSubjectLiteral for %q should have returned false", s)
+func TestIsChannelNameLiteral(t *testing.T) {
+	channels := []string{"foo.*", "foo.>", "foo.*.bar", "foo.bar.*"}
+	for _, s := range channels {
+		if IsChannelNameLiteral(s) {
+			t.Fatalf("IsChannelNameLiteral for %q should have returned false", s)
 		}
 	}
-	subjects = []string{"foo.bar", "foo.baz", "foo.baz.bar", "foo.bar.baz"}
-	for _, s := range subjects {
-		if !IsSubjectLiteral(s) {
-			t.Fatalf("IsSubjectLiteral for %q should have returned true", s)
+	channels = []string{"foo.bar", "foo.baz", "foo.baz.bar", "foo.bar.baz"}
+	for _, s := range channels {
+		if !IsChannelNameLiteral(s) {
+			t.Fatalf("IsChannelNameLiteral for %q should have returned true", s)
 		}
 	}
 }


### PR DESCRIPTION
This was a problem with FileStore implementation since channels
are not meant to translate into sub directories (but be flat).

The server now rejects channels containing `/`, regardless of
the store type being used.

Resolves #403