### PR TITLE
[IMPROVED] Subscriptions performance

### DIFF
--- a/server/clustering_test.go
+++ b/server/clustering_test.go
@@ -3435,13 +3435,13 @@ func TestClusteringUnableToContactPeer(t *testing.T) {
 	s1Opts.Clustering.RaftLogging = true
 	s1Opts.CustomLogger = logger
 	s1 := runServerWithOpts(t, s1Opts, nil)
-	// Due to the nature of this test, do not defer Shutdown here
+	defer s1.Shutdown()
 
 	s2Opts := getTestDefaultOptsForClustering("b", false)
 	s2Opts.Clustering.NodeID = "b"
 	s2Opts.Clustering.Peers = []string{"a"}
 	s2 := runServerWithOpts(t, s2Opts, nil)
-	// Due to the nature of this test, do not defer Shutdown here
+	defer s2.Shutdown()
 
 	getLeader(t, 10*time.Second, s1, s2)
 

--- a/server/snapshot.go
+++ b/server/snapshot.go
@@ -321,9 +321,8 @@ func (r *raftFSM) restoreChannelsFromSnapshot(serverSnap *spb.RaftSnapshot, inNe
 			}
 			delete(channelsBeforeRestore, sc.Channel)
 		}
-		ackSubject := c.getAckSubject()
 		for _, ss := range sc.Subscriptions {
-			s.recoverOneSub(c, ackSubject, ss.State, nil, ss.AcksPending)
+			s.recoverOneSub(c, ss.State, nil, ss.AcksPending)
 		}
 	}
 	if !inNewRaftCall {

--- a/stores/bench_test.go
+++ b/stores/bench_test.go
@@ -267,6 +267,7 @@ func BenchmarkStore__RecoverMsgs(b *testing.B) {
 				}
 				cs.Msgs.Flush()
 			}
+			s.Close()
 		}
 		benchInitRecoverMsgs = false
 	}
@@ -353,6 +354,7 @@ func BenchmarkStore__RecoverSubs(b *testing.B) {
 				b.Fatalf("Error pesisting msgseq or ack: %v", e)
 			default:
 			}
+			s.Close()
 		}
 		benchInitRecoverSubs = false
 	}


### PR DESCRIPTION
Especially with n to m. Use a dedicated connection for receiving
acks and use ack subscription's per sub instead of one per channel.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>