### PR TITLE
[FIXED] Avoid possible duplicate redeliveries after message is ack'ed

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1307,12 +1307,10 @@ func (s *StanServer) createNatsClientConn(name string) (*nats.Conn, error) {
 	ncOpts.ReconnectWait = 250 * time.Millisecond
 	// Make it try to reconnect for ever.
 	ncOpts.MaxReconnect = -1
-	// For FT make the reconnect buffer as small as possible since
-	// we don't really want FT HBs to be buffered while we are disconnected
-	// and be sent as a burst on reconnect.
-	if name == "ft" {
-		ncOpts.ReconnectBufSize = 128
-	}
+	// To avoid possible duplicate redeliveries, etc.., set the reconnect
+	// buffer to -1 to avoid any buffering in the nats library and flush
+	// on reconnect.
+	ncOpts.ReconnectBufSize = -1
 
 	s.log.Tracef(" NATS conn opts: %v", ncOpts)
 


### PR DESCRIPTION
If the streaming server is connecting to a standalone NATS Server,
and the streaming server is redelivering messages, if a disconnect
occurs, these redeliveries may be buffered by the NATS client
library used by the Streaming server. When the NATS Server is restarted
and the Streaming server reconnects, the pending buffer is flushed,
which if the client has reconnected before the server, would cause
the client to receive possibly a serie of the same redelivered
messages, even if the client is ack'ing them.
To prevent this, set the reconnect buffer to -1 to prevent any
buffering.