### PR TITLE
[FIXED] SQLStore Message first sequence after all messages have expired

### DIFF
--- a/stores/sqlstore.go
+++ b/stores/sqlstore.go
@@ -808,7 +808,7 @@ func (s *SQLStore) Recover() (*RecoveredState, error) {
 		// the Channel table may contain a maxseq that we should use as starting
 		// point.
 		if msgStore.last == 0 {
-			msgStore.first = maxseq
+			msgStore.first = maxseq + 1
 			msgStore.last = maxseq
 		}
 


### PR DESCRIPTION
If all messages expire and then the server is restarted, the
first sequence would be 1 less than it should be.