### PR TITLE
[FIXED] Channel not deleted if sub not explicitly closed

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -3893,7 +3893,7 @@ func (s *StanServer) removeAllNonDurableSubscribers(client *client) {
 	clientID := client.info.ID
 	client.RUnlock()
 	var (
-		storesToFlush map[string]stores.SubStore
+		storesToFlush = map[string]stores.SubStore{}
 		channels      = map[string]struct{}{}
 	)
 	for _, sub := range subs {
@@ -3913,9 +3913,6 @@ func (s *StanServer) removeAllNonDurableSubscribers(client *client) {
 		// so we will want to flush the store. In clustering, during replay,
 		// subStore may be nil.
 		if isDurable && subStore != nil {
-			if storesToFlush == nil {
-				storesToFlush = make(map[string]stores.SubStore, 16)
-			}
 			storesToFlush[subject] = subStore
 		}
 		channels[subject] = struct{}{}

--- a/server/server_limits_test.go
+++ b/server/server_limits_test.go
@@ -14,6 +14,7 @@
 package server
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -735,4 +736,55 @@ func TestMaxInactivity(t *testing.T) {
 	verifyChannelExist(t, s, "c10", false, 2*opts.MaxInactivity)
 
 	sc.Close()
+}
+
+func TestMaxInactivityOnConnectionClose(t *testing.T) {
+	o := GetDefaultOptions()
+	o.MaxInactivity = 250 * time.Millisecond
+	o.ClientHBInterval = 100 * time.Millisecond
+	o.ClientHBTimeout = 50 * time.Millisecond
+	o.ClientHBFailCount = 2
+	s := runServerWithOpts(t, o, nil)
+	defer s.Shutdown()
+
+	sc := NewDefaultConnection(t)
+	defer sc.Close()
+	if _, err := sc.Subscribe("foo", func(_ *stan.Msg) {}); err != nil {
+		t.Fatalf("Error on subscribe: %v", err)
+	}
+	if s.channels.get("foo") == nil {
+		t.Fatalf("Channel should exit")
+	}
+	// Close connection without closing subscription
+	sc.Close()
+	// Wait for server to remove...
+	waitForNumClients(t, s, 0)
+	// Wait for channel to be removed
+	waitFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		if s.channels.get("foo") != nil {
+			return fmt.Errorf("Channel should have been removed")
+		}
+		return nil
+	})
+	sc.Close()
+
+	sc = NewDefaultConnection(t)
+	defer sc.Close()
+	if _, err := sc.Subscribe("foo", func(_ *stan.Msg) {}); err != nil {
+		t.Fatalf("Error on subscribe: %v", err)
+	}
+	if s.channels.get("foo") == nil {
+		t.Fatalf("Channel should exit")
+	}
+	// Close NATS connection to cause server to remove it
+	sc.NatsConn().Close()
+	// Wait for server to remove...
+	waitForNumClients(t, s, 0)
+	// Wait for channel to be removed
+	waitFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		if s.channels.get("foo") != nil {
+			return fmt.Errorf("Channel should have been removed")
+		}
+		return nil
+	})
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -291,7 +291,7 @@ func waitFor(t tLogger, totalWait, waitInBetween time.Duration, f func() error) 
 		time.Sleep(waitInBetween)
 	}
 	if err != nil {
-		t.Fatalf(err.Error())
+		stackFatalf(t, err.Error())
 	}
 }
 


### PR DESCRIPTION
Trigger the channel delete timer (when max inactivity is set)
when a connection is closed (either explicitly or due to lack
of HB).

Resolves #690

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>