### PR TITLE
Fixed WaitForNumSubs test helper functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 sudo: false
 go:
-- 1.8.6
-- 1.9.3
+- 1.8.x
+- 1.9.x
 install:
 - go get -t ./...
 - go get github.com/nats-io/gnatsd

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -291,6 +291,13 @@ func waitForNumSubs(t tLogger, s *StanServer, ID string, expected int) {
 		// We avoid getting a copy of the subscriptions array here
 		// by directly returning the length of the array.
 		c := s.clients.lookup(ID)
+		if c == nil {
+			// Could happen in clustering mode when creation
+			// of channel did not happen yet in a node and test
+			// if checking that node. Just return something different
+			// from expected to cause waitForCount to try again.
+			return "subscriptions", -1
+		}
 		c.RLock()
 		defer c.RUnlock()
 		return "subscriptions", len(c.subs)

--- a/stores/common_msg_test.go
+++ b/stores/common_msg_test.go
@@ -338,7 +338,7 @@ func TestCSMaxAge(t *testing.T) {
 					expectedFirst, expectedLast, first, last)
 			}
 			// Wait more and all should be gone.
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(250 * time.Millisecond)
 			if n, _ := msgStoreState(t, cs.Msgs); n != 0 {
 				t.Fatalf("All messages should have expired, got %v", n)
 			}


### PR DESCRIPTION
In clustering mode, the channel may not exist yet when this
function is invoked.