### PR TITLE
Revisit FileStore GetSequenceFromTimestamp()

### DIFF
--- a/stores/memstore.go
+++ b/stores/memstore.go
@@ -167,7 +167,7 @@ func (ms *MemoryMsgStore) GetSequenceFromTimestamp(timestamp int64) (uint64, err
 	if ms.first > ms.last {
 		return ms.last + 1, nil
 	}
-	if ms.msgs[ms.first].Timestamp >= timestamp {
+	if timestamp <= ms.msgs[ms.first].Timestamp {
 		return ms.first, nil
 	}
 	if timestamp == ms.msgs[ms.last].Timestamp {


### PR DESCRIPTION
Following PR #687, changed the way FileStore searches for the
first sequence greater or equal to given timestamp.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>