### PR TITLE
[FIXED] Panic on raft write issue

### DIFF
--- a/server/raft_log.go
+++ b/server/raft_log.go
@@ -64,7 +64,9 @@ func newRaftLog(log logger.Logger, fileName string, sync bool, _ int, encrypt bo
 		return nil, err
 	}
 	db.NoSync = !sync
-	db.NoFreelistSync = true
+	// Don't use this for now.
+	// See https://github.com/etcd-io/bbolt/issues/152
+	// db.NoFreelistSync = true
 	db.FreelistType = bolt.FreelistMapType
 	r.conn = db
 	if err := r.init(); err != nil {


### PR DESCRIPTION
An user reported the panic due to a volume full issue and was
asking if we could print a more explicit error message (#754)

It seems that there is an issue with Boltdb and a recent param
called NoFreelistSync. When set to true and a transaction is
rolled-back, a panic occurs.

This boolean was used when moving from boltdb to etcd/bbolt
in the recent 0.12.0 release.

Disabling for now until the underlying issue can be resolved.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>