### PR TITLE
[FIXED] Windows Service: do not force usage of syslog

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -115,7 +115,7 @@ Embedded NATS Server Options:
 Logging Options:
     -l, --log <string>               File to redirect log output
     -T, --logtime=<bool>             Timestamp log entries (default: true)
-    -s, --syslog <string>            Enable syslog as log method
+    -s, --syslog <bool>              Enable syslog as log method
     -r, --remote_syslog <string>     Syslog server addr (udp://localhost:514)
     -D, --debug=<bool>               Enable debugging output
     -V, --trace=<bool>               Trace the raw protocol

--- a/server/service_windows.go
+++ b/server/service_windows.go
@@ -131,7 +131,7 @@ func Run(sOpts *Options, nOpts *natsd.Options) (*StanServer, error) {
 	}
 	if isInteractive {
 		run = debug.Run
-	} else {
+	} else if nOpts.Syslog || nOpts.LogFile == "" {
 		sysLogInitLock.Lock()
 		// We create a syslog here because we want to capture possible startup
 		// failure message.


### PR DESCRIPTION
When starting as a Windows Service, we were creating a syslog to
possibly log the failure to start. But users running without
admin privileges would be unable to use the service since the
server would fail to create the event log entry.
So create the syslog only if explicit set (-syslog <bool> option)
or if no logfile has been specified.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>