### PR TITLE
[ADDED] FileStore: read ahead capability

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -80,6 +80,7 @@ Streaming Server File Store Options:
     --file_fds_limit <int>               Store will try to use no more file descriptors than this given limit
     --file_parallel_recovery <int>       On startup, number of channels that can be recovered in parallel
     --file_truncate_bad_eof <bool>       Truncate files for which there is an unexpected EOF on recovery, dataloss may occur
+    --file_read_buffer_size <size>       Size of messages read ahead buffer (0 to disable)
 
 Streaming Server SQL Store Options:
     --sql_driver <string>            Name of the SQL Driver ("mysql" or "postgres")

--- a/server/conf.go
+++ b/server/conf.go
@@ -498,6 +498,11 @@ func parseFileOptions(itf interface{}, opts *Options) error {
 				return err
 			}
 			opts.FileStoreOpts.ParallelRecovery = int(v.(int64))
+		case "file_read_buffer_size", "read_buffer_size":
+			if err := checkType(k, reflect.Int64, v); err != nil {
+				return err
+			}
+			opts.FileStoreOpts.ReadBufferSize = int(v.(int64))
 		}
 	}
 	return nil
@@ -592,6 +597,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.IntVar(&sopts.FileStoreOpts.CompactInterval, "file_compact_interval", stores.DefaultFileStoreOptions.CompactInterval, "stan.FileStoreOpts.CompactInterval")
 	fs.String("file_compact_min_size", fmt.Sprintf("%v", stores.DefaultFileStoreOptions.CompactMinFileSize), "stan.FileStoreOpts.CompactMinFileSize")
 	fs.String("file_buffer_size", fmt.Sprintf("%v", stores.DefaultFileStoreOptions.BufferSize), "stan.FileStoreOpts.BufferSize")
+	fs.String("file_read_buffer_size", fmt.Sprintf("%v", stores.DefaultFileStoreOptions.ReadBufferSize), "")
 	fs.BoolVar(&sopts.FileStoreOpts.DoCRC, "file_crc", stores.DefaultFileStoreOptions.DoCRC, "stan.FileStoreOpts.DoCRC")
 	fs.Int64Var(&sopts.FileStoreOpts.CRCPolynomial, "file_crc_poly", stores.DefaultFileStoreOptions.CRCPolynomial, "stan.FileStoreOpts.CRCPolynomial")
 	fs.BoolVar(&sopts.FileStoreOpts.DoSync, "file_sync", stores.DefaultFileStoreOptions.DoSync, "stan.FileStoreOpts.DoSync")
@@ -690,10 +696,14 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 			sopts.MaxBytes, flagErr = getBytes(f)
 		case "file_compact_min_size":
 			sopts.FileStoreOpts.CompactMinFileSize, flagErr = getBytes(f)
-		case "file_buffer_size":
+		case "file_buffer_size", "file_read_buffer_size":
 			var i64 int64
 			i64, flagErr = getBytes(f)
