### PR TITLE
[ADDED] Support for client pings

### DIFF
--- a/server/client_test.go
+++ b/server/client_test.go
@@ -87,6 +87,7 @@ func TestClientUnregister(t *testing.T) {
 	cs := createClientStore()
 
 	clientID, hbInbox := createClientInfo()
+	uid := []byte(getUIDFromInbox(hbInbox))
 
 	// Unregistering one that does not exist should not cause a crash
 	cs.unregister(clientID)
@@ -95,7 +96,13 @@ func TestClientUnregister(t *testing.T) {
 	cs.register(clientID, hbInbox)
 
 	// Verify it's in the list of clients
-	if !cs.isValid(clientID) {
+	if !cs.isValid(clientID, nil) {
+		t.Fatal("Expected client to be registered")
+	}
+	if !cs.isValid("", uid) {
+		t.Fatal("Expected client to be registered")
+	}
+	if !cs.isValid(clientID, uid) {
 		t.Fatal("Expected client to be registered")
 	}
 
@@ -103,7 +110,13 @@ func TestClientUnregister(t *testing.T) {
 	cs.unregister(clientID)
 
 	// Verify it's gone.
-	if cs.isValid(clientID) {
+	if cs.isValid(clientID, nil) {
+		t.Fatal("Expected client to be unregistered")
+	}
+	if cs.isValid("", uid) {
+		t.Fatal("Expected client to be unregistered")
+	}
+	if cs.isValid(clientID, uid) {
 		t.Fatal("Expected client to be unregistered")
 	}
 }

--- a/server/clustering_test.go
+++ b/server/clustering_test.go
@@ -3479,3 +3479,38 @@ func TestClusteringUnableToContactPeer(t *testing.T) {
 	checkShutdown(s2)
 	checkShutdown(s1)
 }
+
+func TestClusteringClientPings(t *testing.T) {
+	cleanupDatastore(t)
+	defer cleanupDatastore(t)
+	cleanupRaftLog(t)
+	defer cleanupRaftLog(t)
+
+	clientCheckTimeout = 150 * time.Millisecond
+	defer func() { clientCheckTimeout = defaultClientCheckTimeout }()
+
+	// For this test, use a central NATS server.
+	ns := natsdTest.RunDefaultServer()
+	defer ns.Shutdown()
+
+	// Configure first server
+	s1sOpts := getTestDefaultOptsForClustering("a", true)
+	s1 := runServerWithOpts(t, s1sOpts, nil)
+	defer s1.Shutdown()
+
+	// Configure second server.
+	s2sOpts := getTestDefaultOptsForClustering("b", false)
+	s2 := runServerWithOpts(t, s2sOpts, nil)
+	defer s2.Shutdown()
+
+	servers := []*StanServer{s1, s2}
+	// Wait for leader to be elected.
+	leader := getLeader(t, 10*time.Second, servers...)
+
+	leader.mu.RLock()
+	discoverySubj := leader.info.Discovery
+	pubSubj := leader.info.Publish
+	leader.mu.RUnlock()
+
+	testClientPings(t, discoverySubj, pubSubj)
+}

--- a/server/partitions_test.go
+++ b/server/partitions_test.go
@@ -861,3 +861,39 @@ func TestPartitionsAndFT(t *testing.T) {
 		t.Fatalf("Error on publish: %v", err)
 	}
 }
+
+func TestPartitionsClientPings(t *testing.T) {
+	setPartitionsVarsForTest()
+	defer resetDefaultPartitionsVars()
+
+	clientCheckTimeout = 150 * time.Millisecond
+	defer func() { clientCheckTimeout = defaultClientCheckTimeout }()
+
+	// For this test, create a single NATS server to which both servers connect to.
+	ns := natsdTest.RunDefaultServer()
+	defer ns.Shutdown()
+
+	fooSubj := "foo"
+	barSubj := "bar"
+
+	opts1 := GetDefaultOptions()
+	opts1.NATSServerURL = "nats://localhost:4222"
+	opts1.Partitioning = true
+	opts1.StoreLimits.AddPerChannel(fooSubj, &stores.ChannelLimits{})
+	s1 := runServerWithOpts(t, opts1, nil)
+	defer s1.Shutdown()
+
+	opts2 := GetDefaultOptions()
+	opts2.NATSServerURL = "nats://localhost:4222"
+	opts2.Partitioning = true
+	opts2.StoreLimits.AddPerChannel(barSubj, &stores.ChannelLimits{})
+	s2 := runServerWithOpts(t, opts2, nil)
+	defer s2.Shutdown()
+
+	s1.mu.RLock()
+	discoverySubj := s1.info.Discovery
+	pubSubj := s1.info.Publish
+	s1.mu.RUnlock()
+
+	testClientPings(t, discoverySubj, pubSubj)
+}


### PR DESCRIPTION
Server can now receive client PINGs and not only echo back, but
can send a response indicating if the client sending the PING
is still valid or not. Indeed, a client could be "separated"
from the server and another client with the same client ID could
start and the old client be replaced. When the old client communication
with the server is restored, there would be a situation where two
clients with the same ID would exist.
The old client would now know from the PING response that it is
no longer valid.
Also, published message now contain a client UID that allows the
server to reject messages from the old client in the situation
described above.

This PR contains changes on the server. Clients implementations
to follow.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>