### PR TITLE
[FIXED] Clustering: Reject use of memory store

### DIFF
--- a/server/clustering_test.go
+++ b/server/clustering_test.go
@@ -230,6 +230,26 @@ func assertMsg(t *testing.T, msg pb.MsgProto, expectedData []byte, expectedSeq u
 	}
 }
 
+func TestClusteringMemoryStoreNotSupported(t *testing.T) {
+	cleanupRaftLog(t)
+	defer cleanupRaftLog(t)
+
+	// Configure the server in non-clustered mode.
+	opts := getTestDefaultOptsForClustering("a", true)
+	opts.NATSServerURL = ""
+	opts.StoreType = stores.TypeMemory
+	s, err := RunServerWithOpts(opts, nil)
+	if err == nil {
+		if s != nil {
+			s.Shutdown()
+		}
+		t.Fatal("Expected error got none")
+	}
+	if !strings.Contains(err.Error(), stores.TypeMemory) {
+		t.Fatalf("Expected error about MEMORY store not supported, got %v", err)
+	}
+}
+
 // Ensure restarting a non-clustered server in clustered mode fails.
 func TestClusteringRestart(t *testing.T) {
 	cleanupDatastore(t)

--- a/server/server.go
+++ b/server/server.go
@@ -1341,6 +1341,9 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (newServer *
 	}
 
 	if sOpts.Clustering.Clustered {
+		if sOpts.StoreType == stores.TypeMemory {
+			return nil, fmt.Errorf("stan: clustering mode not supported with %s store type", stores.TypeMemory)
+		}
 		// Override store sync configuration with cluster sync.
 		sOpts.FileStoreOpts.DoSync = sOpts.Clustering.Sync
 	}


### PR DESCRIPTION
Memory store is not supported in clustering mode. Fail to start
if users attempt to do so.