### PR TITLE
[FIXED] Skipped redelivery not resolved after client restart

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -4187,6 +4187,10 @@ func (s *StanServer) addSubscription(ss *subStore, sub *subState) error {
 // updateDurable adds back `sub` to the client and updates the store.
 // No lock is needed for `sub` since it has just been created.
 func (s *StanServer) updateDurable(ss *subStore, sub *subState) error {
+	// Reset the hasFailedHB boolean since it may have been set
+	// if the client previously crashed and server set this
+	// flag to its subs.
+	sub.hasFailedHB = false
 	// Store in the client
 	if !s.clients.addSub(sub.ClientID, sub) {
 		return fmt.Errorf("can't find clientID: %v", sub.ClientID)


### PR DESCRIPTION
If a client has durable subscriptions and some unacknowledged
messages, then crashes, the server will detect the HB failure and
skip the redelivery until the connection is closed.
If the client is restarted and durables resumed, then the
server should redeliver messages. Since v0.10.0, it is possible
that this client's subscription are already marked has having
a failed HB which would prevent redelivery.

Resovles #600

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>