### PR TITLE
[ADDED] Trap for SIGTERM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ services:
 - mysql
 before_script:
 - EXCLUDE_VENDOR=$(go list ./... | grep -v "/vendor/")
-- go build
+- go install
 - $(exit $(go fmt $EXCLUDE_VENDOR | wc -l))
 - go vet $EXCLUDE_VENDOR
 - $(exit $(misspell -locale US . | grep -v "vendor/" | wc -l))

--- a/server/signal.go
+++ b/server/signal.go
@@ -24,14 +24,14 @@ import (
 // Signal Handling
 func (s *StanServer) handleSignals() {
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, syscall.SIGINT, syscall.SIGUSR1)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1)
 	go func() {
 		for sig := range c {
 			// Notify will relay only the signals that we have
 			// registered, so we don't need a "default" in the
 			// switch statement.
 			switch sig {
-			case syscall.SIGINT:
+			case syscall.SIGINT, syscall.SIGTERM:
 				s.Shutdown()
 				os.Exit(0)
 			case syscall.SIGUSR1:


### PR DESCRIPTION
The server was trapping only SIGINT to do a proper shutdown.
In Docker, however, the `docker stop` command sends SIGTERM. So
if we want the server to do proper shutdown, we need to trap
SIGTERM.

Resolves #624

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>