### PR TITLE
Add json field to MaxInactivity using snake case

### DIFF
--- a/stores/store.go
+++ b/stores/store.go
@@ -61,7 +61,7 @@ type ChannelLimits struct {
 	SubStoreLimits
 	// How long without any active subscription and no new message
 	// before this channel can be deleted.
-	MaxInactivity time.Duration
+	MaxInactivity time.Duration `json:"max_inactivity"`
 }
 
 // MsgStoreLimits defines limits for a MsgStore.


### PR DESCRIPTION
Fixes `MaxInactivity` being exposed in camel case when polling from monitoring endpoint to be consistent with other fields:

Before:

```sh
curl http://127.0.0.1:8222/streaming/storez
... 
  "limits": {
    "max_channels": 100,
    "max_msgs": 1000000,
    "max_bytes": 1024000000,
    "max_age": 0,
    "max_subscriptions": 1000,
    "MaxInactivity": 0
  },
```

After:

```sh
curl http://127.0.0.1:8222/streaming/storez
... 
  "limits": {
    "max_channels": 100,
    "max_msgs": 1000000,
    "max_bytes": 1024000000,
    "max_age": 0,
    "max_subscriptions": 1000,
    "max_inactivity": 0
  },
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>