### PR TITLE
[FIXED] FileStore: handle possible sequence gap in index files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,11 @@ before_script:
 - $(exit $(misspell -locale US README.md | wc -l))
 - staticcheck $EXCLUDE_VENDOR_AND_PROTO_DIR
 script:
+- set -e
 - mysql -u root -e "CREATE USER 'nss'@'localhost' IDENTIFIED BY 'password'; GRANT ALL PRIVILEGES ON *.* TO 'nss'@'localhost'; CREATE DATABASE test_nats_streaming;"
 - go test -i $EXCLUDE_VENDOR
 - if [[ "$TRAVIS_GO_VERSION" =~ 1.12 ]]; then ./scripts/cov.sh TRAVIS; else go test -failfast $EXCLUDE_VENDOR; fi
+- set +e
 
 deploy:
   provider: script

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -432,6 +432,10 @@ func getTestDefaultOptsForPersistentStore() *Options {
 	case stores.TypeFile:
 		opts.FilestoreDir = defaultDataStore
 		opts.FileStoreOpts.BufferSize = 1024
+		// Go 1.12 on macOS is very slow at doing sync writes...
+		if runtime.GOOS == "darwin" && strings.HasPrefix(runtime.Version(), "go1.12") {
+			opts.FileStoreOpts.DoSync = false
+		}
 	case stores.TypeSQL:
 		opts.SQLStoreOpts.Driver = testSQLDriver
 		opts.SQLStoreOpts.Source = testSQLSource


### PR DESCRIPTION
Differentiate error reading from the index file as opposed to
not find a given sequence. Gaps should not exist but if that happens
it would prevent messages from being expired or next messages to
be delivered.

Resolves #928

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>