### PR TITLE
[FIXED] Clustering: possible panic on startup

### DIFF
--- a/server/snapshot.go
+++ b/server/snapshot.go
@@ -199,7 +199,10 @@ func (s *serverSnapshot) Release() {}
 func (s *StanServer) restoreFromSnapshot(snapshot io.ReadCloser) error {
 	defer snapshot.Close()
 
-	restoreFromRaftInit := atomic.LoadInt64(&s.raftNodeCreated) == 0
+	// initialized will be 0 until the NewRaft() call has returned.
+	// So restoreFromRaftInit means that the snapshot is restored during
+	// raft node initialization.
+	restoreFromRaftInit := atomic.LoadInt64(&s.raft.initialized) == 0
 
 	// We need to drop current state. The server will recover from snapshot
 	// and all newer Raft entry logs (basically the entire state is being


### PR DESCRIPTION
This could happen when applying raft log entries to the state machine
when s.raft was not yet created. The fix could have been to move
s.raf.leader to the server structure. Instead, I have refactored
the creation of the raft node a bit so we can use the leader and
initialized atomic from s.raft instead of StanServer.
Also made s.raft.shutdown() idempotent.