### PR TITLE
[ADDED] Monitoring endpoint '/isFTActive' to evaluate whether the server is in FTActive mode

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -31,11 +31,12 @@ import (
 
 // Routes for the monitoring pages
 const (
-	RootPath     = "/streaming"
-	ServerPath   = RootPath + "/serverz"
-	StorePath    = RootPath + "/storez"
-	ClientsPath  = RootPath + "/clientsz"
-	ChannelsPath = RootPath + "/channelsz"
+	RootPath       = "/streaming"
+	ServerPath     = RootPath + "/serverz"
+	StorePath      = RootPath + "/storez"
+	ClientsPath    = RootPath + "/clientsz"
+	ChannelsPath   = RootPath + "/channelsz"
+	IsFTActivePath = RootPath + "/isFTActive"
 
 	defaultMonitorListLimit = 1024
 )
@@ -160,6 +161,7 @@ func (s *StanServer) startMonitoring(nOpts *natsd.Options) error {
 	mux.HandleFunc(StorePath, s.handleStorez)
 	mux.HandleFunc(ClientsPath, s.handleClientsz)
 	mux.HandleFunc(ChannelsPath, s.handleChannelsz)
+	mux.HandleFunc(IsFTActivePath, s.handleIsFTActivez)
 
 	return nil
 }
@@ -243,6 +245,17 @@ func (s *StanServer) handleServerz(w http.ResponseWriter, r *http.Request) {
 		MaxFDs:        maxFDs,
 	}
 	s.sendResponse(w, r, serverz)
+}
+
+func (s *StanServer) handleIsFTActivez(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	state := s.state
+	s.mu.RUnlock()
+	if state == FTActive {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusNoContent)
+	}
 }
 
 func myUptime(d time.Duration) string {


### PR DESCRIPTION
My use case for this feature is related to a kubernetes based deployment. We run nats in FT mode, which means that the monitor endpoints return useful information, or no information, depending on which node you make requests against. This feature will enable me to place some kind of reverse proxy in front of the nats nodes to proxy http requests on the monitor port to only the active node. 

With this PR in its current state, the only proxy i've found that i can configure to use appropriately is envoy. it seems most of the common reverse proxy solutions in use on k8s have varying levels of opinionatedness about how to configure health checks, and what constitutes "healthy". For instance, traefik considers any health check that returns a 2XX or 3XX to be healthy, and there's no way to alter that configuration. NGINX Plus supports active health checks that allow you to specify a path to a health check endpoint. The free NGINX offering only supports passive health checks, which evaluate traffic as a whole and removes upstream nodes from load balancing if a node begins throwing 5XX status codes. Envoy seems to be only proxy that allows you to fully configure a health check that fits inline with the expected status codes added by this feature.