### PR TITLE
[ADDED] Reload signal now accepted for the embedded NATS Server

### DIFF
--- a/nats-streaming-server.go
+++ b/nats-streaming-server.go
@@ -48,7 +48,7 @@ Streaming Server Options:
     -hbt, --hb_timeout <duration>        How long server waits for a heartbeat response
     -hbf, --hb_fail_count <int>          Number of failed heartbeats before server closes the client connection
           --ft_group <string>            Name of the FT Group. A group can be 2 or more servers with a single active server and all sharing the same datastore
-    -sl,  --signal <signal>[=<pid>]      Send signal to nats-streaming-server process (stop, quit, reopen)
+    -sl,  --signal <signal>[=<pid>]      Send signal to nats-streaming-server process (stop, quit, reopen, reload - only for embedded NATS Server)
           --encrypt <bool>               Specify if server should use encryption at rest
           --encryption_cipher <string>   Cipher to use for encryption. Currently support AES and CHAHA (ChaChaPoly). Defaults to AES
           --encryption_key <string>      Encryption Key. It is recommended to specify it through the NATS_STREAMING_ENCRYPTION_KEY environment variable instead

--- a/server/signal.go
+++ b/server/signal.go
@@ -51,7 +51,16 @@ func (s *StanServer) handleSignals() {
 					// File log re-open for rotating file logs.
 					s.log.ReopenLogFile()
 				case syscall.SIGHUP:
-					// Ignore for now
+					s.mu.Lock()
+					ns := s.natsServer
+					s.mu.Unlock()
+					if ns != nil {
+						if err := ns.Reload(); err != nil {
+							s.log.Errorf("Reload: %v", err)
+						}
+					} else {
+						s.log.Warnf("Reload supported only for embedded NATS Server's configuration")
+					}
 				}
 			case <-s.shutdownCh:
 				return


### PR DESCRIPTION
Previously, the reload signal was ignored. It will now be passed
on to the embedded NATS Server. If the streaming server remotely
connects to a NATS Server and a reload signal is received, the
streaming server will print a warning indicating that it works
only for NATS Server configuration and only if it is embedded.

Resolves #1030

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>