### PR TITLE
[FIXED] Clarify usage of bootstrap in README and add defensive code

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,9 +327,9 @@ more information.
 
 ### Clustering Auto Configuration
 
-We can also bootstrap a NATS Streaming cluster by starting one server as the
+We can also bootstrap a NATS Streaming cluster by starting <b>one server</b> as the
 seed node using the `-cluster_bootstrap` flag. This node will elect itself
-leader, so it's important to avoid starting multiple servers as seed. Once a
+leader, <b>so it's important to avoid starting multiple servers as seed</b>. Once a
 seed node is started, other servers will automatically join the cluster. If the
 server is recovering, it will use the recovered cluster configuration.
 
@@ -343,6 +343,14 @@ nats-streaming-server -store file -dir store-b -clustered -nats_server nats://lo
 
 nats-streaming-server -store file -dir store-c -clustered -nats_server nats://localhost:4222
 ```
+
+For a given cluster ID, if more than one server is started with `cluster_bootstrap` set to true,
+each server with this parameter will report the misconfiguration and exit.
+
+The very first server that bootstrapped the cluster can be restarted, however, the operator
+<b>must remove the datastores</b> of the other servers that were incorrectly started with
+the bootstrap parameter before attempting to restart them. If they are restarted -even without the
+`-cluster_bootstrap` parameter- but with existing state, they will once again start as a leader.
 
 ## Fault Tolerance
 

--- a/server/server_run_test.go
+++ b/server/server_run_test.go
@@ -744,6 +744,21 @@ func (l *captureNoticesLogger) Noticef(format string, args ...interface{}) {
 	l.Unlock()
 }
 
+type captureFatalLogger struct {
+	dummyLogger
+	fatal string
+}
+
+func (l *captureFatalLogger) Fatalf(format string, args ...interface{}) {
+	l.Lock()
+	// Normally the server would stop after first fatal error.
+	// So capture only one.
+	if l.fatal == "" {
+		l.fatal = fmt.Sprintf(format, args...)
+	}
+	l.Unlock()
+}
+
 func TestGhostDurableSubs(t *testing.T) {
 	cleanupDatastore(t)
 	defer cleanupDatastore(t)


### PR DESCRIPTION
The servers started with `-cluster_bootstrap` will emit a message
every second that each server started with this parameter listen
to. When they detect other servers with this flag, they will
report the misconfiguration and exit.

Resolves #476