### PR TITLE
[FIXED] Possible panic and other issue with file logger

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1401,7 +1401,7 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (newServer *
 	// If a custom logger is provided, use this one, otherwise, check
 	// if we should configure the logger or not.
 	if sOpts.CustomLogger != nil {
-		s.log.SetLogger(sOpts.CustomLogger, sOpts.Debug, sOpts.Trace)
+		s.log.SetLogger(sOpts.CustomLogger, nOpts.Logtime, sOpts.Debug, sOpts.Trace, "")
 	} else if sOpts.EnableLogging {
 		s.configureLogger()
 	}
@@ -1564,7 +1564,7 @@ func (s *StanServer) configureLogger() {
 		newLogger = natsdLogger.NewStdLogger(nOpts.Logtime, enableDebug, enableTrace, colors, true)
 	}
 
-	s.log.SetLogger(newLogger, sOpts.Debug, sOpts.Trace)
+	s.log.SetLogger(newLogger, nOpts.Logtime, sOpts.Debug, sOpts.Trace, nOpts.LogFile)
 }
 
 // This is either running inside RunServerWithOpts() and before any reference

--- a/server/signal.go
+++ b/server/signal.go
@@ -36,7 +36,7 @@ func (s *StanServer) handleSignals() {
 				os.Exit(0)
 			case syscall.SIGUSR1:
 				// File log re-open for rotating file logs.
-				s.natsServer.ReOpenLogFile()
+				s.log.ReopenLogFile()
 			}
 		}
 	}()


### PR DESCRIPTION
- On file log re-open, we were incorrectly call s.natsserver.ReOpenLogFile()
  since when using remote NATS Server, s.natsserver would be nil.
- Even when embedding, re-open caused a new logger to be set in the
  nats server's logging object, not the stan server.

Reproduce the logic of the NATS Server's re-opening of the log file
in Streaming Server's own logger.

Resolves #621
Resolves #622

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>