### PR TITLE
[FIXED] Add filename in "unable to verify version" error

### DIFF
--- a/server/server_run_test.go
+++ b/server/server_run_test.go
@@ -1148,7 +1148,7 @@ func TestDontExposeUserPassword(t *testing.T) {
 		waitFor(t, 2*time.Second, 15*time.Millisecond, func() error {
 			l.Lock()
 			for _, n := range l.notices {
-				if strings.Contains(n, "reconnected to NATS Server at") {
+				if strings.Contains(n, "general\" reconnected to NATS Server at") {
 					msg = n
 					l.Unlock()
 					return nil


### PR DESCRIPTION
In some cases, the file name of the file unable to be recovered
due to an error reading the first 4 bytes of the file (to check
the file version) was not included in the error message, making
it difficult to debug which file was impacted.

Resolves #1034

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>