### PR TITLE
Fixed possible test data races

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
 - windows
 language: go
 go:
-- 1.12.x
+- 1.14.x
 - 1.13.x
 addons:
   apt:

--- a/server/clustering_test.go
+++ b/server/clustering_test.go
@@ -7139,10 +7139,12 @@ func TestClusteringRestoreSnapshotErrorDontSkipSeq(t *testing.T) {
 		t.Fatalf("Error on snapshot: %v", err)
 	}
 
-	c := s1.channels.get("foo")
 	ch1 := make(chan struct{})
 	ch2 := make(chan bool)
+	s1.channels.Lock()
+	c := s1.channels.channels["foo"]
 	c.store.Msgs = &blockingLookupStore{MsgStore: c.store.Msgs, inLookupCh: ch1, releaseCh: ch2}
+	s1.channels.Unlock()
 
 	// Configure second server.
 	s3sOpts := getTestDefaultOptsForClustering("c", false)
@@ -7257,10 +7259,12 @@ func TestClusteringRestoreSnapshotGapInSeq(t *testing.T) {
 		t.Fatalf("Error on snapshot: %v", err)
 	}
 
-	c := s1.channels.get("foo")
 	ch1 := make(chan struct{})
 	ch2 := make(chan bool)
+	s1.channels.Lock()
+	c := s1.channels.channels["foo"]
 	c.store.Msgs = &blockingLookupStore{MsgStore: c.store.Msgs, inLookupCh: ch1, releaseCh: ch2}
+	s1.channels.Unlock()
 
 	// Configure second server.
 	s3sOpts := getTestDefaultOptsForClustering("c", false)

--- a/server/server_delivery_test.go
+++ b/server/server_delivery_test.go
@@ -353,10 +353,12 @@ func TestDeliveryRaceBetweenNextMsgAndStoring(t *testing.T) {
 
 	sc.Publish("foo", []byte("msg1"))
 
-	c := s.channels.get("foo")
 	ch1 := make(chan struct{})
 	ch2 := make(chan bool)
+	s.channels.Lock()
+	c := s.channels.channels["foo"]
 	c.store.Msgs = &blockingLookupStore{MsgStore: c.store.Msgs, inLookupCh: ch1, releaseCh: ch2}
+	s.channels.Unlock()
 
 	sub := s.clients.getSubs(clientName)[0]
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
Update Travis go matrix to 1.14/1.13 instead of 1.13/1.12

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>