### PR TITLE
[FIXED] Clustering: avoid accumulation of internal RAFT subscriptions when disconnected

### DIFF
--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -217,6 +217,10 @@ func (n *natsStreamLayer) newNATSConn(address string) *natsConn {
 // performing a handshake over NATS which establishes unique inboxes at each
 // endpoint for streaming data.
 func (n *natsStreamLayer) Dial(address raft.ServerAddress, timeout time.Duration) (net.Conn, error) {
+	if !n.conn.IsConnected() {
+		return nil, errors.New("stan: raft dial failed since not connected to NATS")
+	}
+
 	// QUESTION: The Raft NetTransport does connection pooling, which is useful
 	// for TCP sockets. The NATS transport simulates a socket using a
 	// subscription at each endpoint, but everything goes over the same NATS


### PR DESCRIPTION
When the NATS transport is down, the leader from a Raft cluster will try to 'Dial' again to the other nodes that it has perceived by making a unique subscription to a subject like:

```
raft.test-cluster.$NODE_NAME.$CLUSTER.request._INBOX.$NUID

raft.test-cluster.4tSGOGQFyl6FOd8felGDeR.test-cluster.request._INBOX.4tSGOGQFyl6FOd8felGDsZ
```

then sending a request expecting single response, but since the transport is down these subscriptions become accumulated by the client.

In order to prevent this, a potential fix could be to try skipping Dial again in case the client is aware that it is not currently connected to NATS.

Fixes #550 

Signed-off-by: Waldemar Quevedo <wally@synadia.com>