### PR TITLE
[ADDED] FileStore: option to truncate corrupted store files

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -75,6 +75,7 @@ Streaming Server File Store Options:
     --file_slice_archive_script <string> Path to script to use if you want to archive a file slice being removed
     --file_fds_limit <int>               Store will try to use no more file descriptors than this given limit
     --file_parallel_recovery <int>       On startup, number of channels that can be recovered in parallel
+    --file_truncate_bad_eof <bool>       Truncate files for which there is an unexpected EOF on recovery, dataloss may occur
 
 Streaming Server SQL Store Options:
     --sql_driver <string>            Name of the SQL Driver ("mysql" or "postgres")

--- a/server/conf.go
+++ b/server/conf.go
@@ -556,6 +556,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.StringVar(&sopts.FileStoreOpts.SliceArchiveScript, "file_slice_archive_script", "", "stan.FileStoreOpts.SliceArchiveScript")
 	fs.Int64Var(&sopts.FileStoreOpts.FileDescriptorsLimit, "file_fds_limit", stores.DefaultFileStoreOptions.FileDescriptorsLimit, "stan.FileStoreOpts.FileDescriptorsLimit")
 	fs.IntVar(&sopts.FileStoreOpts.ParallelRecovery, "file_parallel_recovery", stores.DefaultFileStoreOptions.ParallelRecovery, "stan.FileStoreOpts.ParallelRecovery")
+	fs.BoolVar(&sopts.FileStoreOpts.TruncateUnexpectedEOF, "file_truncate_bad_eof", stores.DefaultFileStoreOptions.TruncateUnexpectedEOF, "Truncate files for which there is an unexpected EOF on recovery, dataloss may occur")
 	fs.IntVar(&sopts.IOBatchSize, "io_batch_size", DefaultIOBatchSize, "stan.IOBatchSize")
 	fs.Int64Var(&sopts.IOSleepTime, "io_sleep_time", DefaultIOSleepTime, "stan.IOSleepTime")
 	fs.StringVar(&sopts.FTGroupName, "ft_group", "", "stan.FTGroupName")

--- a/stores/memstore.go
+++ b/stores/memstore.go
@@ -196,6 +196,10 @@ func (ms *MemoryMsgStore) expireMsgs() {
 	for {
 		m, ok := ms.msgs[ms.first]
 		if !ok {
+			if ms.first < ms.last {
+				ms.first++
+				continue
+			}
 			ms.ageTimer = nil
 			ms.wg.Done()
 			return


### PR DESCRIPTION
Works for errors due to unexpected EOF errors, when the files have
not been fully flushed, etc..

See README.md for details.

Resolves #557

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>