-			sopts.FileStoreOpts.BufferSize = int(i64)
+			if f.Name == "file_buffer_size" {
+				sopts.FileStoreOpts.BufferSize = int(i64)
+			} else {
+				sopts.FileStoreOpts.ReadBufferSize = int(i64)
+			}
 		}
 	})
 	if flagErr != nil {

--- a/server/conf.go
+++ b/server/conf.go
@@ -696,14 +696,14 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 			sopts.MaxBytes, flagErr = getBytes(f)
 		case "file_compact_min_size":
 			sopts.FileStoreOpts.CompactMinFileSize, flagErr = getBytes(f)
-		case "file_buffer_size", "file_read_buffer_size":
+		case "file_buffer_size":
 			var i64 int64
 			i64, flagErr = getBytes(f)
-			if f.Name == "file_buffer_size" {
-				sopts.FileStoreOpts.BufferSize = int(i64)
-			} else {
-				sopts.FileStoreOpts.ReadBufferSize = int(i64)
-			}
+			sopts.FileStoreOpts.BufferSize = int(i64)
+		case "file_read_buffer_size":
+			var i64 int64
+			i64, flagErr = getBytes(f)
+			sopts.FileStoreOpts.ReadBufferSize = int(i64)
 		}
 	})
 	if flagErr != nil {

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -117,6 +117,9 @@ func TestParseConfig(t *testing.T) {
 	if opts.FileStoreOpts.ParallelRecovery != 9 {
 		t.Fatalf("Expected ParallelRecovery to be 9, got %v", opts.FileStoreOpts.ParallelRecovery)
 	}
+	if opts.FileStoreOpts.ReadBufferSize != 10 {
+		t.Fatalf("Expected ReadBufferSize to be 10, got %v", opts.FileStoreOpts.ReadBufferSize)
+	}
 	if opts.MaxChannels != 11 {
 		t.Fatalf("Expected MaxChannels to be 11, got %v", opts.MaxChannels)
 	}
@@ -434,6 +437,7 @@ func TestParseWrongTypes(t *testing.T) {
 	expectFailureFor(t, "file:{compact_interval:false}", wrongTypeErr)
 	expectFailureFor(t, "file:{compact_min_size:false}", wrongTypeErr)
 	expectFailureFor(t, "file:{buffer_size:false}", wrongTypeErr)
+	expectFailureFor(t, "file:{read_buffer_size:false}", wrongTypeErr)
 	expectFailureFor(t, "file:{crc:123}", wrongTypeErr)
 	expectFailureFor(t, "file:{crc_poly:false}", wrongTypeErr)
 	expectFailureFor(t, "file:{sync:123}", wrongTypeErr)
@@ -545,7 +549,7 @@ func TestParseConfigureOptions(t *testing.T) {
 	}
 
 	// Test bytes values
-	sopts, _ = mustNotFail([]string{"-max_bytes", "100KB", "-mb", "100KB", "-file_compact_min_size", "200KB", "-file_buffer_size", "300KB"})
+	sopts, _ = mustNotFail([]string{"-max_bytes", "100KB", "-mb", "100KB", "-file_compact_min_size", "200KB", "-file_buffer_size", "300KB", "-file_read_buffer_size", "1MB"})
 	if sopts.MaxBytes != 100*1024 {
 		t.Fatalf("Expected max_bytes to be 100KB, got %v", sopts.MaxBytes)
 	}
@@ -554,6 +558,9 @@ func TestParseConfigureOptions(t *testing.T) {
 	}
 	if sopts.FileStoreOpts.BufferSize != 300*1024 {
 		t.Fatalf("Expected file_buffer_size to be 300KB, got %v", sopts.FileStoreOpts.BufferSize)
+	}
+	if sopts.FileStoreOpts.ReadBufferSize != 1024*1024 {
+		t.Fatalf("Expected file_read_buffer_size to be 1MB, got %v", sopts.FileStoreOpts.ReadBufferSize)
 	}
 
 	// Failures with bytes

--- a/stores/common_test.go
+++ b/stores/common_test.go
@@ -375,6 +375,7 @@ func TestMain(m *testing.M) {
 	var encryptionKey string
 
 	flag.BoolVar(&testFSDisableBufferWriters, "fs_no_buffer", false, "Disable use of buffer writers")
+	flag.BoolVar(&testFSDisableReadBuffer, "fs_no_read_buffer", false, "Disable use of read buffer")
 	flag.BoolVar(&testFSSetFDsLimit, "fs_set_fds_limit", false, "Set some FDs limit")
 	flag.BoolVar(&doSQL, "sql", true, "Set this to false if you don't want SQL to be tested")
 	test.AddSQLFlags(flag.CommandLine, &testSQLDriver, &testSQLSource, &testSQLSourceAdmin, &testSQLDatabaseName)

--- a/stores/filestore_msg_test.go
+++ b/stores/filestore_msg_test.go
@@ -1841,3 +1841,190 @@ func TestFSNoPanicOnRemoveMsg(t *testing.T) {
 		t.Fatal("Did not get error about removing message")
 	}
 }
+
+func TestFSReadBuffer(t *testing.T) {
+	cleanupFSDatastore(t)
+	defer cleanupFSDatastore(t)
+
+	cacheTTL = int64(5 * time.Second)
+	defer func() { cacheTTL = testFSDefaultCacheTTL }()
+
+	limits := testDefaultStoreLimits
+	s, err := NewFileStore(testLogger, testFSDefaultDatastore, &limits, BufferSize(0), ReadBufferSize(0))
+	if err != nil {
+		t.Fatalf("Error creating store: %v", err)
+	}
+	defer s.Close()
+
+	c := storeCreateChannel(t, s, "foo")
+	for i := uint64(1); i <= 10; i++ {
+		storeMsg(t, c, "foo", i, []byte(fmt.Sprintf("%v", i)))
+	}
+	c.Msgs.Flush()
+
+	// Force empty of cache
+	ms := c.Msgs.(*FileMsgStore)
+	ms.Lock()
+	ms.cache.empty()
+	ms.Unlock()
+
+	// Lookup first message and check that it is in the cache.
+	m := msgStoreLookup(t, c.Msgs, 1)
+	if string(m.Data) != "1" {
+		t.Fatalf("Expected message's data to be %q, got %q", "1", m.Data)
+	}
+	// Ensure that other messages are not in the cache
+	for i := uint64(2); i <= 10; i++ {
+		ms.Lock()
+		m := ms.cache.get(i)
+		ms.Unlock()
+		if m != nil {
+			t.Fatalf("Expected msg seq %v to not be in the cache, got %v", i, m)
+		}
+	}
+
+	s.Close()
+	cleanupFSDatastore(t)
+
+	// Restart test but now with a read buffer...
+	s, err = NewFileStore(testLogger, testFSDefaultDatastore, &limits, BufferSize(0), ReadBufferSize(1024*1024))
+	if err != nil {
+		t.Fatalf("Error creating store: %v", err)
+	}
+	defer s.Close()
+
+	c = storeCreateChannel(t, s, "foo")
+	for i := uint64(1); i <= 10; i++ {
+		storeMsg(t, c, "foo", i, []byte(fmt.Sprintf("%v", i)))
+	}
+	c.Msgs.Flush()
+
+	// Force empty of cache
+	ms = c.Msgs.(*FileMsgStore)
+	ms.Lock()
+	ms.cache.empty()
+	ms.Unlock()
+
+	// Lookup first message
+	msgStoreLookup(t, c.Msgs, 1)
+	// All others should have been added to the cache
+	for i := uint64(1); i <= 10; i++ {
+		ms.Lock()
+		m := ms.cache.get(i)
+		ms.Unlock()
+		if m == nil {
+			t.Fatalf("Expected msg seq %v to be in cache, it was not", i)
+		}
+		if string(m.Data) != fmt.Sprintf("%v", i) {
+			t.Fatalf("Expected content to be %q, got %q", i, m.Data)
+		}
+	}
+}
+
+func TestFSReadMsgRecord(t *testing.T) {
+	cleanupFSDatastore(t)
+	defer cleanupFSDatastore(t)
+
+	s := createDefaultFileStore(t)
+	defer s.Close()
+
+	c := storeCreateChannel(t, s, "foo")
+	ms := c.Msgs.(*FileMsgStore)
+
+	r := &testReader{}
+
+	var err error
+
+	buf := make([]byte, recordHeaderSize+5)
+	var retBuf []byte
+
+	// Reader returns an error
+	errReturned := fmt.Errorf("Fake error")
+	r.setErrToReturn(errReturned)
+	retBuf, err = ms.readMsgRecord(r, buf, 1)
+	if !strings.Contains(err.Error(), errReturned.Error()) {
+		t.Fatalf("Expected error %v, got: %v", errReturned, err)
+	}
+	if !reflect.DeepEqual(retBuf, buf) {
+		t.Fatal("Expected returned buffer to be same as the one provided")
+	}
+
+	// Record not containing CRC
+	_header := [4]byte{}
+	header := _header[:]
+	util.ByteOrder.PutUint32(header, 0)
+	r.setErrToReturn(nil)
+	r.setContent(header)
+	retBuf, err = ms.readMsgRecord(r, buf, 1)
+	if err == nil {
+		t.Fatal("Expected error got none")
+	}
+	if !reflect.DeepEqual(retBuf, buf) {
+		t.Fatal("Expected returned buffer to be same as the one provided")
+	}
+
+	// Wrong CRC
+	b := make([]byte, recordHeaderSize+5)
+	util.ByteOrder.PutUint32(b, 5)
+	copy(b[recordHeaderSize:], []byte("hello"))
+	r.setErrToReturn(nil)
+	r.setContent(b)
+	retBuf, err = ms.readMsgRecord(r, buf, 5)
+	if err == nil {
+		t.Fatal("Expected error got none")
+	}
+	if !reflect.DeepEqual(retBuf, b) {
+		t.Fatal("Expected returned buffer to be same as the one provided")
+	}
+
+	// Not asking for CRC should return ok
+	r.setContent(b)
+	ms.fstore.opts.DoCRC = false
+	retBuf, err = ms.readMsgRecord(r, buf, 5)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(retBuf, buf) {
+		t.Fatal("Expected returned buffer to be same as the one provided")
+	}
+	if string(retBuf[recordHeaderSize:recordHeaderSize+5]) != "hello" {
+		t.Fatalf("Expected body to be \"hello\", got %q", string(retBuf[recordHeaderSize:recordHeaderSize+5]))
+	}
+
+	// Check that returned buffer has expanded as required
+	ms.fstore.opts.DoCRC = true
+	b = make([]byte, recordHeaderSize+10)
+	payload := []byte("hellohello")
+	util.ByteOrder.PutUint32(b, uint32(len(payload)))
+	util.ByteOrder.PutUint32(b[4:recordHeaderSize], crc32.ChecksumIEEE(payload))
+	copy(b[recordHeaderSize:], payload)
+	r.setErrToReturn(nil)
+	r.setContent(b)
+	retBuf, err = ms.readMsgRecord(r, buf, 10)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if reflect.DeepEqual(retBuf, buf) {
+		t.Fatal("Expected returned buffer to be different than the one provided")
+	}
+	if string(retBuf[recordHeaderSize:recordHeaderSize+10]) != string(payload) {
+		t.Fatalf("Expected body to be %q got %v", string(payload), string(retBuf[recordHeaderSize:recordHeaderSize+10]))
+	}
+
+	// Append zeros to the end of buffer
+	for i := 0; i < recordHeaderSize+2; i++ {
+		b = append(b, 0)
+	}
+	// Don't call setContent since this would reset the read position
+	r.content = b
+	if _, err := ms.readMsgRecord(r, buf, 2); err != errNeedRewind {
+		t.Fatalf("Expected error %v, got %v", errNeedRewind, err)
+	}
+
+	// Check that error returned if size does not match
+	b = b[:len(b)-2]
+	r.setContent(b)
+	if _, err := ms.readMsgRecord(r, buf, 8); err == nil || !strings.Contains(err.Error(), "expected size") {
+		t.Fatalf("Expected error about wrong size, got %v", err)
+	}
+}

--- a/test/configs/test_parse.conf
+++ b/test/configs/test_parse.conf
@@ -65,6 +65,7 @@ streaming: {
       slice_archive_script: "myArchiveScript"
       fds_limit: 8
       parallel_recovery: 9
+      read_buffer_size: 10
   }
 
   cluster: {


### PR DESCRIPTION
A new option `file_read_buffer_size` is added and defaults to 2MB.
If not set to 0, when a message is read from disk, the store will
actually read the following messages, up to that buffer size, and
add them to the internal cache (which already existed and has a
default TTL of 1sec).
This will speed up lookups of following messages since they are
likely to be in the cache.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>