### PR TITLE
[FIXED] Clustering: restore snapshot with some messages no longer avail

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -545,9 +545,6 @@ func (s *StanServer) subToSnapshotRestoreRequests() error {
 			if err := s.ncsr.Publish(m.Reply, buf); err != nil {
 				s.log.Errorf("Snapshot restore request error for channel %q, unable to send response for seq %v: %v", c.name, seq, err)
 			}
-			if buf == nil {
-				return
-			}
 			select {
 			case <-s.shutdownCh:
 				return


### PR DESCRIPTION
When a snapshot is performed prior to messages being removed (either
expired or remove due to count/size limits), a node that would
restore from this snapshot would ask the leader to send messages
which indexes (first/last) are in the snapshot.
Both leader and node would stop the restore when the first unavail
message was found.

Resolves #834

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>