### PR TITLE
[ADDED] GetNATSOptions() to return an empty NATS Options structure

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -4955,3 +4955,10 @@ func (s *StanServer) Snapshot() (raft.FSMSnapshot, error) {
 func (s *StanServer) Restore(snapshot io.ReadCloser) error {
 	return s.restoreFromSnapshot(snapshot)
 }
+
+// GetNATSOptions returns an empty NATS Options structure that one can
+// use to configure and then pass to RunServerWithOpts()
+func GetNATSOptions() *server.Options {
+	opts := server.Options{}
+	return &opts
+}

--- a/server/server_run_test.go
+++ b/server/server_run_test.go
@@ -818,3 +818,20 @@ func TestGhostDurableSubs(t *testing.T) {
 	s = runServerWithOpts(t, opts, nil)
 	check(false)
 }
+
+func TestGetNATSOptions(t *testing.T) {
+	opts := GetDefaultOptions()
+	nopts := GetNATSOptions()
+	nopts.Host = "127.0.0.1"
+	nopts.Port = 4567
+	s, err := RunServerWithOpts(opts, nopts)
+	if err != nil {
+		t.Fatalf("Error running server: %v", err)
+	}
+	defer s.Shutdown()
+	sc, err := stan.Connect(clusterName, clientName, stan.NatsURL("nats://127.0.0.1:4567"))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	sc.Close()
+}


### PR DESCRIPTION
This is required for users wanting to embed NATS Streaming.

Resolves #499