### PR TITLE
[ADDED] Ability to set logfile size limit

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -36,6 +36,7 @@ type StanLogger struct {
 	trace bool
 	ltime bool
 	lfile string
+	fszl  int64
 	log   natsd.Logger
 }
 
@@ -52,6 +53,13 @@ func (s *StanLogger) SetLogger(log Logger, logtime, debug, trace bool, logfile s
 	s.debug = debug
 	s.trace = trace
 	s.lfile = logfile
+	s.mu.Unlock()
+}
+
+// SetFileSizeLimit sets the size limit for a logfile
+func (s *StanLogger) SetFileSizeLimit(limit int64) {
+	s.mu.Lock()
+	s.fszl = limit
 	s.mu.Unlock()
 }
 
@@ -80,6 +88,9 @@ func (s *StanLogger) ReopenLogFile() {
 		}
 	}
 	fileLog := natsdLogger.NewFileLogger(s.lfile, s.ltime, s.debug, s.trace, true)
+	if s.fszl > 0 {
+		fileLog.SetSizeLimit(s.fszl)
+	}
 	s.log = fileLog
 	s.mu.Unlock()
 	s.Noticef("File log re-opened")

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -176,10 +177,15 @@ func TestLogger(t *testing.T) {
 	checkLogger("Unable to close logger: dummy error")
 
 	// Switch to file log
-	fname := "test.log"
-	defer os.Remove(fname)
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Unable to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	fname := filepath.Join(tmpDir, "test.log")
 	fl := natsdLogger.NewFileLogger(fname, true, true, true, true)
 	logger.SetLogger(fl, true, true, true, fname)
+	logger.SetFileSizeLimit(1000)
 	// Reopen and check file content
 	logger.ReopenLogFile()
 	buf, err := ioutil.ReadFile(fname)
@@ -189,6 +195,18 @@ func TestLogger(t *testing.T) {
 	expectedStr := "File log re-opened"
 	if !strings.Contains(string(buf), expectedStr) {
 		t.Fatalf("Expected log to contain %q, got %q", expectedStr, string(buf))
+	}
+	// Make sure that the file size limit was applied to the new file
+	notice := "This is some notice..."
+	for i := 0; i < 100; i++ {
+		logger.Noticef(notice)
+	}
+	files, err := ioutil.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("Unable to read temp dir: %v", err)
+	}
+	if len(files) == 1 {
+		t.Fatalf("Size limit was not applied")
 	}
 	logger.Close()
 	if err := os.Remove(fname); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -1838,6 +1838,11 @@ func (s *StanServer) configureLogger() {
 
 	if nOpts.LogFile != "" {
 		newLogger = natsdLogger.NewFileLogger(nOpts.LogFile, nOpts.Logtime, enableDebug, enableTrace, true)
+		if nOpts.LogSizeLimit > 0 {
+			if l, ok := newLogger.(*natsdLogger.Logger); ok {
+				l.SetSizeLimit(nOpts.LogSizeLimit)
+			}
+		}
 	} else if nOpts.RemoteSyslog != "" {
 		newLogger = natsdLogger.NewRemoteSysLogger(nOpts.RemoteSyslog, enableDebug, enableTrace)
 	} else if syslog {


### PR DESCRIPTION
Needed to pull NATS Server 2.1.4, and call the new SetSizeLimit() API

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>