### PR TITLE
[FIXED] Removed imports of SQL drivers from Store.go

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -12,6 +12,9 @@ import (
 
 	natsd "github.com/nats-io/gnatsd/server"
 	stand "github.com/nats-io/nats-streaming-server/server"
+
+	_ "github.com/go-sql-driver/mysql" // mysql driver
+	_ "github.com/lib/pq"              // postgres driver
 )
 
 var usageStr = `

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -21,11 +21,13 @@ import (
 	"github.com/nats-io/go-nats"
 	"github.com/nats-io/go-nats-streaming"
 	"github.com/nats-io/go-nats-streaming/pb"
-	"github.com/nats-io/nuid"
-
 	"github.com/nats-io/nats-streaming-server/logger"
 	"github.com/nats-io/nats-streaming-server/stores"
 	"github.com/nats-io/nats-streaming-server/test"
+	"github.com/nats-io/nuid"
+
+	_ "github.com/go-sql-driver/mysql" // mysql driver
+	_ "github.com/lib/pq"              // postgres driver
 )
 
 const (

--- a/stores/sqlstore.go
+++ b/stores/sqlstore.go
@@ -12,9 +12,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	_ "github.com/go-sql-driver/mysql" // mysql driver
-	_ "github.com/lib/pq"              // postgres driver
-
 	"github.com/nats-io/go-nats-streaming/pb"
 	"github.com/nats-io/nats-streaming-server/logger"
 	"github.com/nats-io/nats-streaming-server/spb"

--- a/stores/sqlstore_test.go
+++ b/stores/sqlstore_test.go
@@ -15,9 +15,11 @@ import (
 	"time"
 
 	"github.com/nats-io/go-nats-streaming/pb"
-
 	"github.com/nats-io/nats-streaming-server/spb"
 	"github.com/nats-io/nats-streaming-server/test"
+
+	_ "github.com/go-sql-driver/mysql" // mysql driver
+	_ "github.com/lib/pq"              // postgres driver
 )
 
 // The SourceAdmin is used by the test setup to have access


### PR DESCRIPTION
These were moved to nats-streaming-server.go (main) and to tests
files where needed. That will allow users that import NATS Streaming
server code and SQL drivers to work properly.

Resolves #485