### PR TITLE
[FIXED] FileStore: Empty() should remove all message files (dat/idx)

### DIFF
--- a/stores/filestore_msg_test.go
+++ b/stores/filestore_msg_test.go
@@ -1745,6 +1745,40 @@ func TestFSRecoverEmptyIndexMsgFile(t *testing.T) {
 	}
 }
 
+func TestFSEmptyRemovesAllMsgsFiles(t *testing.T) {
+	cleanupFSDatastore(t)
+	defer cleanupFSDatastore(t)
+
+	s := createDefaultFileStore(t)
+	defer s.Close()
+
+	c := storeCreateChannel(t, s, "foo")
+	ms := c.Msgs
+	storeMsg(t, c, "foo", 1, []byte("msg"))
+	ms.(*FileMsgStore).RLock()
+	datname := ms.(*FileMsgStore).writeSlice.file.name
+	idxname := ms.(*FileMsgStore).writeSlice.idxFile.name
+	ms.(*FileMsgStore).RUnlock()
+	s.Close()
+
+	os.Remove(datname)
+
+	s, rs := openDefaultFileStore(t)
+	defer s.Close()
+
+	c = getRecoveredChannel(t, rs, "foo")
+	if n, b := msgStoreState(t, c.Msgs); n != 0 || b != 0 {
+		t.Fatalf("Unexpected state: %v - %v", n, b)
+	}
+	if err := c.Msgs.Empty(); err != nil {
+		t.Fatalf("Error on empty: %v", err)
+	}
+	// Make sure we have remove the index file too.
+	if fi, err := os.Stat(idxname); err == nil || fi != nil {
+		t.Fatalf("Expected index file to be gone, it was not")
+	}
+}
+
 func TestFSGetSeqFromTimestamp(t *testing.T) {
 	cleanupFSDatastore(t)
 	defer cleanupFSDatastore(t)


### PR DESCRIPTION
Doing some manual tests with removing the single .dat file for
a channel, I realized that in cluster mode, when the channel message
store was being emptied, the .idx file was not removed, which then
caused a problem since the info was added to the index file while
it should have been replaced.
Ensure that all files matching the messages files pattern are removed
during an Empty() call.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>