### PR TITLE
[FIXED] Incorrect number of subscriptions in /streaming/serverz

### DIFF
--- a/server/clustering_test.go
+++ b/server/clustering_test.go
@@ -5322,3 +5322,72 @@ func TestClusteringGapsAfterSnapshotAndNoFlush(t *testing.T) {
 		}
 	}
 }
+
+func TestClusteringNumSubs(t *testing.T) {
+	cleanupDatastore(t)
+	defer cleanupDatastore(t)
+	cleanupRaftLog(t)
+	defer cleanupRaftLog(t)
+
+	// For this test, use a central NATS server.
+	ns := natsdTest.RunDefaultServer()
+	defer ns.Shutdown()
+
+	// Configure first server
+	s1sOpts := getTestDefaultOptsForClustering("a", true)
+	s1sOpts.Clustering.TrailingLogs = 3
+	s1 := runServerWithOpts(t, s1sOpts, nil)
+	defer s1.Shutdown()
+
+	// Configure second server.
+	s2sOpts := getTestDefaultOptsForClustering("b", false)
+	s2 := runServerWithOpts(t, s2sOpts, nil)
+	defer s2.Shutdown()
+
+	getLeader(t, 10*time.Second, s1, s2)
+
+	sc := NewDefaultConnection(t)
+	defer sc.Close()
+
+	var subs []stan.Subscription
+	for i := 0; i < 10; i++ {
+		sub, err := sc.Subscribe("foo", func(_ *stan.Msg) {})
+		if err != nil {
+			t.Fatalf("Error on subscribe: %v", err)
+		}
+		subs = append(subs, sub)
+	}
+
+	for i := 0; i < 8; i++ {
+		if err := subs[i].Close(); err != nil {
+			t.Fatalf("Error on sub close: %v", err)
+		}
+	}
+	if err := s1.raft.Snapshot().Error(); err != nil {
+		t.Fatalf("Error during snapshot: %v", err)
+	}
+	for i := 8; i < 10; i++ {
+		if err := subs[i].Close(); err != nil {
+			t.Fatalf("Error on sub close: %v", err)
+		}
+	}
+
+	checkNumSubs(t, s1, 0)
+	checkNumSubs(t, s2, 0)
+
+	s1.Shutdown()
+	s2.Shutdown()
+
+	s1 = runServerWithOpts(t, s1sOpts, nil)
+	defer s1.Shutdown()
+
+	s2 = runServerWithOpts(t, s2sOpts, nil)
+	defer s2.Shutdown()
+
+	leader := getLeader(t, 10*time.Second, s1, s2)
+
+	waitForNumClients(t, leader, 1)
+	checkNumSubs(t, leader, 0)
+	sc.Close()
+	leader.Shutdown()
+}

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -192,9 +192,8 @@ func (s *StanServer) handleServerz(w http.ResponseWriter, r *http.Request) {
 		role = s.raft.State().String()
 	}
 	s.mu.RUnlock()
-	s.monMu.RLock()
-	numSubs := s.numSubs
-	s.monMu.RUnlock()
+
+	numSubs := s.numSubs()
 	now := time.Now()
 
 	fds := 0

--- a/server/server_sub_test.go
+++ b/server/server_sub_test.go
@@ -1148,9 +1148,7 @@ func TestSubAckInboxFromOlderStore(t *testing.T) {
 func checkNumSubs(t *testing.T, s *StanServer, expected int) {
 	t.Helper()
 	waitFor(t, 2*time.Second, 15*time.Millisecond, func() error {
-		s.monMu.Lock()
-		count := s.numSubs
-		s.monMu.Unlock()
+		count := s.numSubs()
 		if count != expected {
 			return fmt.Errorf("Expected %v subscriptions, got %v", expected, count)
 		}


### PR DESCRIPTION
Replaces the use of a variable that was supposed to be updated
on subscription create/remove. It was started to be a bit brittle.

Provide a function that computes the number of subscriptions
(including offline durables/queue durables).
This is a bit more costly than using the variable but will be
less prone to issues.

Resolves #819

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>