### PR TITLE
[FIXED] Clustering: erroneous "too many subscriptions per channel"

### DIFF
--- a/stores/common_sub_test.go
+++ b/stores/common_sub_test.go
@@ -55,6 +55,7 @@ func TestCSMaxSubs(t *testing.T) {
 				var err error
 				lastSubID := uint64(0)
 				for i := 0; i < total; i++ {
+					sub.ID = 0
 					err = cs.Subs.CreateSub(sub)
 					if err != nil {
 						break
@@ -80,10 +81,12 @@ func TestCSMaxSubs(t *testing.T) {
 					}
 					// Now try to add back 2 subscriptions...
 					// First should be fine
+					sub.ID = 0
 					if err := cs.Subs.CreateSub(sub); err != nil {
 						t.Fatalf("Error on create: %v", err)
 					}
 					// This one should fail:
+					sub.ID = 0
 					if err := cs.Subs.CreateSub(sub); err == nil || err != ErrTooManySubs {
 						t.Fatalf("Error should have been ErrTooManySubs, got %v", err)
 					}
@@ -145,6 +148,7 @@ func TestCSBasicSubStore(t *testing.T) {
 			}
 
 			// Create a new subscription, make sure subID is not reused
+			sub.ID = 0
 			err = ss.CreateSub(sub)
 			if err != nil {
 				t.Fatalf("Error on create sub: %v", err)
@@ -155,6 +159,7 @@ func TestCSBasicSubStore(t *testing.T) {
 			subToDelete := sub.ID
 			subID = sub.ID
 			// Create another
+			sub.ID = 0
 			err = ss.CreateSub(sub)
 			if err != nil {
 				t.Fatalf("Error on create sub: %v", err)
@@ -169,6 +174,7 @@ func TestCSBasicSubStore(t *testing.T) {
 			}
 			// Create a last one and make sure it does not collide with the
 			// second sub we created.
+			sub.ID = 0
 			err = ss.CreateSub(sub)
 			if err != nil {
 				t.Fatalf("Error on create sub: %v", err)

--- a/stores/common_test.go
+++ b/stores/common_test.go
@@ -519,7 +519,7 @@ func TestCSInit(t *testing.T) {
 			case TypeRaft:
 				s, err = NewFileStore(testLogger, testRSDefaultDatastore, nil)
 				if err == nil {
-					s = NewRaftStore(s)
+					s = NewRaftStore(testLogger, s, nil)
 				}
 			default:
 				panic(fmt.Errorf("Add store type %q in this test", st.name))

--- a/stores/raftstore_test.go
+++ b/stores/raftstore_test.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/nats-io/nats-streaming-server/spb"
 )
 
 var testRSDefaultDatastore string
@@ -46,7 +48,7 @@ func createDefaultRaftStore(t tLogger) *RaftStore {
 	if err != nil {
 		stackFatalf(t, "Error creating raft store: %v", err)
 	}
-	rs := NewRaftStore(fs)
+	rs := NewRaftStore(testLogger, fs, &limits)
 	state, err := rs.Recover()
 	if err != nil {
 		rs.Close()
@@ -70,7 +72,7 @@ func TestRSRecover(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating store: %v", err)
 	}
-	s := NewRaftStore(fs)
+	s := NewRaftStore(testLogger, fs, &limits)
 	defer s.Close()
 
 	info := testDefaultServerInfo
@@ -107,7 +109,78 @@ func TestRSRecover(t *testing.T) {
 	if err != nil {
 		stackFatalf(t, "Error creating raft store: %v", err)
 	}
-	s = NewRaftStore(fs)
+	s = NewRaftStore(testLogger, fs, &limits)
+	defer s.Close()
+	state, err := s.Recover()
+	if err != nil {
+		t.Fatalf("Error on recover: %v", err)
+	}
+	if state == nil {
+		t.Fatal("Expected a state, did not get one")
+	}
+	if !reflect.DeepEqual(*state.Info, info) {
+		t.Fatalf("Expected ServerInfo to be %v, got %v", *state.Info, info)
+	}
+	// Expect single channel "foo"
+	if len(state.Channels) != 1 {
+		t.Fatalf("Expected only 1 channel, got %v", len(state.Channels))
+	}
+	cs = getRecoveredChannel(t, state, "foo")
+	// Expect no client
+	if len(state.Clients) != 0 {
+		t.Fatalf("Expected no client, got %v", len(state.Clients))
+	}
+	// Expect no subscription
+	for _, rc := range state.Channels {
+		if len(rc.Subscriptions) != 0 {
+			t.Fatalf("Should have no subscription, got %v", len(rc.Subscriptions))
+		}
+	}
+	// Expect 10 messages
+	count, _ := msgStoreState(t, cs.Msgs)
+	if count != 10 {
+		t.Fatalf("Expected 10 messages, got %v", count)
+	}
+}
+
+func TestRSRecoverOldStore(t *testing.T) {
+	cleanupRaftDatastore(t)
+	defer cleanupRaftDatastore(t)
+
+	limits := testDefaultStoreLimits
+	fs, err := NewFileStore(testLogger, testRSDefaultDatastore, &limits)
+	if err != nil {
+		t.Fatalf("Error creating store: %v", err)
+	}
+
+	info := testDefaultServerInfo
+	info.ClusterID = "testRaftStore"
+	if err := fs.Init(&info); err != nil {
+		t.Fatalf("Error on init: %v", err)
+	}
+
+	// Add some messages
+	cs := storeCreateChannel(t, fs, "foo")
+	for i := 0; i < 10; i++ {
+		storeMsg(t, cs, "foo", uint64(i+1), []byte("msg"))
+	}
+
+	// Add some subscriptions activity
+	sub1 := storeSub(t, cs, "foo")
+	sub2 := storeSub(t, cs, "foo")
+	storeSubPending(t, cs, "foo", sub1, 1, 2, 3)
+	storeSubAck(t, cs, "foo", sub1, 1, 3)
+	storeSubPending(t, cs, "foo", sub2, 1, 2, 3, 4, 5)
+	storeSubAck(t, cs, "foo", sub2, 1, 2, 3, 4)
+
+	// Close store and re-open it
+	fs.Close()
+
+	fs, err = NewFileStore(testLogger, testRSDefaultDatastore, &limits)
+	if err != nil {
+		stackFatalf(t, "Error creating raft store: %v", err)
+	}
+	s := NewRaftStore(testLogger, fs, &limits)
 	defer s.Close()
 	state, err := s.Recover()
 	if err != nil {
@@ -143,5 +216,76 @@ func TestRSRecover(t *testing.T) {
 	sub3 := storeSub(t, cs, "foo")
 	if sub3 != 3 {
 		t.Fatalf("Expected sub3 to have ID 3, got %v", sub3)
+	}
+}
+
+func TestRSUseSubID(t *testing.T) {
+	cleanupRaftDatastore(t)
+	defer cleanupRaftDatastore(t)
+
+	limits := testDefaultStoreLimits
+	limits.MaxSubscriptions = 2
+	ms, err := NewMemoryStore(testLogger, &limits)
+	if err != nil {
+		t.Fatalf("Error creating store: %v", err)
+	}
+	s := NewRaftStore(testLogger, ms, &limits)
+	defer s.Close()
+
+	cs := storeCreateChannel(t, s, "foo")
+	sub := &spb.SubState{
+		ID:            10,
+		ClientID:      "me",
+		Inbox:         "ibx",
+		AckInbox:      "ackibx",
+		AckWaitInSecs: 10,
+	}
+	if err := cs.Subs.CreateSub(sub); err != nil {
+		t.Fatalf("Error creating sub: %v", err)
+	}
+	if sub.ID != 10 {
+		t.Fatalf("Store did not use the provided sub ID, expected 10, got %v", sub.ID)
+	}
+	// Store another with different sub.ID
+	newSub := *sub
+	newSub.ID = 11
+	if err := cs.Subs.CreateSub(&newSub); err != nil {
+		t.Fatalf("Error creating sub: %v", err)
+	}
+	if newSub.ID != 11 {
+		t.Fatalf("Store did not use the provided sub ID, expected 11, got %v", newSub.ID)
+	}
+
+	// Now if we call with one of existing ID it should not count toward max subs.
+	newSub2 := *sub
+	newSub2.ID = 10
+	if err := cs.Subs.CreateSub(&newSub2); err != nil {
+		t.Fatalf("Error creating sub: %v", err)
+	}
+	if newSub2.ID != 10 {
+		t.Fatalf("Store did not use the provided sub ID, expected 10, got %v", newSub2.ID)
+	}
+
+	// Now, a new one should fail.
+	newSub3 := *sub
+	newSub3.ID = 12
+	if err := cs.Subs.CreateSub(&newSub3); err != ErrTooManySubs {
+		t.Fatalf("Expected too many subs error, got %v", err)
+	}
+
+	// Delete the first (ID=10)
+	if err := cs.Subs.DeleteSub(10); err != nil {
+		t.Fatalf("Error deleting sub: %v", err)
+	}
+
+	// Check that we support sub.ID == 0 and take the max+1.
+	// So if we change newSub3.ID to 0, after create it should be
+	// set to 12 (since last max is 11)
+	newSub3.ID = 0
+	if err := cs.Subs.CreateSub(&newSub3); err != nil {
+		t.Fatalf("Error creating sub: %v", err)
+	}
+	if newSub3.ID != 12 {
+		t.Fatalf("Expected newSub3.ID to be 12, got %v", newSub3.ID)
 	}
 }


### PR DESCRIPTION
This was introduced by #802. The server was replacing the sub's ID
after the call to CreateSub(), but that meant that DeleteSub() in
the underlying sub store would not find that subscription, which
will then cause it to report too many subscriptions after a while
because the removed subscriptions were not removed from their
internal map.
The approach in this PR is to make RaftSubStore completely bypass
the underlying SubStore. It should work with a mix of servers
of different versions.

Resolves #809

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>