### PR TITLE
Fixed TestMain for logger and util

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 sudo: false
 go:
-- 1.8.x
 - 1.9.x
+- 1.10.x
 install:
 - go get -t ./...
 - go get github.com/nats-io/gnatsd

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -16,14 +16,16 @@ package logger
 import (
 	"flag"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 )
 
-func TestMain(_ *testing.M) {
+func TestMain(m *testing.M) {
 	// This one is added here so that if we want to disable sql for stores tests
 	// we can use the same param for all packages as in "go test -v ./... -sql=false"
 	flag.Bool("sql", false, "Not used for logger tests")
+	os.Exit(m.Run())
 }
 
 type dummyLogger struct {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -23,10 +23,11 @@ import (
 	"time"
 )
 
-func TestMain(_ *testing.M) {
+func TestMain(m *testing.M) {
 	// This one is added here so that if we want to disable sql for stores tests
 	// we can use the same param for all packages as in "go test -v ./... -sql=false"
 	flag.Bool("sql", false, "Not used for util tests")
+	os.Exit(m.Run())
 }
 
 func stackFatalf(t *testing.T, f string, args ...interface{}) {


### PR DESCRIPTION
Support for flag -sql was added to each package, but when adding
the TestMain on logger and util, call to os.Exit(m.Run()) was missing.
This resulted in those tests to not run and affected code coverage.