### PR TITLE
[FIXED] Acks processing when moving from 0.7.2 to 0.8.0+ if subs still running

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -607,8 +607,15 @@ func TestOptionsClone(t *testing.T) {
 	}
 }
 
-func TestGetSubStoreRace(t *testing.T) {
-	numChans := 8000
+func TestConcurrentLookupOfChannels(t *testing.T) {
+	// The original test (TestGetSubStoreRace) was a test to detect a race
+	// that previously existed when creating a channel's subStore. However,
+	// the internal code around that has drastically changed and does not
+	// make that test really relevant. Will keep this to perform concurrent
+	// lookup or create or channels, but lower the number of channels to
+	// 100 (down from 8000) because otherwise with -race, this takes a lot
+	// of memory, slowing down some other tests below...
+	numChans := 100
 
 	opts := GetDefaultOptions()
 	opts.MaxChannels = numChans + 1

--- a/server/snapshot.go
+++ b/server/snapshot.go
@@ -321,8 +321,9 @@ func (r *raftFSM) restoreChannelsFromSnapshot(serverSnap *spb.RaftSnapshot, inNe
 			}
 			delete(channelsBeforeRestore, sc.Channel)
 		}
+		ackSubject := c.getAckSubject()
 		for _, ss := range sc.Subscriptions {
-			s.recoverOneSub(c, ss.State, nil, ss.AcksPending)
+			s.recoverOneSub(c, ackSubject, ss.State, nil, ss.AcksPending)
 		}
 	}
 	if !inNewRaftCall {


### PR DESCRIPTION
This issue exists only if an application is left running while
server prior to 0.8.0 is stopped and replaced with a version
0.8.0+ (up to current version of 0.9.1).

Resolves #539