### PR TITLE
Change tests "localhost" to "127.0.0.1"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ os:
 - linux
 - windows
 language: go
-sudo: false
 go:
 - 1.12.x
 - 1.13.x
@@ -47,9 +46,8 @@ script:
 
 deploy:
   provider: script
-  skip_cleanup: false
+  cleanup: true
   script: curl -sL http://git.io/goreleaser | bash
-  verbose: true
   on:
     tags: true
     condition: ("$TRAVIS_OS_NAME" = "linux") && ("$TRAVIS_GO_VERSION" =~ "1.13")

--- a/server/ft_test.go
+++ b/server/ft_test.go
@@ -160,7 +160,7 @@ func TestFTBasic(t *testing.T) {
 
 	// Configure first server
 	s1sOpts := getTestFTDefaultOptions()
-	s1sOpts.NATSServerURL = "nats://localhost:4222"
+	s1sOpts.NATSServerURL = "nats://127.0.0.1:4222"
 	s1, err := RunServerWithOpts(s1sOpts, nil)
 	if err != nil {
 		t.Fatalf("Error starting server: %v", err)
@@ -170,7 +170,7 @@ func TestFTBasic(t *testing.T) {
 
 	// Configure second server
 	s2sOpts := getTestFTDefaultOptions()
-	s2sOpts.NATSServerURL = "nats://localhost:4222"
+	s2sOpts.NATSServerURL = "nats://127.0.0.1:4222"
 	s2, err := RunServerWithOpts(s2sOpts, nil)
 	if err != nil {
 		t.Fatalf("Error starting server: %v", err)
@@ -302,9 +302,9 @@ func TestFTPartition(t *testing.T) {
 		cleanupFTDatastore(t)
 		defer cleanupFTDatastore(t)
 
-		nOpts.Cluster.ListenStr = "nats://localhost:6222"
-		nOpts.RoutesStr = "nats://localhost:6223"
-		natsURL = "nats://localhost:4222"
+		nOpts.Cluster.ListenStr = "nats://127.0.0.1:6222"
+		nOpts.RoutesStr = "nats://127.0.0.1:6223"
+		natsURL = "nats://127.0.0.1:4222"
 
 		// Use a separate NATS server for communication between
 		// processes for the test
@@ -314,13 +314,13 @@ func TestFTPartition(t *testing.T) {
 		defer ipcNATS.Shutdown()
 	} else {
 		nOpts.Port = 4223
-		nOpts.Cluster.ListenStr = "nats://localhost:6223"
-		nOpts.RoutesStr = "nats://localhost:6222"
-		natsURL = "nats://localhost:4223"
+		nOpts.Cluster.ListenStr = "nats://127.0.0.1:6223"
+		nOpts.RoutesStr = "nats://127.0.0.1:6222"
+		natsURL = "nats://127.0.0.1:4223"
 	}
 	// Create NATS client just for synchronization between the
 	// two processes.
-	syncNC, err := nats.Connect("nats://localhost:5222")
+	syncNC, err := nats.Connect("nats://127.0.0.1:5222")
 	if err != nil {
 		t.Fatalf("Error on connect: %v", err)
 	}
@@ -432,9 +432,9 @@ func TestFTPartitionReversed(t *testing.T) {
 		cleanupFTDatastore(t)
 		defer cleanupFTDatastore(t)
 
-		nOpts.Cluster.ListenStr = "nats://localhost:6222"
-		nOpts.RoutesStr = "nats://localhost:6223"
-		natsURL = "nats://localhost:4222"
+		nOpts.Cluster.ListenStr = "nats://127.0.0.1:6222"
+		nOpts.RoutesStr = "nats://127.0.0.1:6223"
+		natsURL = "nats://127.0.0.1:4222"
 
 		// Use a separate NATS server for communication between
 		// processes for the test
@@ -444,13 +444,13 @@ func TestFTPartitionReversed(t *testing.T) {
 		defer ipcNATS.Shutdown()
 	} else {
 		nOpts.Port = 4223
-		nOpts.Cluster.ListenStr = "nats://localhost:6223"
-		nOpts.RoutesStr = "nats://localhost:6222"
-		natsURL = "nats://localhost:4223"
+		nOpts.Cluster.ListenStr = "nats://127.0.0.1:6223"
+		nOpts.RoutesStr = "nats://127.0.0.1:6222"
+		natsURL = "nats://127.0.0.1:4223"
 	}
 	// Create NATS client just for synchronization between the
 	// two processes.
-	syncNC, err := nats.Connect("nats://localhost:5222")
+	syncNC, err := nats.Connect("nats://127.0.0.1:5222")
 	if err != nil {
 		t.Fatalf("Error on connect: %v", err)
 	}
@@ -685,7 +685,7 @@ func TestFTSteppingDown(t *testing.T) {
 
 	// Start first server
 	opts1 := getTestFTDefaultOptions()
-	opts1.NATSServerURL = "nats://localhost:4222"
+	opts1.NATSServerURL = "nats://127.0.0.1:4222"
 	s1 := runServerWithOpts(t, opts1, nil)
 	defer s1.Shutdown()
 	ftReleasePause()
@@ -694,7 +694,7 @@ func TestFTSteppingDown(t *testing.T) {
 
 	// Start 2nd server, give it a mock store that says it can get the lock
 	opts2 := getTestFTDefaultOptions()
-	opts2.NATSServerURL = "nats://localhost:4222"
+	opts2.NATSServerURL = "nats://127.0.0.1:4222"
 	s2 := runServerWithOpts(t, opts2, nil)
 	defer s2.Shutdown()
 	replaceWithMockedStore(s2, true, nil)
@@ -730,7 +730,7 @@ func TestFTActiveSendsHB(t *testing.T) {
 
 	// Start Streaming server
 	opts := getTestFTDefaultOptions()
-	opts.NATSServerURL = "nats://localhost:4222"
+	opts.NATSServerURL = "nats://127.0.0.1:4222"
 	s := runServerWithOpts(t, opts, nil)
 	defer s.Shutdown()
 	// Wait for it to be active
@@ -803,7 +803,7 @@ func TestFTActiveReceivesInvalidHBMessages(t *testing.T) {
 
 	// Start Streaming server
 	opts := getTestFTDefaultOptions()
-	opts.NATSServerURL = "nats://localhost:4222"
+	opts.NATSServerURL = "nats://127.0.0.1:4222"
 	s := runServerWithOpts(t, opts, nil)
 	defer s.Shutdown()
 	// Wait for it to be active

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -126,7 +126,7 @@ func TestMonitorStartOwnHTTPServer(t *testing.T) {
 	nOpts.HTTPHost = monitorHost
 	nOpts.HTTPPort = monitorPort
 	sOpts := GetDefaultOptions()
-	sOpts.NATSServerURL = "nats://localhost:4222"
+	sOpts.NATSServerURL = "nats://127.0.0.1:4222"
 	s := runServerWithOpts(t, sOpts, &nOpts)
 	defer s.Shutdown()
 
@@ -149,7 +149,7 @@ func TestMonitorStartOwnHTTPSServer(t *testing.T) {
 	}
 	nOpts.TLSConfig.Certificates = []tls.Certificate{cert}
 	sOpts := GetDefaultOptions()
-	sOpts.NATSServerURL = "nats://localhost:4222"
+	sOpts.NATSServerURL = "nats://127.0.0.1:4222"
 	s := runServerWithOpts(t, sOpts, &nOpts)
 	defer s.Shutdown()
 

--- a/server/partitions_test.go
+++ b/server/partitions_test.go
@@ -159,7 +159,7 @@ func TestPartitionsMaxPayload(t *testing.T) {
 	defer ns.Shutdown()
 
 	opts1 := GetDefaultOptions()
-	opts1.NATSServerURL = "nats://localhost:4222"
+	opts1.NATSServerURL = "nats://127.0.0.1:4222"
 	opts1.Partitioning = true
 	opts1.StoreLimits.AddPerChannel("foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo", &stores.ChannelLimits{})
 	failSrv, err := RunServerWithOpts(opts1, nil)
@@ -179,7 +179,7 @@ func TestPartitionsMaxPayload(t *testing.T) {
 	defer ns.Shutdown()
 
 	opts1 = GetDefaultOptions()
-	opts1.NATSServerURL = "nats://localhost:4222"
+	opts1.NATSServerURL = "nats://127.0.0.1:4222"
 	opts1.Partitioning = true
 	opts1.StoreLimits.AddPerChannel("foo", &stores.ChannelLimits{})
 	s1 := runServerWithOpts(t, opts1, nil)
@@ -216,7 +216,7 @@ func TestPartitionsMaxPayload(t *testing.T) {
 	}
 
 	opts2 := GetDefaultOptions()
-	opts2.NATSServerURL = "nats://localhost:4222"
+	opts2.NATSServerURL = "nats://127.0.0.1:4222"
 	opts2.Partitioning = true
 	for i := 0; i < total-1; i++ {
 		channelName := fmt.Sprintf("channel.number.%d", (i + 1))
@@ -301,14 +301,14 @@ func TestPartitionsWithClusterOfServers(t *testing.T) {
 	barSubj := "bar"
 
 	opts1 := GetDefaultOptions()
-	opts1.NATSServerURL = "nats://localhost:4222"
+	opts1.NATSServerURL = "nats://127.0.0.1:4222"
 	opts1.Partitioning = true
 	opts1.StoreLimits.AddPerChannel(fooSubj, &stores.ChannelLimits{})
 	s1 := runServerWithOpts(t, opts1, nil)
 	defer s1.Shutdown()
 
 	opts2 := GetDefaultOptions()
-	opts2.NATSServerURL = "nats://localhost:4222"
+	opts2.NATSServerURL = "nats://127.0.0.1:4222"
 	opts2.Partitioning = true
 	opts2.StoreLimits.AddPerChannel(barSubj, &stores.ChannelLimits{})
 	s2 := runServerWithOpts(t, opts2, nil)
@@ -385,7 +385,7 @@ func TestPartitionsDuplicatedOnTwoServers(t *testing.T) {
 	barSubj := "bar"
 
 	opts1 := GetDefaultOptions()
-	opts1.NATSServerURL = "nats://localhost:4222"
+	opts1.NATSServerURL = "nats://127.0.0.1:4222"
 	opts1.Partitioning = true
 	opts1.StoreLimits.AddPerChannel(fooSubj, &stores.ChannelLimits{})
 	opts1.StoreLimits.AddPerChannel(barSubj, &stores.ChannelLimits{})
@@ -393,7 +393,7 @@ func TestPartitionsDuplicatedOnTwoServers(t *testing.T) {
 	defer s1.Shutdown()
 
 	opts2 := GetDefaultOptions()
-	opts2.NATSServerURL = "nats://localhost:4222"
+	opts2.NATSServerURL = "nats://127.0.0.1:4222"
 	opts2.Partitioning = true
 	opts2.StoreLimits.AddPerChannel(barSubj, &stores.ChannelLimits{})
 	// Expecting this to fail
@@ -417,7 +417,7 @@ func TestPartitionsConflictDueToWildcards(t *testing.T) {
 	defer s1.Shutdown()
 
 	opts2 := GetDefaultOptions()
-	opts2.NATSServerURL = "nats://localhost:4222"
+	opts2.NATSServerURL = "nats://127.0.0.1:4222"
 	opts2.Partitioning = true
 	opts2.StoreLimits.AddPerChannel("foo.bar", &stores.ChannelLimits{})
 	// Expecting this to fail
@@ -932,7 +932,7 @@ func TestPartitionsAndFT(t *testing.T) {
 	opts := getTestFTDefaultOptions()
 	opts.Partitioning = true
 	opts.AddPerChannel("foo", &stores.ChannelLimits{})
-	opts.NATSServerURL = "nats://localhost:4222"
+	opts.NATSServerURL = "nats://127.0.0.1:4222"
 
 	ft1 := runServerWithOpts(t, opts, nil)
 	defer ft1.Shutdown()
@@ -969,14 +969,14 @@ func TestPartitionsClientPings(t *testing.T) {
 	barSubj := "bar"
 
 	opts1 := GetDefaultOptions()
-	opts1.NATSServerURL = "nats://localhost:4222"
+	opts1.NATSServerURL = "nats://127.0.0.1:4222"
 	opts1.Partitioning = true
 	opts1.StoreLimits.AddPerChannel(fooSubj, &stores.ChannelLimits{})
 	s1 := runServerWithOpts(t, opts1, nil)
 	defer s1.Shutdown()
 
 	opts2 := GetDefaultOptions()
-	opts2.NATSServerURL = "nats://localhost:4222"
+	opts2.NATSServerURL = "nats://127.0.0.1:4222"
 	opts2.Partitioning = true
 	opts2.StoreLimits.AddPerChannel(barSubj, &stores.ChannelLimits{})
 	s2 := runServerWithOpts(t, opts2, nil)

--- a/server/server_delivery_test.go
+++ b/server/server_delivery_test.go
@@ -281,7 +281,7 @@ func TestPersistentStoreSQLSubsPendingRows(t *testing.T) {
 	defer ns.Shutdown()
 
 	opts := GetDefaultOptions()
-	opts.NATSServerURL = "nats://localhost:4222"
+	opts.NATSServerURL = "nats://127.0.0.1:4222"
 	opts.StoreType = stores.TypeSQL
 	opts.SQLStoreOpts.Driver = testSQLDriver
 	opts.SQLStoreOpts.Source = source

--- a/server/server_run_test.go
+++ b/server/server_run_test.go
@@ -62,7 +62,7 @@ func TestRunServerFailureLogsCause(t *testing.T) {
 	d := &dummyLogger{}
 
 	sOpts := GetDefaultOptions()
-	sOpts.NATSServerURL = "nats://localhost:4444"
+	sOpts.NATSServerURL = "nats://127.0.0.1:4444"
 	sOpts.CustomLogger = d
 
 	// We expect the server to fail to start
@@ -513,7 +513,7 @@ func TestDontEmbedNATSNotRunning(t *testing.T) {
 	s.Shutdown()
 
 	// Point to a NATS Server that will not be running
-	sOpts.NATSServerURL = "nats://localhost:5223"
+	sOpts.NATSServerURL = "nats://127.0.0.1:5223"
 
 	// Don't start a NATS Server, starting streaming server
 	// should fail.
@@ -526,7 +526,7 @@ func TestDontEmbedNATSNotRunning(t *testing.T) {
 
 func TestDontEmbedNATSRunning(t *testing.T) {
 	sOpts := GetDefaultOptions()
-	sOpts.NATSServerURL = "nats://localhost:5223"
+	sOpts.NATSServerURL = "nats://127.0.0.1:5223"
 
 	nOpts := DefaultNatsServerOptions
 	nOpts.Host = "127.0.0.1"
@@ -540,7 +540,7 @@ func TestDontEmbedNATSRunning(t *testing.T) {
 
 func TestDontEmbedNATSMultipleURLs(t *testing.T) {
 	nOpts := DefaultNatsServerOptions
-	nOpts.Host = "localhost"
+	nOpts.Host = "127.0.0.1"
 	nOpts.Port = 5223
 	nOpts.Username = "ivan"
 	nOpts.Password = "pwd"
@@ -550,9 +550,9 @@ func TestDontEmbedNATSMultipleURLs(t *testing.T) {
 	sOpts := GetDefaultOptions()
 
 	workingURLs := []string{
-		"nats://localhost:5223",
-		"nats://ivan:pwd@localhost:5223",
-		"nats://ivan:pwd@localhost:5223, nats://ivan:pwd@localhost:5224",
+		"nats://127.0.0.1:5223",
+		"nats://ivan:pwd@127.0.0.1:5223",
+		"nats://ivan:pwd@127.0.0.1:5223, nats://ivan:pwd@127.0.0.1:5224",
 	}
 	for _, url := range workingURLs {
 		sOpts.NATSServerURL = url
@@ -561,11 +561,11 @@ func TestDontEmbedNATSMultipleURLs(t *testing.T) {
 	}
 
 	notWorkingURLs := []string{
-		"nats://ivan:incorrect@localhost:5223",
-		"nats://localhost:5223,nats://ivan:pwd@localhost:5224",
-		"nats://localhost",
-		"localhost:5223",
-		"localhost",
+		"nats://ivan:incorrect@127.0.0.1:5223",
+		"nats://127.0.0.1:5223,nats://ivan:pwd@127.0.0.1:5224",
+		"nats://127.0.0.1",
+		"127.0.0.1:5223",
+		"127.0.0.1",
 		"nats://ivan:pwd@:5224",
 		" ",
 	}
@@ -1130,7 +1130,7 @@ func TestDontExposeUserPassword(t *testing.T) {
 	l := &captureNoticesLogger{}
 	sOpts := GetDefaultOptions()
 	sOpts.CustomLogger = l
-	sOpts.NATSServerURL = "nats://localhost:4222"
+	sOpts.NATSServerURL = "nats://127.0.0.1:4222"
 	nOpts := natsdTest.DefaultTestOptions
 	nOpts.Username = "ivan"
 	nOpts.Password = "password"
@@ -1170,7 +1170,7 @@ func TestDontExposeUserPassword(t *testing.T) {
 	l.Lock()
 	l.notices = l.notices[:0]
 	l.Unlock()
-	sOpts.NATSServerURL = "nats://ivan:password@localhost:4222"
+	sOpts.NATSServerURL = "nats://ivan:password@127.0.0.1:4222"
 	s = runServerWithOpts(t, sOpts, nil)
 	defer s.Shutdown()
 
@@ -1180,7 +1180,7 @@ func TestDontExposeUserPassword(t *testing.T) {
 	ns = natsdTest.RunDefaultServer()
 
 	msg = collectNotice(t)
-	if !strings.Contains(msg, "nats://[REDACTED]@localhost:") {
+	if !strings.Contains(msg, "nats://[REDACTED]@127.0.0.1:") {
 		t.Fatalf("Password exposed in url: %v", msg)
 	}
 }
@@ -1231,7 +1231,7 @@ func TestStreamingServerReadyLog(t *testing.T) {
 	sOpts := GetDefaultOptions()
 	l := &captureNoticesLogger{}
 	sOpts.CustomLogger = l
-	sOpts.NATSServerURL = "nats://localhost:4222"
+	sOpts.NATSServerURL = "nats://127.0.0.1:4222"
 	s := runServerWithOpts(t, sOpts, nil)
 	defer s.Shutdown()
 	checkLog(t, l, true)
@@ -1241,7 +1241,7 @@ func TestStreamingServerReadyLog(t *testing.T) {
 	sOpts = getTestFTDefaultOptions()
 	l = &captureNoticesLogger{}
 	sOpts.CustomLogger = l
-	sOpts.NATSServerURL = "nats://localhost:4222"
+	sOpts.NATSServerURL = "nats://127.0.0.1:4222"
 	s = runServerWithOpts(t, sOpts, nil)
 	defer s.Shutdown()
 	checkLog(t, l, true)
@@ -1249,7 +1249,7 @@ func TestStreamingServerReadyLog(t *testing.T) {
 	sOpts = getTestFTDefaultOptions()
 	l2 := &captureNoticesLogger{}
 	sOpts.CustomLogger = l2
-	sOpts.NATSServerURL = "nats://localhost:4222"
+	sOpts.NATSServerURL = "nats://127.0.0.1:4222"
 	s2 := runServerWithOpts(t, sOpts, nil)
 	defer s2.Shutdown()
 	// At first, we should not get the lock since server

--- a/stores/sqlstore_test.go
+++ b/stores/sqlstore_test.go
@@ -2042,7 +2042,7 @@ func TestSQLDeadlines(t *testing.T) {
 	} else {
 		port = 5432
 	}
-	proxy, err := newProxy(fmt.Sprintf("localhost:%d", port))
+	proxy, err := newProxy(fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		t.Fatalf("Error creating proxy: %v", err)
 	}
@@ -2050,7 +2050,7 @@ func TestSQLDeadlines(t *testing.T) {
 
 	pport := proxy.getPort()
 	if testSQLDriver == driverMySQL {
-		source = fmt.Sprintf("nss:password@tcp(localhost:%d)/%s?readTimeout=500ms&writeTimeout=500ms", pport, testDefaultDatabaseName)
+		source = fmt.Sprintf("nss:password@tcp(127.0.0.1:%d)/%s?readTimeout=500ms&writeTimeout=500ms", pport, testDefaultDatabaseName)
 		mysql.SetLogger(&silenceMySQLLogger{})
 	} else {
 		source = fmt.Sprintf("port=%d dbname=%s readTimeout=500ms writeTimeout=500ms sslmode=disable", pport, testDefaultDatabaseName)


### PR DESCRIPTION
This may help speed up some Windows test in case "localhost" would
cause an attempt to connect to ::1 before failing back to 127.0.0.1.

Also update .travis.yml based on warnings displayed on the UI.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>