### PR TITLE
[FIXED] The pod of nats-streaming will change status to “Completed” after k8s node reboot #954

### DIFF
--- a/server/signal.go
+++ b/server/signal.go
@@ -39,9 +39,12 @@ func (s *StanServer) handleSignals() {
 			// registered, so we don't need a "default" in the
 			// switch statement.
 			switch sig {
-			case syscall.SIGINT, syscall.SIGTERM:
+			case syscall.SIGINT:
 				s.Shutdown()
 				os.Exit(0)
+			case syscall.SIGTERM:
+				s.Shutdown()
+				os.Exit(2)
 			case syscall.SIGUSR1:
 				// File log re-open for rotating file logs.
 				s.log.ReopenLogFile()


### PR DESCRIPTION
  The reason of this error is when the nats streaming pod received a SIGTERM, the container of nats streaming server will exit with code 0. When container exit with code 0, K8s consider the container is noraml exit, so it will change the pods status to “Completed” and will not restart the container. If the container exit with code none zore, K8s will change the pods status to “Error” and restart the container.
  This pr change the exit code from 0 to 2 when nats streaming server received a SIGTERM. This can avoid the error of issue #945.

Resolves #954