### PR TITLE
[FIXED] Remove ghost queue durable when such record is recovered

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2010,6 +2010,7 @@ func (s *StanServer) recoverOneSub(c *channel, recSub *spb.SubState, pendingAcks
 		// has ClientID but for which connection was closed (=>!added)
 		if !added && sub.isQueueDurableSubscriber() && !sub.isShadowQueueDurable() {
 			s.log.Noticef("WARN: Not recovering ghost durable queue subscriber: [%s]:[%s] subject=%s inbox=%s", sub.ClientID, sub.QGroup, sub.subject, sub.Inbox)
+			c.store.Subs.DeleteSub(sub.ID)
 			return nil
 		}
 		// Fix for older offline durable subscribers. Newer offline durable


### PR DESCRIPTION
In issue #215, we incorrectly kept the record of a queue durable
member that closed. After the fix, on recovery this record would
not be recovered and a warning was printed. However, the record
was not deleted and subsequent restarts would continue to print
the warning.

This PR will print the warning as usual but then delete the record,
which means that at the next restart, the record (and therefore
warning) should no longer be recovered.