### PR TITLE
[FIXED] Subscription incorrectly marked as stalled after restart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 - go get github.com/nats-io/gnatsd
 - go get github.com/mattn/goveralls
 - go get github.com/wadey/gocovmerge
-# - go get -u honnef.co/go/tools/cmd/megacheck
+- go get -u -insecure honnef.co/go/tools/cmd/megacheck
 - go get -u github.com/client9/misspell/cmd/misspell
 - go get -u github.com/go-sql-driver/mysql
 services:
@@ -19,7 +19,7 @@ before_script:
 - $(exit $(go fmt $EXCLUDE_VENDOR | wc -l))
 - go vet $EXCLUDE_VENDOR
 - $(exit $(misspell -locale US . | grep -v "vendor/" | wc -l))
-# - megacheck -ignore "$(cat staticcheck.ignore)" $EXCLUDE_VENDOR
+- megacheck -ignore "$(cat staticcheck.ignore)" $EXCLUDE_VENDOR
 script:
 - mysql -u root -e "CREATE USER 'nss'@'localhost' IDENTIFIED BY 'password'; GRANT ALL PRIVILEGES ON *.* TO 'nss'@'localhost'; CREATE DATABASE test_nats_streaming;"
 - go test -i $EXCLUDE_VENDOR

--- a/server/server.go
+++ b/server/server.go
@@ -2163,9 +2163,10 @@ func (s *StanServer) recoverOneSub(c *channel, recSub *spb.SubState, pendingAcks
 
 	// Create a subState
 	sub := &subState{
-		subject: c.name,
-		ackWait: computeAckWait(recSub.AckWaitInSecs),
-		store:   c.store.Subs,
+		SubState: *recSub,
+		subject:  c.name,
+		ackWait:  computeAckWait(recSub.AckWaitInSecs),
+		store:    c.store.Subs,
 	}
 	// Depending from where this function is called, we are given
 	// a map[uint64]struct{} or a []uint64.
@@ -2189,8 +2190,6 @@ func (s *StanServer) recoverOneSub(c *channel, recSub *spb.SubState, pendingAcks
 			sub.stalled = true
 		}
 	}
-	// Copy over fields from SubState protobuf
-	sub.SubState = *recSub
 	// When recovering older stores, IsDurable may not exist for
 	// durable subscribers. Set it now.
 	durableSub := sub.isDurableSubscriber() // not a durable queue sub!


### PR DESCRIPTION
If a subscription has pending messages (unack'ed) during server
recovery, then the server would mark it as stalled because it
was checking the number of pending messages vs the MaxInflight
value before that value was set from the recovered subscription
record.

Resolves #594

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>