### PR TITLE
[FIXED] Clustering: message store not flushed on followers

### DIFF
--- a/server/clustering.go
+++ b/server/clustering.go
@@ -523,7 +523,7 @@ func (r *raftFSM) Apply(l *raft.Log) interface{} {
 					msg.Sequence, msg.Subject, err))
 			}
 		}
-		return nil
+		return c.store.Msgs.Flush()
 	case spb.RaftOperation_Connect:
 		// Client connection create replication.
 		return s.processConnect(op.ClientConnect.Request, op.ClientConnect.Refresh)

--- a/server/server_delivery_test.go
+++ b/server/server_delivery_test.go
@@ -257,6 +257,9 @@ func TestDeliveryWithGapsInSequence(t *testing.T) {
 }
 
 func TestPersistentStoreSQLSubsPendingRows(t *testing.T) {
+	if !doSQL {
+		t.SkipNow()
+	}
 	source := testSQLSource
 	if persistentStoreType != stores.TypeSQL {
 		// If not running tests with `-persistent_store sql`,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -81,13 +81,13 @@ var (
 	testSQLSourceAdmin  = testDefaultMySQLSourceAdmin
 	testSQLDatabaseName = testDefaultDatabaseName
 	testDBSuffixes      = []string{"", "_a", "_b", "_c"}
+	doSQL               = false
 )
 
 func TestMain(m *testing.M) {
 	var (
 		bst         string
 		pst         string
-		doSQL       bool
 		sqlCreateDb bool
 		sqlDeleteDb bool
 	)


### PR DESCRIPTION
With the SQLStore, this would cause messages to be accumulated
in write cache causing memory growth and no message stored in the
DB until the follower shutsdown or become leader.

Resolves #846

Also made server tests skip SQL specific tests if running tests
with `-sql=false` for users that don't have/want to setup an
SQL server.

Resolves #845

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>