### PR TITLE
[FIXED] Clustering: Possible panic leader election

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1806,6 +1806,7 @@ func (s *StanServer) startRaftNode(hasStreamingState bool) error {
 							// Node shutdown, just return.
 							return
 						case err == raft.ErrLeadershipLost:
+						case err == raft.ErrNotLeader:
 							// Node lost leadership, continue loop.
 							continue
 						default:


### PR DESCRIPTION
If the leadership is lost while a node was just previously
elected leader, the election will fail but could result in panic.

Resolves #662

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>