### PR TITLE
[FIXED] Durable subscriptions miss messages after cluster restart

### DIFF
--- a/server/clustering.go
+++ b/server/clustering.go
@@ -72,7 +72,6 @@ type raftNode struct {
 }
 
 type replicatedSub struct {
-	c   *channel
 	sub *subState
 	err error
 }
@@ -463,8 +462,8 @@ func (r *raftFSM) Apply(l *raft.Log) interface{} {
 		return s.closeClient(op.ClientDisconnect.ClientID)
 	case spb.RaftOperation_Subscribe:
 		// Subscription replication.
-		c, sub, err := s.processSub(op.Sub.Request, op.Sub.AckInbox)
-		return &replicatedSub{c: c, sub: sub, err: err}
+		sub, err := s.processSub(nil, op.Sub.Request, op.Sub.AckInbox)
+		return &replicatedSub{sub: sub, err: err}
 	case spb.RaftOperation_RemoveSubscription:
 		fallthrough
 	case spb.RaftOperation_CloseSubscription:


### PR DESCRIPTION
If a durable subscription (can apply to durable queues too) is
created with a start position other than SequenceStart, and this
subscription receive some messages, then is closed. At that time
either more messages are sent or there were already more messages
in the channel, then after a cluster restart (all nodes are
restarted), then when the durable (queue) is resumed, it would
seem to not receive any messages in the channel. Only new messages
produced after the cluster is restarted would be delivered.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>