### PR TITLE
[FIXED] Panic in async error handler when sub is nil

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1182,8 +1182,13 @@ func (s *StanServer) stanClosedHandler(nc *nats.Conn) {
 }
 
 func (s *StanServer) stanErrorHandler(nc *nats.Conn, sub *nats.Subscription, err error) {
-	s.log.Errorf("Asynchronous error on connection %s, subject %s: %s",
-		nc.Opts.Name, sub.Subject, err)
+	if sub != nil {
+		s.log.Errorf("Asynchronous error on connection %s, subject %s: %v",
+			nc.Opts.Name, sub.Subject, err)
+	} else {
+		s.log.Errorf("Asynchronous error on connection %s: %v",
+			nc.Opts.Name, err)
+	}
 }
 
 func (s *StanServer) buildServerURLs() ([]string, error) {


### PR DESCRIPTION
Async errors can have a nil sub parameter, e.g. with publish permission violations.  This fixes a panic that occurs in that case.

Signed-off-by: Colin Sullivan <colin@synadia.com>