### PR TITLE
[FIXED] Display of per-channel limits when set to unlimited

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1574,6 +1574,11 @@ func (s *StanServer) start(runningState State) error {
 	}
 
 	s.log.Noticef("Message store is %s", s.store.Name())
+	// The store has a copy of the limits and the inheritance
+	// was not applied to our limits. To have them displayed correctly,
+	// call Build() on them (we know that this is not going to fail,
+	// otherwise we would not have been able to create the store).
+	s.opts.StoreLimits.Build()
 	storeLimitsLines := (&s.opts.StoreLimits).Print()
 	for _, l := range storeLimitsLines {
 		s.log.Noticef(l)

--- a/server/server_run_test.go
+++ b/server/server_run_test.go
@@ -732,12 +732,12 @@ func TestPersistentStoreRunServer(t *testing.T) {
 	}
 }
 
-type captureWarnGhostQSubLogger struct {
+type captureNoticesLogger struct {
 	dummyLogger
 	notices []string
 }
 
-func (l *captureWarnGhostQSubLogger) Noticef(format string, args ...interface{}) {
+func (l *captureNoticesLogger) Noticef(format string, args ...interface{}) {
 	l.Lock()
 	n := fmt.Sprintf(format, args...)
 	l.notices = append(l.notices, fmt.Sprintf("%s\n", n))
@@ -771,7 +771,7 @@ func TestGhostDurableSubs(t *testing.T) {
 	s.Shutdown()
 
 	// Re-open
-	l := &captureWarnGhostQSubLogger{}
+	l := &captureNoticesLogger{}
 	opts.EnableLogging = true
 	opts.CustomLogger = l
 	s = runServerWithOpts(t, opts, nil)


### PR DESCRIPTION
On startup the server displays global and per-channel limits.
If a channel override a limit to set it to unlimited, they would
incorrectly be displayed as -1.