### PR TITLE
Added Close() for StanLogger to allow resources to be released

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -85,6 +85,16 @@ func (s *StanLogger) ReopenLogFile() {
 	s.Noticef("File log re-opened")
 }
 
+// Close closes this logger, releasing possible held resources.
+func (s *StanLogger) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if l, ok := s.log.(io.Closer); ok {
+		return l.Close()
+	}
+	return nil
+}
+
 // Noticef logs a notice statement
 func (s *StanLogger) Noticef(format string, v ...interface{}) {
 	s.executeLogCall(func(log Logger, format string, v ...interface{}) {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -186,4 +186,8 @@ func TestLogger(t *testing.T) {
 	if !strings.Contains(string(buf), expectedStr) {
 		t.Fatalf("Expected log to contain %q, got %q", expectedStr, string(buf))
 	}
+	logger.Close()
+	if err := os.Remove(fname); err != nil {
+		t.Fatalf("Unable to remove log file: %v", err)
+	}
 }

--- a/server/clustering_test.go
+++ b/server/clustering_test.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -1937,6 +1938,7 @@ func TestClusteringLogSnapshotRestoreBatching(t *testing.T) {
 	follower.opts.Clustering.RaftLogging = true
 	follower.opts.CustomLogger = cl
 	follower = runServerWithOpts(t, follower.opts, nil)
+	defer follower.Shutdown()
 	servers = append(servers, follower)
 
 	getLeader(t, 10*time.Second, servers...)
@@ -3419,6 +3421,9 @@ func TestClusteringNodeIDInPeersArray(t *testing.T) {
 }
 
 func TestClusteringUnableToContactPeer(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
 	cleanupDatastore(t)
 	defer cleanupDatastore(t)
 	cleanupRaftLog(t)

--- a/stores/raftstore_test.go
+++ b/stores/raftstore_test.go
@@ -108,6 +108,7 @@ func TestRSRecover(t *testing.T) {
 		stackFatalf(t, "Error creating raft store: %v", err)
 	}
 	s = NewRaftStore(fs)
+	defer s.Close()
 	state, err := s.Recover()
 	if err != nil {
 		t.Fatalf("Error on recover: %v", err)


### PR DESCRIPTION
If the logger is file based, allow file to be closed for proper
cleanup. This was found when running tests on Windows where test
log could not be cleaned-up because the file was still opened.

Also added some missing defers that would also cause some files
to fail to be deleted on test exit.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>