### PR TITLE
[ADDED] NewNATSOptions() to return a new instance of NATS Options

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1454,6 +1454,14 @@ func (s *StanServer) createNatsConnections() error {
 	return err
 }
 
+// NewNATSOptions returns a new instance of (NATS) Options.
+// This is needed if one wants to configure specific NATS options
+// before starting a NATS Streaming Server (with RunServerWithOpts()).
+func NewNATSOptions() *server.Options {
+	opts := server.Options{}
+	return &opts
+}
+
 // RunServer will startup an embedded STAN server and a nats-server to support it.
 func RunServer(ID string) (*StanServer, error) {
 	sOpts := GetDefaultOptions()
@@ -4954,11 +4962,4 @@ func (s *StanServer) Snapshot() (raft.FSMSnapshot, error) {
 // state.
 func (s *StanServer) Restore(snapshot io.ReadCloser) error {
 	return s.restoreFromSnapshot(snapshot)
-}
-
-// GetNATSOptions returns an empty NATS Options structure that one can
-// use to configure and then pass to RunServerWithOpts()
-func GetNATSOptions() *server.Options {
-	opts := server.Options{}
-	return &opts
 }

--- a/server/server_run_test.go
+++ b/server/server_run_test.go
@@ -821,7 +821,7 @@ func TestGhostDurableSubs(t *testing.T) {
 
 func TestGetNATSOptions(t *testing.T) {
 	opts := GetDefaultOptions()
-	nopts := GetNATSOptions()
+	nopts := NewNATSOptions()
 	nopts.Host = "127.0.0.1"
 	nopts.Port = 4567
 	s, err := RunServerWithOpts(opts, nopts)


### PR DESCRIPTION
This is related to #501 and rename the newly introduced function
GetNATSOptions() to better reflect that the call is simply returning
a new instance of NATS Options.

Resolves #499