### PR TITLE
[FIXED] Expire messages based on their timestamp

### DIFF
--- a/stores/common.go
+++ b/stores/common.go
@@ -15,6 +15,7 @@ package stores
 
 import (
 	"sync"
+	"time"
 
 	"github.com/nats-io/nats-streaming-server/logger"
 	"github.com/nats-io/nats-streaming-server/spb"
@@ -335,6 +336,17 @@ func (gms *genericMsgStore) empty() {
 // Close closes this store.
 func (gms *genericMsgStore) Close() error {
 	return nil
+}
+
+// With the given timestamp, returns in how long the message
+// should expire. If in the past, returns 0
+func (gms *genericMsgStore) msgExpireIn(timestamp int64) time.Duration {
+	now := time.Now().UnixNano()
+	fireIn := time.Duration(timestamp + int64(gms.limits.MaxAge) - now)
+	if fireIn < 0 {
+		fireIn = 0
+	}
+	return fireIn
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/stores/memstore.go
+++ b/stores/memstore.go
@@ -107,7 +107,7 @@ func (ms *MemoryMsgStore) Store(m *pb.MsgProto) (uint64, error) {
 	// If there is an age limit and no timer yet created, do so now
 	if ms.limits.MaxAge > time.Duration(0) && ms.ageTimer == nil {
 		ms.wg.Add(1)
-		ms.ageTimer = time.AfterFunc(ms.limits.MaxAge, ms.expireMsgs)
+		ms.ageTimer = time.AfterFunc(ms.msgExpireIn(m.Timestamp), ms.expireMsgs)
 	}
 
 	// Check if we need to remove any (but leave at least the last added)


### PR DESCRIPTION
This comes into play with clustering when messages are replayed
and their timestamp may now be well in the past.

Resolves #915

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>