### PR TITLE
Clustering race condition fix

### DIFF
--- a/server/clustering_test.go
+++ b/server/clustering_test.go
@@ -226,8 +226,7 @@ func publishWithRetry(t *testing.T, sc stan.Conn, channel string, payload []byte
 			if i == 9 {
 				stackFatalf(t, "Error in publishWithRetry [10/10]: %v", err)
 			}
-			t.Logf("Error in publishWithRetry [%d/10]: %v\n", i+1, err)
-			t.Log(stack())
+			t.Logf("Error in publishWithRetry [%d/10]: %v\n%s\n", i+1, err, stack())
 			time.Sleep(time.Millisecond)
 			continue
 		}

--- a/server/clustering_test.go
+++ b/server/clustering_test.go
@@ -220,12 +220,14 @@ func assertMsg(t *testing.T, msg pb.MsgProto, expectedData []byte, expectedSeq u
 func publishWithRetry(t *testing.T, sc stan.Conn, channel string, payload []byte) {
 	// TODO: there is a race where connection might not be established on
 	// leader so publish can fail, so retry a few times if necessary. Remove
-	// this once connection replication is implemented.
+	// this once connection replication race is fixed.
 	for i := 0; i < 10; i++ {
 		if err := sc.Publish(channel, payload); err != nil {
 			if i == 9 {
-				stackFatalf(t, "Unexpected error on publish: %v", err)
+				stackFatalf(t, "Error in publishWithRetry [10/10]: %v", err)
 			}
+			t.Logf("Error in publishWithRetry [%d/10]: %v\n", i+1, err)
+			t.Log(stack())
 			time.Sleep(time.Millisecond)
 			continue
 		}
@@ -1607,7 +1609,9 @@ func TestClusteringRaftLogReplay(t *testing.T) {
 
 	atomic.StoreInt32(&doAckMsg, 1)
 	// Publish one more message and wait for message to be received
-	publishWithRetry(t, sc, channel, []byte("hello"))
+	if err := sc.Publish(channel, []byte("hello")); err != nil {
+		t.Fatalf("Unexpected error on publish: %v", err)
+	}
 	if err := Wait(ch); err != nil {
 		t.Fatal("Did not get our message")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -2699,8 +2699,8 @@ func (s *StanServer) processClientPublish(m *nats.Msg) {
 		// else we will report an error below...
 	}
 
-	// Make sure we have a clientID, guid, etc.
-	if pm.Guid == "" || !s.clients.isValid(pm.ClientID) || !util.IsChannelNameValid(pm.Subject, false) {
+	// Make sure we have a guid and valid channel name.
+	if pm.Guid == "" || !util.IsChannelNameValid(pm.Subject, false) {
 		s.log.Errorf("Received invalid client publish message %v", pm)
 		s.sendPublishErr(m.Reply, pm.Guid, ErrInvalidPubReq)
 		return
@@ -2718,6 +2718,18 @@ func (s *StanServer) processClientPublish(m *nats.Msg) {
 		if !c.isLeader() {
 			return
 		}
+	}
+
+	// Check if the client is valid. We do this after the clustered check so
+	// that only the leader performs this check.
+	//
+	// TODO: there is a race where the connection might not be replicated yet
+	// on this server, resulting in an invalid client id. This causes the
+	// publish to fail, so the client must retry.
+	if !s.clients.isValid(pm.ClientID) {
+		s.log.Errorf("Received invalid client publish message %v", pm)
+		s.sendPublishErr(m.Reply, pm.Guid, ErrInvalidPubReq)
+		return
 	}
 
 	s.ioChannel <- iopm

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -100,9 +100,12 @@ func init() {
 }
 
 func stackFatalf(t tLogger, f string, args ...interface{}) {
+	msg := fmt.Sprintf(f, args...) + "\n" + stack()
+	t.Fatalf(msg)
+}
+
+func stack() string {
 	lines := make([]string, 0, 32)
-	msg := fmt.Sprintf(f, args...)
-	lines = append(lines, msg)
 
 	// Generate the Stack of callers:
 	for i := 1; true; i++ {
@@ -114,7 +117,7 @@ func stackFatalf(t tLogger, f string, args ...interface{}) {
 		lines = append(lines, msg)
 	}
 
-	t.Fatalf("%s", strings.Join(lines, "\n"))
+	return strings.Join(lines, "\n")
 }
 
 func msgStoreFirstAndLastSequence(t tLogger, ms stores.MsgStore) (uint64, uint64) {


### PR DESCRIPTION
Fixes a race condition in `processClientPublish` and adds some tracing to `publishWithRetry` test function for debugging purposes.

@kozlovic 