### PR TITLE
Allow custom nats client options server configuration

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1176,6 +1176,7 @@ type Options struct {
 	EncryptionCipher   string        // Cipher used for encryption. Supported are "AES" and "CHACHA". If none is specified, defaults to AES on platforms with Intel processors, CHACHA otherwise.
 	EncryptionKey      []byte        // Encryption key. The environment NATS_STREAMING_ENCRYPTION_KEY takes precedence and is the preferred way to provide the key.
 	Clustering         ClusteringOptions
+	NATSClientOpts     []nats.Option
 }
 
 // Clone returns a deep copy of the Options object.
@@ -1313,6 +1314,10 @@ func (s *StanServer) buildServerURLs() ([]string, error) {
 func (s *StanServer) createNatsClientConn(name string) (*nats.Conn, error) {
 	var err error
 	ncOpts := nats.DefaultOptions
+
+	for _, o := range s.opts.NATSClientOpts {
+		o(&ncOpts)
+	}
 
 	ncOpts.Servers, err = s.buildServerURLs()
 	if err != nil {


### PR DESCRIPTION
## Summary

Allows custom NATS client options to be set on the internal NATS client connection.

## Rationale

I am integrating NATS streaming into Chef's Automate product. Automate internally has a Microservices architecture with connections between services secured by mutual TLS cert verification. Automate is usually deployed by our customers on their own infrastructure so we have elected not to rely on using hostnames in our certificates' CN fields; instead we use the internal service names (i.e., something like `event-service` instead of `host.example.com`). In go it's fairly straightforward to adapt to this by setting the `ServerName` field of the `tls.Config` struct when it's exposed, as the NATS go client does; however NATS streaming does not currently expose the full set of NATS client options.

## Tests?

Yep! Happy to add tests, I just wanted to ensure I'm taking the preferred approach for implementing this functionality first.
