### PR TITLE
[FIXED] Duplicate shadow durable queue sub due to race

### DIFF
--- a/server/server_storefailures_test.go
+++ b/server/server_storefailures_test.go
@@ -41,6 +41,7 @@ type mockedSubStore struct {
 	sync.RWMutex
 	fail          bool
 	failFlushOnce bool
+	ch            chan bool
 }
 
 func (ms *mockedStore) CreateChannel(name string) (*stores.Channel, error) {
@@ -253,7 +254,12 @@ func TestMsgLookupFailures(t *testing.T) {
 func (ss *mockedSubStore) CreateSub(sub *spb.SubState) error {
 	ss.RLock()
 	fail := ss.fail
+	ch := ss.ch
 	ss.RUnlock()
+	if ch != nil {
+		// Wait for notification that we can continue
+		<-ch
+	}
 	if fail {
 		return fmt.Errorf("On purpose")
 	}

--- a/server/snapshot.go
+++ b/server/snapshot.go
@@ -429,8 +429,8 @@ func (r *raftFSM) restoreChannelsFromSnapshot(serverSnap *spb.RaftSnapshot, inNe
 		c.lSeqChecked = false
 
 		for _, ss := range sc.Subscriptions {
-			s.recoverOneSub(c, ss.State, nil, ss.AcksPending)
 			c.ss.Lock()
+			s.recoverOneSub(c, ss.State, nil, ss.AcksPending)
 			if ss.State.ID >= c.nextSubID {
 				c.nextSubID = ss.State.ID + 1
 			}


### PR DESCRIPTION
A race between a durable queue subscriber close and create could
cause the server to store multiple shadow subscriptions.

Resolves #950

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>