### PR TITLE
[CHANGED] FT Standby exit on error trying to get exclusive lock

### DIFF
--- a/server/ft.go
+++ b/server/ft.go
@@ -62,8 +62,11 @@ func (s *StanServer) ftStart() (retErr error) {
 		}
 		locked, err := s.ftGetStoreLock()
 		if err != nil {
-			// This is considered a fatal error and we exit
-			return err
+			// Log the error, but go back and wait for the next interval and
+			// try again. It is possible that the error resolves (for instance
+			// the connection to the database is restored - for SQL stores).
+			s.log.Errorf("ft: error attempting to get the store lock: %v", err)
+			continue
 		} else if locked {
 			break
 		}


### PR DESCRIPTION
An FT Standby server that tried to get the exclusive lock when
missing FT heartbeats would exit if it got an error (as opposed
to knowing that it did not get the lock). In otherwords, the error
was considered fatal.
But with the introduction of SQL store, losing the DB connection
would result in standby exiting. So the server will now report
the error but go back to the loop of trying again after the
missed HB interval.

Resolves #446