### PR TITLE
[UPDATED] Clustering example in README [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,9 @@ more information.
 Here is an example of a cluster of 3 nodes using the following configuration files.
 The nodes are running on `host1`, `host2` and `host3` respectively.
 
+<b>NOTE</b> If you have an existing NATS cluster and want to run NATS Streaming Cluster on top of that,
+see details at the end of this section.
+
 On `host1`, this configuration indicates that the server will accept client connections on port 4222.
 It will accept route connections on port 6222. It creates 2 routes, to `host2` and `host3` cluster port.
 
@@ -417,7 +420,7 @@ streaming {
 }
 ```
 
-This is the configuration for the server running on `host2`. Notice how the routes are now to `host1` and `host3`.
+Below is the configuration for the server running on `host2`. Notice how the routes are now to `host1` and `host3`.
 The other thing that changed is the node id that is set to `b` and peers are updated accordingly to `a` and `c`.
 
 Note that the `dir` configuration is also `store` but these are local directories and do not (actually must not)
@@ -464,6 +467,11 @@ streaming {
   }
 }
 ```
+
+In the example abve, the configuration assumes no existing NATS Cluster and therefore configure the
+NATS routes between each node. Should you want to use an existing NATS cluster, do not include the
+"NATS specific configuration" section, instead, add `nats_server_url` in the `streaming` section
+to point to the NATS server you want.
 
 ### Clustering Auto Configuration
 


### PR DESCRIPTION
Added some clarification about NATS Streaming Clustering configuration
when using an existing NATS cluster.

This is in reference to https://github.com/nats-io/go-nats-streaming/issues/192

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>