### PR TITLE
[ADDED] Cluster role in serverz endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,6 +840,28 @@ various general statistics.
 }
 ```
 
+In clustering mode, there is an additional field that indicates the RAFT role of the given node.
+Here is an example:
+```
+{
+  "cluster_id": "test-cluster",
+  "server_id": "5bJdRWJW4dSxrfjKSUOgOH",
+  "version": "0.12.2",
+  "go": "go1.12.1",
+  "state": "CLUSTERED",
+  "role": "Leader",
+  "now": "2019-04-15T19:25:39.350491-06:00",
+  "start_time": "2019-04-15T19:25:30.75881-06:00",
+  "uptime": "8s",
+  "clients": 0,
+  "subscriptions": 0,
+  "channels": 0,
+  "total_msgs": 0,
+  "total_bytes": 0
+}
+```
+The possible values are: `Leader`, `Follower` or `Candidate`.
+
 #### /storez
 
 The endpoint [http://localhost:8222/streaming/storez](http://localhost:8222/streaming/storez) reports

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -47,6 +47,7 @@ type Serverz struct {
 	Version       string    `json:"version"`
 	GoVersion     string    `json:"go"`
 	State         string    `json:"state"`
+	Role          string    `json:"role,omitempty"`
 	Now           time.Time `json:"now"`
 	Start         time.Time `json:"start_time"`
 	Uptime        string    `json:"uptime"`
@@ -184,8 +185,12 @@ func (s *StanServer) handleServerz(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Error getting information about channels state: %v", err), http.StatusInternalServerError)
 		return
 	}
+	var role string
 	s.mu.RLock()
 	state := s.state
+	if s.raft != nil {
+		role = s.raft.State().String()
+	}
 	s.mu.RUnlock()
 	s.monMu.RLock()
 	numSubs := s.numSubs
@@ -214,6 +219,7 @@ func (s *StanServer) handleServerz(w http.ResponseWriter, r *http.Request) {
 		Version:       VERSION,
 		GoVersion:     runtime.Version(),
 		State:         state.String(),
+		Role:          role,
 		Now:           now,
 		Start:         s.startTime,
 		Uptime:        myUptime(now.Sub(s.startTime)),


### PR DESCRIPTION
A new field indicates the RAFT role of the node when running in
clustered mode. The possible values are `Leader`, `Follower` or
`Candidate`.

Resolves #792

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>