### PR TITLE
[FIXED] Failed subscription appears in client's list of subscriptions

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -3728,7 +3728,11 @@ func (s *StanServer) addSubscription(ss *subStore, sub *subState) error {
 		return fmt.Errorf("can't find clientID: %v", sub.ClientID)
 	}
 	// Store this subscription in subStore
-	return ss.Store(sub)
+	if err := ss.Store(sub); err != nil {
+		s.clients.removeSub(sub.ClientID, sub)
+		return err
+	}
+	return nil
 }
 
 // updateDurable adds back `sub` to the client and updates the store.


### PR DESCRIPTION
When the MaxSubscriptions limit is set, an application would correctly
get an error when trying to create a subscription more than the limit.
However, this subscription would still appear in the list of
subscriptions for that client (as seen in the monitor endpoints).

Resolves #467