### PR TITLE
[IMPROVED] Use NoFreelistSync for RAFT's bbolt store

### DIFF
--- a/server/raft_log.go
+++ b/server/raft_log.go
@@ -64,9 +64,7 @@ func newRaftLog(log logger.Logger, fileName string, sync bool, _ int, encrypt bo
 		return nil, err
 	}
 	db.NoSync = !sync
-	// Don't use this for now.
-	// See https://github.com/etcd-io/bbolt/issues/152
-	// db.NoFreelistSync = true
+	db.NoFreelistSync = true
 	db.FreelistType = bolt.FreelistMapType
 	r.conn = db
 	if err := r.init(); err != nil {


### PR DESCRIPTION
This option had been disabled due to a defect in bbolt implementation.
Since it has been fixed, re-enable it.

Was commented out in https://github.com/nats-io/nats-streaming-server/pull/766

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>