### PR TITLE
[FIXED] New messages skipped on processing ack

### DIFF
--- a/server/clustering_test.go
+++ b/server/clustering_test.go
@@ -6627,11 +6627,12 @@ type blockingLookupStore struct {
 }
 
 func (b *blockingLookupStore) Lookup(seq uint64) (*pb.MsgProto, error) {
+	msg, err := b.MsgStore.Lookup(seq)
 	if !b.skip {
 		b.inLookupCh <- struct{}{}
 		b.skip = <-b.releaseCh
 	}
-	return b.MsgStore.Lookup(seq)
+	return msg, err
 }
 
 func TestClusteringRestoreSnapshotErrorDontSkipSeq(t *testing.T) {


### PR DESCRIPTION
There is a possible race between trying to send new messages and
the storing of new messages that could cause the server to skip
some messages.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>