### PR TITLE
Remove NodeID from Peers in RunServerWithOpts()

### DIFF
--- a/server/clustering_test.go
+++ b/server/clustering_test.go
@@ -3389,3 +3389,33 @@ func TestClusteringNoRaftStateButStreamingState(t *testing.T) {
 		t.Fatal("Expected error, got none")
 	}
 }
+
+func TestClusteringNodeIDInPeersArray(t *testing.T) {
+	cleanupDatastore(t)
+	defer cleanupDatastore(t)
+	cleanupRaftLog(t)
+	defer cleanupRaftLog(t)
+
+	ns := natsdTest.RunDefaultServer()
+	defer ns.Shutdown()
+
+	s1Opts := getTestDefaultOptsForClustering("a", true)
+	s1Opts.Clustering.NodeID = "a"
+	s1Opts.Clustering.Peers = []string{"a", "b", "c"}
+	s1 := runServerWithOpts(t, s1Opts, nil)
+	defer s1.Shutdown()
+
+	s2Opts := getTestDefaultOptsForClustering("b", false)
+	s2Opts.Clustering.NodeID = "b"
+	s2Opts.Clustering.Peers = []string{"a", "b", "c"}
+	s2 := runServerWithOpts(t, s2Opts, nil)
+	defer s2.Shutdown()
+
+	s3Opts := getTestDefaultOptsForClustering("c", false)
+	s3Opts.Clustering.NodeID = "c"
+	s3Opts.Clustering.Peers = []string{"a", "b", "c"}
+	s3 := runServerWithOpts(t, s3Opts, nil)
+	defer s3.Shutdown()
+
+	getLeader(t, 10*time.Second, s1, s2, s3)
+}

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -623,4 +623,17 @@ func TestParseConfigureOptions(t *testing.T) {
 	if !reflect.DeepEqual(sopts.Clustering.Peers, expectedPeers) {
 		t.Fatalf("Expected Cluster.Peers to be %v, got %v", expectedPeers, sopts.Clustering.Peers)
 	}
+
+	// Check that the node id can be in the peers but is then excluded
+	sopts, _ = mustNotFail([]string{"-clustered", "-cluster_node_id", "a", "-cluster_peers", "a,b,c"})
+	if !sopts.Clustering.Clustered {
+		t.Fatal("Expected Clustering.Clustered to be true")
+	}
+	if sopts.Clustering.NodeID != "a" {
+		t.Fatalf("Expected Clustering.NodeID to be %q, got %q", "a", sopts.Clustering.NodeID)
+	}
+	expectedPeers = []string{"b", "c"}
+	if !reflect.DeepEqual(sopts.Clustering.Peers, expectedPeers) {
+		t.Fatalf("Expected Cluster.Peers to be %v, got %v", expectedPeers, sopts.Clustering.Peers)
+	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -594,6 +594,17 @@ func TestOptionsClone(t *testing.T) {
 	if _, exist := clone.PerChannel["bar"]; exist {
 		t.Fatal("The channel bar should not be in the cloned options")
 	}
+
+	opts = GetDefaultOptions()
+	opts.Clustering.Peers = []string{"a", "b", "c"}
+	clone = opts.Clone()
+	if !reflect.DeepEqual(opts.Clustering.Peers, clone.Clustering.Peers) {
+		t.Fatalf("Expected %#v, got %#v", opts.Clustering.Peers, clone.Clustering.Peers)
+	}
+	opts.Clustering.Peers[0] = "z"
+	if reflect.DeepEqual(opts.Clustering.Peers, clone.Clustering.Peers) {
+		t.Fatal("Expected clone to be different after original changed, was not")
+	}
 }
 
 func TestGetSubStoreRace(t *testing.T) {


### PR DESCRIPTION
This is an addition to PR #522.