### PR TITLE
[IMPROVED] Handle end of files filled with null bytes

### DIFF
--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -4,6 +4,7 @@ package stores
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -163,6 +164,12 @@ type FileStoreOptions struct {
 	// Number of channels recovered in parallel (default is 1).
 	ParallelRecovery int
 }
+
+// This is an internal error to detect situations where we do
+// not get an EOF but all data we read are zeros. The file
+// will be rewind to previous position and use this as the
+// first write position.
+var errNeedRewind = errors.New("end of file padded with zeros")
 
 // DefaultFileStoreOptions defines the default options for a File Store.
 var DefaultFileStoreOptions = FileStoreOptions{
@@ -686,7 +693,8 @@ func writeRecord(w io.Writer, buf []byte, recType recordType, rec record, recSiz
 func readRecord(r io.Reader, buf []byte, recTyped bool, crcTable *crc32.Table, checkCRC bool) ([]byte, int, recordType, error) {
 	_header := [recordHeaderSize]byte{}
 	header := _header[:]
-	if _, err := io.ReadFull(r, header); err != nil {
+	if read, err := io.ReadFull(r, header); err != nil {
+		err = expandReadFullError(err, "record header", recordHeaderSize, read)
 		return buf, 0, recNoType, err
 	}
 	recType := recNoType
@@ -698,19 +706,34 @@ func readRecord(r io.Reader, buf []byte, recTyped bool, crcTable *crc32.Table, c
 	} else {
 		recSize = firstInt
 	}
-	crc := util.ByteOrder.Uint32(header[4:recordHeaderSize])
+	if recSize == 0 && recType == 0 {
+		crc := util.ByteOrder.Uint32(header[4:recordHeaderSize])
+		if crc == 0 {
+			return buf, 0, 0, errNeedRewind
+		}
+	}
 	// Now we are going to read the payload
 	buf = util.EnsureBufBigEnough(buf, recSize)
-	if _, err := io.ReadFull(r, buf[:recSize]); err != nil {
+	if read, err := io.ReadFull(r, buf[:recSize]); err != nil {
+		err = expandReadFullError(err, "message payload", recSize, read)
 		return buf, 0, recNoType, err
 	}
 	if checkCRC {
+		crc := util.ByteOrder.Uint32(header[4:recordHeaderSize])
 		// check CRC against what was stored
 		if c := crc32.Checksum(buf[:recSize], crcTable); c != crc {
 			return buf, 0, recNoType, fmt.Errorf("corrupted data, expected crc to be 0x%08x, got 0x%08x", crc, c)
 		}
 	}
 	return buf, recSize, recType, nil
+}
+
+func expandReadFullError(err error, text string, expectedSize, read int) error {
+	// This is a "normal" error that indicates that we are at the end of file.
+	if err == io.EOF {
+		return err
+	}
+	return fmt.Errorf("%v (%s expected to be %v bytes, only read %v)", err, text, expectedSize, read)
 }
 
 // setSize sets the initial buffer size and keep track of min/max allowed sizes
@@ -1051,6 +1074,51 @@ func (fm *filesManager) setBeforeCloseCb(file *file, bccb beforeFileClose) {
 	fm.Unlock()
 }
 
+// rewindAndTruncateFile rewinds the file from the current position by the
+// given number of bytes and truncate the file to this new position.
+// The file is assumed to be locked on entry.
+// If the file's flags indicate that this file is opened with O_APPEND, it
+// is first closed, reopened in non append mode, truncated, then reopened
+// (and locked) with original flags.
+func (fm *filesManager) rewindAndTruncateFile(file *file, numBytes int) error {
+	reopen := false
+	fd := file.handle
+	curPos, err := fd.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return err
+	}
+	if file.flags&os.O_APPEND != 0 {
+		if err := fm.closeLockedFile(file); err != nil {
+			return err
+		}
+		fd, err = openFileWithFlags(file.name, os.O_RDWR)
+		if err != nil {
+			return err
+		}
+		reopen = true
+	}
+	newPos := curPos - int64(numBytes)
+	if err := fd.Truncate(newPos); err != nil {
+		return err
+	}
+	pos, err := fd.Seek(newPos, io.SeekStart) // or Seek(0, io.SeekEnd)
+	if err != nil {
+		return err
+	}
+	if pos != newPos {
+		return fmt.Errorf("unable to set position of file %q to %v", file.name, newPos)
+	}
+	if reopen {
+		if err := fd.Close(); err != nil {
+			return err
+		}
+		if err := fm.openFile(file); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // close the files manager, including all files currently opened.
 // Returns the first error encountered when closing the files.
 func (fm *filesManager) close() error {
@@ -1174,7 +1242,7 @@ func (fs *FileStore) Recover() (*RecoveredState, error) {
 	}
 
 	// Recover the server file.
-	serverInfo, err = fs.recoverServerInfo(fs.serverFile.handle)
+	serverInfo, err = fs.recoverServerInfo()
 	if err != nil {
 		return nil, err
 	}
@@ -1185,7 +1253,7 @@ func (fs *FileStore) Recover() (*RecoveredState, error) {
 	}
 
 	// Recover the clients file
-	recoveredClients, err = fs.recoverClients(fs.clientsFile.handle)
+	recoveredClients, err = fs.recoverClients()
 	if err != nil {
 		return nil, err
 	}
@@ -1364,7 +1432,7 @@ func (fs *FileStore) Init(info *spb.ServerInfo) error {
 		return err
 	}
 	// Move offset to 4 (truncate does not do that)
-	if _, err := f.Seek(4, 0); err != nil {
+	if _, err := f.Seek(4, io.SeekStart); err != nil {
 		return err
 	}
 	// ServerInfo record is not typed. We also don't pass a reusable buffer.
@@ -1375,7 +1443,7 @@ func (fs *FileStore) Init(info *spb.ServerInfo) error {
 }
 
 // recoverClients reads the client files and returns an array of RecoveredClient
-func (fs *FileStore) recoverClients(file *os.File) ([]*Client, error) {
+func (fs *FileStore) recoverClients() ([]*Client, error) {
 	var err error
 	var recType recordType
 	var recSize int
@@ -1384,11 +1452,17 @@ func (fs *FileStore) recoverClients(file *os.File) ([]*Client, error) {
 	buf := _buf[:]
 
 	// Create a buffered reader to speed-up recovery
-	br := bufio.NewReaderSize(file, defaultBufSize)
+	br := bufio.NewReaderSize(fs.clientsFile.handle, defaultBufSize)
 
 	for {
 		buf, recSize, recType, err = readRecord(br, buf, true, fs.crcTable, fs.opts.DoCRC)
 		if err != nil {
+			if err == errNeedRewind {
+				err = fs.fm.rewindAndTruncateFile(fs.clientsFile, recordHeaderSize)
+				if err == nil {
+					break
+				}
+			}
 			if err == io.EOF {
 				err = nil
 				break
@@ -1427,9 +1501,9 @@ func (fs *FileStore) recoverClients(file *os.File) ([]*Client, error) {
 }
 
 // recoverServerInfo reads the server file and returns a ServerInfo structure
-func (fs *FileStore) recoverServerInfo(file *os.File) (*spb.ServerInfo, error) {
+func (fs *FileStore) recoverServerInfo() (*spb.ServerInfo, error) {
 	info := &spb.ServerInfo{}
-	buf, size, _, err := readRecord(file, nil, false, fs.crcTable, fs.opts.DoCRC)
+	buf, size, _, err := readRecord(fs.serverFile.handle, nil, false, fs.crcTable, fs.opts.DoCRC)
 	if err != nil {
 		if err == io.EOF {
 			// We are done, no state recovered
@@ -1441,7 +1515,7 @@ func (fs *FileStore) recoverServerInfo(file *os.File) (*spb.ServerInfo, error) {
 	// of the record we are supposed to recover. Account for the
 	// 12 bytes (4 + recordHeaderSize) corresponding to the fileVersion and
 	// record header.
-	fstat, err := file.Stat()
+	fstat, err := fs.serverFile.handle.Stat()
 	if err != nil {
 		return nil, err
 	}
@@ -1886,7 +1960,7 @@ func (ms *FileMsgStore) setFile(fslice *fileSlice, offset int64) error {
 		ms.writer = ms.bw.createNewWriter(file)
 	}
 	if offset == -1 {
-		ms.wOffset, err = file.Seek(0, 2)
+		ms.wOffset, err = file.Seek(0, io.SeekEnd)
 	} else {
 		ms.wOffset = offset
 	}
@@ -1992,6 +2066,12 @@ func (ms *FileMsgStore) recoverOneMsgFile(fslice *fileSlice, fseq int, useIdxFil
 		for {
 			seq, mindex, err = ms.readIndex(br)
 			if err != nil {
+				if err == errNeedRewind {
+					err = ms.fm.rewindAndTruncateFile(file, msgIndexRecSize)
+					if err == nil {
+						break
+					}
+				}
 				if err == io.EOF {
 					// We are done, reset err
 					err = nil
@@ -2023,6 +2103,12 @@ func (ms *FileMsgStore) recoverOneMsgFile(fslice *fileSlice, fseq int, useIdxFil
 		for {
 			ms.tmpMsgBuf, msgSize, _, err = readRecord(br, ms.tmpMsgBuf, false, crcTable, doCRC)
 			if err != nil {
+				if err == errNeedRewind {
+					err = ms.fm.rewindAndTruncateFile(file, recordHeaderSize)
+					if err == nil {
+						break
+					}
+				}
 				if err == io.EOF {
 					// We are done, reset err
 					err = nil
@@ -2179,7 +2265,8 @@ func (ms *FileMsgStore) addIndex(buf []byte, seq uint64, offset, timestamp int64
 func (ms *FileMsgStore) readIndex(r io.Reader) (uint64, *msgIndex, error) {
 	_buf := [msgIndexRecSize]byte{}
 	buf := _buf[:]
-	if _, err := io.ReadFull(r, buf); err != nil {
+	if read, err := io.ReadFull(r, buf); err != nil {
+		err = expandReadFullError(err, "message index record", msgIndexRecSize, read)
 		return 0, nil, err
 	}
 	mindex := &msgIndex{}
@@ -2187,6 +2274,13 @@ func (ms *FileMsgStore) readIndex(r io.Reader) (uint64, *msgIndex, error) {
 	mindex.offset = int64(util.ByteOrder.Uint64(buf[8:]))
 	mindex.timestamp = int64(util.ByteOrder.Uint64(buf[16:]))
 	mindex.msgSize = util.ByteOrder.Uint32(buf[24:])
+	// If all zeros, return that caller should rewind (for recovery)
+	if seq == 0 && mindex.offset == 0 && mindex.timestamp == 0 && mindex.msgSize == 0 {
+		storedCRC := util.ByteOrder.Uint32(buf[msgIndexRecSize-crcSize:])
+		if storedCRC == 0 {
+			return 0, nil, errNeedRewind
+		}
+	}
 	if ms.fstore.opts.DoCRC {
 		storedCRC := util.ByteOrder.Uint32(buf[msgIndexRecSize-crcSize:])
 		crc := crc32.Checksum(buf[:msgIndexRecSize-crcSize], ms.fstore.crcTable)
@@ -2504,7 +2598,7 @@ func (ms *FileMsgStore) readMsgIndex(slice *fileSlice, seq uint64) *msgIndex {
 	// Compute the offset in the index file itself.
 	idxFileOffset := 4 + (int64(seq-slice.firstSeq)+int64(slice.rmCount))*msgIndexRecSize
 	// Then position the file pointer of the index file.
-	if _, err := slice.idxFile.handle.Seek(idxFileOffset, 0); err != nil {
+	if _, err := slice.idxFile.handle.Seek(idxFileOffset, io.SeekStart); err != nil {
 		return nil
 	}
 	// Read the index record and ensure we have what we expect
@@ -2771,7 +2865,7 @@ func (ms *FileMsgStore) lookup(seq uint64) (*pb.MsgProto, error) {
 		if msgIndex != nil {
 			file := fslice.file.handle
 			// Position file to message's offset. 0 means from start.
-			_, err = file.Seek(msgIndex.offset, 0)
+			_, err = file.Seek(msgIndex.offset, io.SeekStart)
 			if err == nil {
 				ms.tmpMsgBuf, _, _, err = readRecord(file, ms.tmpMsgBuf, false, ms.fstore.crcTable, ms.fstore.opts.DoCRC)
 			}
@@ -3090,7 +3184,7 @@ func (fs *FileStore) newFileSubStore(channel string, limits *SubStoreLimits, doR
 		ss.writer = ss.bw.createNewWriter(ss.file.handle)
 	}
 	if doRecover {
-		if err := ss.recoverSubscriptions(ss.file.handle); err != nil {
+		if err := ss.recoverSubscriptions(); err != nil {
 			fs.fm.unlockFile(ss.file)
 			ss.Close()
 			return nil, fmt.Errorf("unable to recover subscription store for [%s]: %v", channel, err)
@@ -3167,17 +3261,23 @@ func (ss *FileSubStore) shrinkBuffer(fromTimer bool) {
 }
 
 // recoverSubscriptions recovers subscriptions state for this store.
-func (ss *FileSubStore) recoverSubscriptions(file *os.File) error {
+func (ss *FileSubStore) recoverSubscriptions() error {
 	var err error
 	var recType recordType
 
 	recSize := 0
 	// Create a buffered reader to speed-up recovery
-	br := bufio.NewReaderSize(file, defaultBufSize)
+	br := bufio.NewReaderSize(ss.file.handle, defaultBufSize)
 
 	for {
 		ss.tmpSubBuf, recSize, recType, err = readRecord(br, ss.tmpSubBuf, true, ss.crcTable, ss.opts.DoCRC)
 		if err != nil {
+			if err == errNeedRewind {
+				err = ss.fm.rewindAndTruncateFile(ss.file, recordHeaderSize)
+				if err == nil {
+					break
+				}
+			}
 			if err == io.EOF {
 				// We are done, reset err
 				err = nil

--- a/stores/filestore_msg_test.go
+++ b/stores/filestore_msg_test.go
@@ -1296,3 +1296,109 @@ func TestFSPanicOnStoreCloseWhileMsgsExpire(t *testing.T) {
 	time.Sleep(30 * time.Millisecond)
 	fs.Close()
 }
+
+func TestFSMsgIndexFileWithExtraZeros(t *testing.T) {
+	cleanupFSDatastore(t)
+	defer cleanupFSDatastore(t)
+
+	s := createDefaultFileStore(t)
+	defer s.Close()
+
+	c := storeCreateChannel(t, s, "foo")
+	ms := c.Msgs
+	msg1 := storeMsg(t, c, "foo", []byte("msg1"))
+	ms.(*FileMsgStore).RLock()
+	fname := ms.(*FileMsgStore).writeSlice.idxFile.name
+	ms.(*FileMsgStore).RUnlock()
+	s.Close()
+
+	f, err := openFileWithFlags(fname, os.O_CREATE|os.O_RDWR|os.O_APPEND)
+	if err != nil {
+		t.Fatalf("Error opening file: %v", err)
+	}
+	defer f.Close()
+	b := make([]byte, msgIndexRecSize)
+	if _, err := f.Write(b); err != nil {
+		t.Fatalf("Error adding zeros: %v", err)
+	}
+	f.Close()
+
+	// Reopen file store
+	s, rs := openDefaultFileStore(t)
+	defer s.Close()
+	rc := getRecoveredChannel(t, rs, "foo")
+	msg := msgStoreLookup(t, rc.Msgs, msg1.Sequence)
+	if !reflect.DeepEqual(msg, msg1) {
+		t.Fatalf("Expected message %v, got %v", msg1, msg)
+	}
+	// Add one more message
+	msg2 := storeMsg(t, rc, "foo", []byte("msg2"))
+	s.Close()
+
+	// Reopen file store
+	s, rs = openDefaultFileStore(t)
+	defer s.Close()
+	rc = getRecoveredChannel(t, rs, "foo")
+	msgs := []*pb.MsgProto{msg1, msg2}
+	for _, omsg := range msgs {
+		msg := msgStoreLookup(t, rc.Msgs, omsg.Sequence)
+		if !reflect.DeepEqual(msg, omsg) {
+			t.Fatalf("Expected message %v, got %v", omsg, msg)
+		}
+	}
+}
+
+func TestFSMsgFileWithExtraZeros(t *testing.T) {
+	cleanupFSDatastore(t)
+	defer cleanupFSDatastore(t)
+
+	s := createDefaultFileStore(t)
+	defer s.Close()
+
+	c := storeCreateChannel(t, s, "foo")
+	ms := c.Msgs
+	msg1 := storeMsg(t, c, "foo", []byte("msg1"))
+	ms.(*FileMsgStore).RLock()
+	datname := ms.(*FileMsgStore).writeSlice.file.name
+	idxname := ms.(*FileMsgStore).writeSlice.idxFile.name
+	ms.(*FileMsgStore).RUnlock()
+	s.Close()
+
+	// Remove index file to make store use dat file on recovery
+	os.Remove(idxname)
+	// Add zeros at end of datafile
+	f, err := openFileWithFlags(datname, os.O_CREATE|os.O_RDWR|os.O_APPEND)
+	if err != nil {
+		t.Fatalf("Error opening file: %v", err)
+	}
+	defer f.Close()
+	b := make([]byte, recordHeaderSize)
+	if _, err := f.Write(b); err != nil {
+		t.Fatalf("Error adding zeros: %v", err)
+	}
+	f.Close()
+
+	// Reopen file store
+	s, rs := openDefaultFileStore(t)
+	defer s.Close()
+	rc := getRecoveredChannel(t, rs, "foo")
+	msg := msgStoreLookup(t, rc.Msgs, msg1.Sequence)
+	if !reflect.DeepEqual(msg, msg1) {
+		t.Fatalf("Expected message %v, got %v", msg1, msg)
+	}
+	// Add one more message
+	msg2 := storeMsg(t, rc, "foo", []byte("msg2"))
+	s.Close()
+
+	// Reopen file store
+	s, rs = openDefaultFileStore(t)
+	defer s.Close()
+	rc = getRecoveredChannel(t, rs, "foo")
+	msgs := []*pb.MsgProto{msg1, msg2}
+	for _, omsg := range msgs {
+		msg := msgStoreLookup(t, rc.Msgs, omsg.Sequence)
+		if !reflect.DeepEqual(msg, omsg) {
+			t.Fatalf("Expected message %v, got %v", omsg, msg)
+		}
+	}
+}

--- a/stores/filestore_sub_test.go
+++ b/stores/filestore_sub_test.go
@@ -791,3 +791,78 @@ func TestFSCreateSubNotCountedOnError(t *testing.T) {
 		t.Fatalf("Expected subs map to be empty, got %v", lm)
 	}
 }
+
+func TestFSSubscriptionsFileWithExtraZeros(t *testing.T) {
+	cleanupFSDatastore(t)
+	defer cleanupFSDatastore(t)
+
+	s := createDefaultFileStore(t)
+	defer s.Close()
+
+	c := storeCreateChannel(t, s, "foo")
+	ss := c.Subs
+	sub1 := &spb.SubState{
+		ClientID:      "me",
+		Inbox:         "inbox",
+		AckInbox:      "ackInbox",
+		AckWaitInSecs: 10,
+	}
+	if err := ss.CreateSub(sub1); err != nil {
+		t.Fatalf("Error creating sub: %v", err)
+	}
+	ss.(*FileSubStore).RLock()
+	fname := ss.(*FileSubStore).file.name
+	ss.(*FileSubStore).RUnlock()
+
+	s.Close()
+
+	f, err := openFileWithFlags(fname, os.O_CREATE|os.O_RDWR|os.O_APPEND)
+	if err != nil {
+		t.Fatalf("Error opening file: %v", err)
+	}
+	defer f.Close()
+	b := make([]byte, recordHeaderSize)
+	if _, err := f.Write(b); err != nil {
+		t.Fatalf("Error adding zeros: %v", err)
+	}
+	f.Close()
+
+	// Reopen file store
+	s, rs := openDefaultFileStore(t)
+	defer s.Close()
+	c = getRecoveredChannel(t, rs, "foo")
+	ss = c.Subs
+	subs := getRecoveredSubs(t, rs, "foo", 1)
+	sub := subs[0]
+	if !reflect.DeepEqual(sub.Sub, sub1) {
+		t.Fatalf("Expected subscription %v, got %v", sub1, sub.Sub)
+	}
+	// Add one more sub
+	sub2 := &spb.SubState{
+		ClientID:      "me2",
+		Inbox:         "inbox2",
+		AckInbox:      "ackInbox2",
+		AckWaitInSecs: 12,
+	}
+	if err := ss.CreateSub(sub2); err != nil {
+		t.Fatalf("Error creating sub: %v", err)
+	}
+	s.Close()
+
+	// Reopen file store
+	s, rs = openDefaultFileStore(t)
+	defer s.Close()
+	subs = getRecoveredSubs(t, rs, "foo", 2)
+	for _, sub := range subs {
+		// subs is an array but created from a map, so order is not guaranteed.
+		var osub *spb.SubState
+		if sub.Sub.ID == sub1.ID {
+			osub = sub1
+		} else {
+			osub = sub2
+		}
+		if !reflect.DeepEqual(sub.Sub, osub) {
+			t.Fatalf("Expected subscription %v, got %v", osub, sub.Sub)
+		}
+	}
+}


### PR DESCRIPTION
There have been 2 reports that server fails to start due to a
subscription record of type 0, which is not possible. Without
access to store files, the suspicion is that the file has for some
reason zeros at the end of the file. If there are enough zeros to
fill the record header (8 bytes), then the function readRecord()
would return no error but a record type of 0, which would cause
calling code to return an error.

Files that are recovered have now the following logic:
- If the expected record header (or message index record) is fully
  read but all zero, the file is rewinded to prior this record and
  truncated and no error is reported.
- If there is less bytes that needed, the "unexpected EOF" is now
  augmented with information about how many bytes were expected
  and how many were actually read.

With the second item on the list, one can possibly fix the file
by truncating it. For instance, suppose that the subscriptions
file for channel foo is 3 bytes too long. This can be artificially
done with:
```
truncate -s +3 datastore/foo/subs.dat
```
The server would report this failure:
```
[FTL] STREAM: Failed to start: unable to recover subscription store for [foo]: unexpected EOF (record header expected to be 8 bytes, only read 3)
```
Truncating the file (reverse command) would allow the server to
properly recover:
```
truncate -s -3 datastore/foo/subs.dat
```
If there were more than 8 null bytes, the server would correctly
truncate the file and not even report an error. That is, say that
you stop the server and issue the following command:
```
truncate -s +13 datstore/foo/subs.dat
```
The server should not have a problem starting. Without this fix,
it would complain about unknown record type:
```
[FTL] STREAM: Failed to start: unable to create subscription store for [foo]: unexpected record type: 0
```
Resolves #440