### PR TITLE
Support manual bootstrap configuration of cluster

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -37,7 +37,8 @@ Streaming Server Options:
 Streaming Server Clustering Options:
     --clustered <bool>                   Run the server in a clustered configuration (default: false)
     --cluster_node_id <string>           ID of the node within the cluster if there is no stored ID (default: random UUID)
-    --cluster_bootstrap <bool>           Bootstrap the cluster if there is no existing state (default: false)
+    --cluster_bootstrap <bool>           Bootstrap the cluster if there is no existing state by electing self as leader (default: false)
+    --cluster_peers <string>             List of cluster peer node IDs to bootstrap cluster state.
     --cluster_log_path <string>          Directory to store log replication data
     --cluster_log_cache_size <int>       Number of log entries to cache in memory to reduce disk IO (default: 512)
     --cluster_log_snapshots <int>        Number of log snapshots to retain (default: 2)

--- a/server/clustering.go
+++ b/server/clustering.go
@@ -24,6 +24,7 @@ type ClusteringOptions struct {
 	Clustered      bool          // Run the server in a clustered configuration.
 	NodeID         string        // ID of the node within the cluster.
 	Bootstrap      bool          // Bootstrap the cluster as a seed node if there is no existing state.
+	Peers          []string      // List of cluster peer node IDs to bootstrap cluster state.
 	RaftLogPath    string        // Path to Raft log store directory.
 	LogCacheSize   int           // Number of Raft log entries to cache in memory to reduce disk IO.
 	LogSnapshots   int           // Number of Raft log snapshots to retain.
@@ -151,17 +152,12 @@ func (s *StanServer) createRaftNode(name string, fsm raft.FSM) (*raftNode, error
 	if err != nil {
 		return nil, err
 	}
-	if s.opts.Clustering.Bootstrap && !existingState {
-		config := raft.Configuration{
-			Servers: []raft.Server{
-				raft.Server{
-					ID:      raft.ServerID(s.opts.Clustering.NodeID),
-					Address: raft.ServerAddress(addr),
-				},
-			},
-		}
-		s.log.Debugf("Bootstrapping Raft group %s", name)
-		if err := node.BootstrapCluster(config).Error(); err != nil {
+
+	// Bootstrap if there is no previous state and we are starting this node as
+	// a seed or a cluster configuration is provided.
+	bootstrap := !existingState && (s.opts.Clustering.Bootstrap || len(s.opts.Clustering.Peers) > 0)
+	if bootstrap {
+		if err := s.bootstrapCluster(name, node); err != nil {
 			return nil, err
 		}
 	}
@@ -207,7 +203,7 @@ func (s *StanServer) createRaftNode(name string, fsm raft.FSM) (*raftNode, error
 	}
 
 	// Attempt to join the cluster if we're not bootstrapping.
-	if !s.opts.Clustering.Bootstrap {
+	if !bootstrap {
 		req, err := (&spb.RaftJoinRequest{NodeID: s.opts.Clustering.NodeID, NodeAddr: addr}).Marshal()
 		if err != nil {
 			panic(err)
@@ -256,6 +252,46 @@ func (s *StanServer) createRaftNode(name string, fsm raft.FSM) (*raftNode, error
 	}, nil
 }
 
+// bootstrapCluster bootstraps the node for the provided Raft group either as a
+// seed node or with the given peer configuration, depending on configuration
+// and with the latter taking precedence.
+func (s *StanServer) bootstrapCluster(name string, node *raft.Raft) error {
+	var (
+		servers []raft.Server
+		addr    = s.getClusteringAddr(name)
+	)
+	if len(s.opts.Clustering.Peers) > 0 {
+		// Bootstrap using provided cluster configuration.
+		s.log.Debugf("Bootstrapping Raft group %s using provided configuration", name)
+		servers = make([]raft.Server, len(s.opts.Clustering.Peers)+1) // Add 1 for self.
+		servers[0] = raft.Server{
+			ID:      raft.ServerID(s.opts.Clustering.NodeID),
+			Address: raft.ServerAddress(addr),
+		}
+		for i, peer := range s.opts.Clustering.Peers {
+			servers[i+1] = raft.Server{
+				ID:      raft.ServerID(peer),
+				Address: raft.ServerAddress(s.getClusteringPeerAddr(name, peer)),
+			}
+		}
+	} else if s.opts.Clustering.Bootstrap {
+		// Bootstrap as a seed node.
+		s.log.Debugf("Bootstrapping Raft group %s as seed node", name)
+		servers = []raft.Server{
+			raft.Server{
+				ID:      raft.ServerID(s.opts.Clustering.NodeID),
+				Address: raft.ServerAddress(addr),
+			},
+		}
+	}
+	config := raft.Configuration{Servers: servers}
+	return node.BootstrapCluster(config).Error()
+}
+
 func (s *StanServer) getClusteringAddr(raftName string) string {
-	return fmt.Sprintf("%s.%s.%s", s.opts.ID, s.opts.Clustering.NodeID, raftName)
+	return s.getClusteringPeerAddr(raftName, s.opts.Clustering.NodeID)
+}
+
+func (s *StanServer) getClusteringPeerAddr(raftName, nodeID string) string {
+	return fmt.Sprintf("%s.%s.%s", s.opts.ID, nodeID, raftName)
 }

--- a/server/conf.go
+++ b/server/conf.go
@@ -376,6 +376,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	var (
 		stanConfigFile string
 		natsConfigFile string
+		clusterPeers   string
 	)
 
 	fs.StringVar(&sopts.ID, "cluster_id", DefaultClusterID, "stan.ID")
@@ -432,6 +433,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.BoolVar(&sopts.Clustering.Clustered, "clustered", false, "stan.Clustering.Clustered")
 	fs.StringVar(&sopts.Clustering.NodeID, "cluster_node_id", "", "stan.Clustering.NodeID")
 	fs.BoolVar(&sopts.Clustering.Bootstrap, "cluster_bootstrap", false, "stan.Clustering.Bootstrap")
+	fs.StringVar(&clusterPeers, "cluster_peers", "", "stan.Clustering.Peers")
 	fs.StringVar(&sopts.Clustering.RaftLogPath, "cluster_log_path", "", "stan.Clustering.RaftLogPath")
 	fs.IntVar(&sopts.Clustering.LogCacheSize, "cluster_log_cache_size", DefaultLogCacheSize, "stan.Clustering.LogCacheSize")
 	fs.IntVar(&sopts.Clustering.LogSnapshots, "cluster_log_snapshots", DefaultLogSnapshots, "stan.Clustering.LogSnapshots")
@@ -448,6 +450,13 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	// At this point, if NATS config file was specified in the command line (-c of -config)
 	// nopts.ConfigFile will not be empty.
 	natsConfigFile = nopts.ConfigFile
+
+	if clusterPeers != "" {
+		sopts.Clustering.Peers = []string{}
+		for _, p := range strings.Split(clusterPeers, ",") {
+			sopts.Clustering.Peers = append(sopts.Clustering.Peers, strings.TrimSpace(p))
+		}
+	}
 
 	// If both nats and streaming configuration files are used, then
 	// we only use the config file for the corresponding module.


### PR DESCRIPTION
Now clusters can be bootstrapped either by starting a node in bootstrap
mode and allowing other nodes to automatically join or by starting
servers with a cluster configuration. Once the cluster is formed, new
nodes can join the cluster automatically.

@kozlovic 