### PR TITLE
[FIXED] Stop subscription redelivery timer and signal handler on shutdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 sudo: false
 go:
-- 1.11.x
 - 1.12.x
+- 1.13.x
 addons:
   apt:
     packages:
@@ -30,14 +30,14 @@ script:
 - set -e
 - mysql -u root -e "CREATE USER 'nss'@'localhost' IDENTIFIED BY 'password'; GRANT ALL PRIVILEGES ON *.* TO 'nss'@'localhost'; CREATE DATABASE test_nats_streaming;"
 - go test -i ./...
-- if [[ "$TRAVIS_GO_VERSION" =~ 1.12 ]]; then ./scripts/cov.sh TRAVIS; else go test -failfast ./...; fi
+- if [[ "$TRAVIS_GO_VERSION" =~ 1.13 ]]; then ./scripts/cov.sh TRAVIS; else go test -v -failfast -p=1 ./...; fi
 - set +e
 
 deploy:
   provider: script
-  skip_cleanup: true
+  skip_cleanup: false
   script: curl -sL http://git.io/goreleaser | bash
   verbose: true
   on:
     tags: true
-    condition: $TRAVIS_GO_VERSION =~ 1.11
+    condition: $TRAVIS_GO_VERSION =~ 1.12

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -1212,7 +1212,7 @@ func TestMonitorClusterRole(t *testing.T) {
 				t.Fatalf("Got an error unmarshalling the body: %v", err)
 			}
 			if sz.Role != test.expectedRole {
-				t.Fatalf("Expected role to be %v, gt %v", test.expectedRole, sz.Role)
+				t.Fatalf("Expected role to be %v, got %v", test.expectedRole, sz.Role)
 			}
 		})
 	}

--- a/server/server_queue_test.go
+++ b/server/server_queue_test.go
@@ -757,7 +757,10 @@ type queueGroupStalledMsgStore struct {
 }
 
 func (s *queueGroupStalledMsgStore) Lookup(seq uint64) (*pb.MsgProto, error) {
-	s.lookupCh <- struct{}{}
+	select {
+	case s.lookupCh <- struct{}{}:
+	default:
+	}
 	return s.MsgStore.Lookup(seq)
 }
 

--- a/server/server_redelivery_test.go
+++ b/server/server_redelivery_test.go
@@ -622,6 +622,7 @@ func TestPersistentStoreRedeliveryCbPerSub(t *testing.T) {
 			if len(sub.acksPending) == 1 {
 				good++
 			}
+			sub.Unlock()
 		}
 		return "pending message per sub", good
 	})

--- a/server/server_run_test.go
+++ b/server/server_run_test.go
@@ -1019,6 +1019,7 @@ func TestGhostDurableSubs(t *testing.T) {
 	waitForNumClients(t, s, 0)
 
 	// Change store to simulate no flush on simulated crash
+	orgStore := s.store
 	s.store = &storeNoClose{Store: s.store}
 	s.Shutdown()
 
@@ -1027,6 +1028,7 @@ func TestGhostDurableSubs(t *testing.T) {
 	check(false)
 
 	sc.Close()
+	orgStore.Close()
 }
 
 func TestGetNATSOptions(t *testing.T) {

--- a/server/server_storefailures_test.go
+++ b/server/server_storefailures_test.go
@@ -345,6 +345,9 @@ func TestDeleteSubFailures(t *testing.T) {
 	if err := sc.Publish("foo", []byte("hello")); err != nil {
 		t.Fatalf("Error on publish: %v", err)
 	}
+	if err := Wait(ch); err != nil {
+		t.Fatal("Did not get our message")
+	}
 	// Create 2 more durable queue subs
 	dqsub2, err := sc.QueueSubscribe("foo", "dqueue", func(_ *stan.Msg) {},
 		stan.DurableName("dur"))

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1124,10 +1124,12 @@ func TestDontSendEmptyMsgProto(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error on connect: %v", err)
 	}
+	defer nc.Close()
 	sc, err := stan.Connect(clusterName, clientName, stan.NatsConn(nc))
 	if err != nil {
 		t.Fatalf("Error on connect: %v", err)
 	}
+	defer sc.Close()
 	// Since server is expected to crash, do not attempt to close sc
 	// because it would delay test by 2 seconds.
 
@@ -1148,8 +1150,8 @@ func TestDontSendEmptyMsgProto(t *testing.T) {
 
 	m := &pb.MsgProto{}
 	sub.Lock()
+	defer sub.Unlock()
 	s.sendMsgToSub(sub, m, false)
-	sub.Unlock()
 }
 
 func TestMsgsNotSentToSubBeforeSubReqResponse(t *testing.T) {


### PR DESCRIPTION
This is for users embedding the NATS Streaming Server or for tests
where a server is shutdown but process continues running for a while.

Cleaned-up some tests.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>