### PR TITLE
[FIXED] RAFT Transport timeouts

### DIFF
--- a/server/clustering.go
+++ b/server/clustering.go
@@ -34,7 +34,7 @@ const (
 	defaultRaftElectionTimeout  = 2 * time.Second
 	defaultRaftLeaseTimeout     = time.Second
 	defaultRaftCommitTimeout    = 100 * time.Millisecond
-	defaultTPortTimeout         = 2 * time.Second
+	defaultTPortTimeout         = 10 * time.Second
 )
 
 var (

--- a/server/timeout_reader.go
+++ b/server/timeout_reader.go
@@ -21,7 +21,7 @@ import (
 	"time"
 )
 
-const bufferSize = 4096
+const bufferSize = 32768
 
 // ErrTimeout reports a read timeout error
 var ErrTimeout = errors.New("natslog: read timeout")


### PR DESCRIPTION
Keep a 2sec for the dial and flush, but increase the timeout for
read operations. This will reduce the risk of getting these
type of errors:

```
[ERR] STREAM: raft-net: Failed to flush response: write to closed conn
```

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>