### PR TITLE
Fixed SQL test

### DIFF
--- a/stores/sqlstore_test.go
+++ b/stores/sqlstore_test.go
@@ -1211,7 +1211,7 @@ func TestSQLSubStoreCachingAndRecovery(t *testing.T) {
 	acks := make(map[uint64]struct{})
 	acks[2] = struct{}{}
 	ackBytes, _ := sqlEncodeSeqs(acks, func(_ uint64) {})
-	stmt := "INSERT INTO SubsPending (subid, row, lastsent, pending, acks) VALUES (?, ?, ?, ?, ?)"
+	stmt := "INSERT INTO SubsPending (subid, `row`, lastsent, pending, acks) VALUES (?, ?, ?, ?, ?)"
 	if testSQLDriver == driverPostgres {
 		stmt = "INSERT INTO SubsPending (subid, row, lastsent, pending, acks) VALUES ($1, $2, $3, $4, $5)"
 	}


### PR DESCRIPTION
In https://github.com/nats-io/nats-streaming-server/pull/538 we
escaped `row` in the SQL code, but then this test does not have
it escaped. I recently updated my local MySQL server and got the
test failure.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>