### PR TITLE
[ADDED] serverz expose open files and max open files

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -25,6 +25,7 @@ import (
 
 	gnatsd "github.com/nats-io/gnatsd/server"
 	"github.com/nats-io/nats-streaming-server/stores"
+	"github.com/prometheus/procfs"
 )
 
 // Routes for the monitoring pages
@@ -53,6 +54,8 @@ type Serverz struct {
 	Channels      int       `json:"channels"`
 	TotalMsgs     int       `json:"total_msgs"`
 	TotalBytes    uint64    `json:"total_bytes"`
+	OpenFDs       int       `json:"open_fds,omitempty"`
+	MaxFDs        int       `json:"max_fds,omitempty"`
 }
 
 // Storez describes the NATS Streaming Store
@@ -187,6 +190,23 @@ func (s *StanServer) handleServerz(w http.ResponseWriter, r *http.Request) {
 	numSubs := s.numSubs
 	s.monMu.RUnlock()
 	now := time.Now()
+
+	fds := 0
+	maxFDs := 0
+	if p, err := procfs.Self(); err == nil {
+		fds, err = p.FileDescriptorsLen()
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Error getting file descriptors len: %v", err), http.StatusInternalServerError)
+			return
+		}
+		limits, err := p.NewLimits()
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Error getting process limits: %v", err), http.StatusInternalServerError)
+			return
+		}
+		maxFDs = limits.OpenFiles
+	}
+
 	serverz := &Serverz{
 		ClusterID:     s.info.ClusterID,
 		ServerID:      s.serverID,
@@ -201,6 +221,8 @@ func (s *StanServer) handleServerz(w http.ResponseWriter, r *http.Request) {
 		Subscriptions: numSubs,
 		TotalMsgs:     count,
 		TotalBytes:    bytes,
+		OpenFDs:       fds,
+		MaxFDs:        maxFDs,
 	}
 	s.sendResponse(w, r, serverz)
 }


### PR DESCRIPTION
We are monitoring nats-streamin-service with prometheus-nats-exporter, and since nats-streaming-service doesn't have the open files count as a metric, the exporter can't export it. 

We had an issue yesterday due to "too many open files", so, this PR adds the `max_fds` and  `open_fds` metrics on OSs that have a `/proc`.

I used prometheus/procfs for that, since it is already vendored and also supports all I needed.

Hope this is something you want to add :) 

Cheers

cc/ @aricart
