### PR TITLE
[FIXED] Delayed msg processing when getting invalid pub requests

### DIFF
--- a/server/partitions_test.go
+++ b/server/partitions_test.go
@@ -660,7 +660,7 @@ func checkKnownInvalidMap(t *testing.T, s *StanServer, size int, id string) {
 		var ki bool
 		s.clients.RLock()
 		if id != "" {
-			_, ki = s.clients.knownInvalid[id]
+			_, ki = s.clients.knownInvalid[id+":"]
 		}
 		mlen := len(s.clients.knownInvalid)
 		s.clients.RUnlock()

--- a/server/server.go
+++ b/server/server.go
@@ -118,7 +118,7 @@ const (
 	// To prevent that, when checking if a client exists, in this particular
 	// mode we will possibly wait to be notified when the client has been
 	// registered. This is the default duration for this wait.
-	defaultClientCheckTimeout = 4 * time.Second
+	defaultClientCheckTimeout = time.Second
 
 	// Interval at which server goes through list of subscriptions with
 	// pending sent/ack operations that needs to be replicated.
@@ -2931,11 +2931,15 @@ func (s *StanServer) processClientPublish(m *nats.Msg) {
 		return
 	}
 
+	if s.debug {
+		s.log.Tracef("[Client:%s] Received message from publisher subj=%s guid=%s", pm.ClientID, pm.Subject, pm.Guid)
+	}
+
 	// Check if the client is valid. We do this after the clustered check so
 	// that only the leader performs this check.
 	valid := false
-	if s.partitions != nil || s.isClustered {
-		// In partitioning or clustering it is possible that we get there
+	if s.partitions != nil {
+		// In partitioning mode it is possible that we get there
 		// before the connect request is processed. If so, make sure we wait
 		// for conn request	to be processed first. Check clientCheckTimeout
 		// doc for details.


### PR DESCRIPTION
When a published message is processed by the server and the
associated clientID is not found, in partitions mode, we need
to wait to see if the processing of the connect is going to
happen soon. Delay here is delaying all other inbound messages.
We don't have a choice here, but reducing the wait time and
also remembering the failed clientIDs so that next invalid
message is processed fast (map lookup).

Also removed this check from clustered mode. It used to be required
when clustering was using a RAFT group per channel and one for
meta data, but this is no longer the case (single RAFT group).

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>