### PR TITLE
[FIXED] Clustering: possible panic in follower due to maxInactivity

### DIFF
--- a/server/clustering.go
+++ b/server/clustering.go
@@ -472,6 +472,11 @@ func (r *raftFSM) Apply(l *raft.Log) interface{} {
 			// This is a batch for a given channel, so lookup channel once.
 			if c == nil {
 				c, err = s.lookupOrCreateChannel(msg.Subject)
+				// That should not be the case, but if it happens,
+				// just bail out.
+				if err == ErrChanDelInProgress {
+					return nil
+				}
 			}
 			if err == nil {
 				_, err = c.store.Msgs.Store(msg)

--- a/server/server.go
+++ b/server/server.go
@@ -398,6 +398,9 @@ func (cs *channelStore) maybeStartChannelDeleteTimer(name string, c *channel) {
 func (cs *channelStore) stopDeleteTimer(c *channel) {
 	cs.Lock()
 	c.stopDeleteTimer()
+	if c.activity != nil {
+		c.activity.deleteInProgress = false
+	}
 	cs.Unlock()
 }
 
@@ -2634,7 +2637,16 @@ func (s *StanServer) replicateDeleteChannel(channel string) {
 		panic(err)
 	}
 	// Wait on result of replication.
-	s.raft.Apply(data, 0).Error()
+	if err = s.raft.Apply(data, 0).Error(); err != nil {
+		// If we have lost leadership, clear the deleteInProgress flag.
+		cs := s.channels
+		cs.Lock()
+		c := cs.channels[channel]
+		if c != nil && c.activity != nil {
+			c.activity.deleteInProgress = false
+		}
+		cs.Unlock()
+	}
 }
 
 // Check if the channel can be deleted. If so, do it in place.


### PR DESCRIPTION
If a server was leader and lost leadership while about to delete
a channel due to inactivity, but then becomes a follower and need
to replicate data for this channel, there was a risk that the
server would panic trying to store messages for this channel.

Resolves #757

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>