### PR TITLE
Fix possible race in tests setup

### DIFF
--- a/server/server_limits_test.go
+++ b/server/server_limits_test.go
@@ -282,10 +282,6 @@ func TestPerChannelLimits(t *testing.T) {
 			defer cleanupDatastore(t)
 
 			opts = getTestDefaultOptsForPersistentStore()
-			if opts.StoreType == stores.TypeFile {
-				stores.FileStoreTestSetBackgroundTaskInterval(15 * time.Millisecond)
-				defer stores.FileStoreTestResetBackgroundTaskInterval()
-			}
 		}
 		opts.MaxMsgs = 10
 		opts.MaxAge = time.Hour

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -164,6 +164,8 @@ func init() {
 	// Make the server interpret all our sub's AckWait() as milliseconds instead
 	// of seconds.
 	testAckWaitIsInMillisecond = true
+	// For tests that use FileStore and do message expiration, etc..
+	stores.FileStoreTestSetBackgroundTaskInterval(15 * time.Millisecond)
 }
 
 func stackFatalf(t tLogger, f string, args ...interface{}) {

--- a/stores/filestore_msg_test.go
+++ b/stores/filestore_msg_test.go
@@ -26,7 +26,6 @@ const (
 )
 
 func init() {
-	FileStoreTestSetBackgroundTaskInterval(testFSDefaultBackgroundTaskInterval)
 	bufShrinkInterval = testFSDefaultBufShrinkInterval
 	cacheTTL = testFSDefaultCacheTTL
 	sliceCloseInterval = testFSDefaultSliceCLoseInterval

--- a/stores/filestore_test.go
+++ b/stores/filestore_test.go
@@ -42,6 +42,7 @@ func init() {
 		panic(fmt.Errorf("Error removing temp directory: %v", err))
 	}
 	testFSDefaultDatastore = tmpDir
+	FileStoreTestSetBackgroundTaskInterval(testFSDefaultBackgroundTaskInterval)
 }
 
 func cleanupFSDatastore(t tLogger) {


### PR DESCRIPTION
The server test package and stores test package may have tried
to set/reset a file store variable at the same time.