### PR TITLE
[FIXED] timestamp compare issue in GetSequenceFromTimestamp

### DIFF
--- a/stores/common_msg_test.go
+++ b/stores/common_msg_test.go
@@ -507,6 +507,19 @@ func TestCSGetSeqFromStartTime(t *testing.T) {
 			if seq != msgs[count-1].Sequence+1 {
 				t.Fatalf("Expected seq to be %v, got %v", msgs[count-1].Sequence+1, seq)
 			}
+
+			lastMsg := msgs[len(msgs)-1]
+			seq = msgStoreGetSequenceFromTimestamp(t, cs.Msgs, lastMsg.Timestamp)
+			if seq != lastMsg.Sequence {
+				t.Fatalf("Invalid last sequence. Expected %v got %v", lastMsg.Sequence, seq)
+			}
+
+			firstMsg := msgs[0]
+			seq = msgStoreGetSequenceFromTimestamp(t, cs.Msgs, firstMsg.Timestamp)
+			if seq != firstMsg.Sequence {
+				t.Fatalf("Invalid first sequence. Expected %v got %v", firstMsg.Sequence, seq)
+			}
+
 			// Wait for all messages to expire
 			deadline := time.Now().Add(2 * time.Second)
 			var n int

--- a/stores/memstore.go
+++ b/stores/memstore.go
@@ -170,7 +170,10 @@ func (ms *MemoryMsgStore) GetSequenceFromTimestamp(timestamp int64) (uint64, err
 	if ms.msgs[ms.first].Timestamp >= timestamp {
 		return ms.first, nil
 	}
-	if timestamp >= ms.msgs[ms.last].Timestamp {
+	if timestamp == ms.msgs[ms.last].Timestamp {
+		return ms.last, nil
+	}
+	if timestamp > ms.msgs[ms.last].Timestamp {
 		return ms.last + 1, nil
 	}
 


### PR DESCRIPTION
In GetSequenceFromTimestamp, if the timestamp only match the last
message, it could ignore the last one and return ms.last + 1.

Resolve #686