### PR TITLE
[FIXED] FileStore: Possible panic on recovery with empty index file

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -47,7 +47,7 @@ import (
 // Server defaults.
 const (
 	// VERSION is the current version for the NATS Streaming server.
-	VERSION = "0.10.2"
+	VERSION = "0.10.3"
 
 	DefaultClusterID      = "test-cluster"
 	DefaultDiscoverPrefix = "_STAN.discover"


### PR DESCRIPTION
Index files are normally not created empty, but if the server were
to stop/crash after the file is created but before the first record
is appended, then on recovery the server would panic (true only for
servers 0.10.0+).

Resolves #608

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>