### PR TITLE
[FIXED] Don't send message to subscription that has just been closed

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -3952,7 +3952,7 @@ func (s *StanServer) processReplicatedSendAndAck(ssa *spb.SubSentAndAck) {
 // are not sent and subscriber is marked as stalled.
 // Sub lock should be held before calling.
 func (s *StanServer) sendMsgToSub(sub *subState, m *pb.MsgProto, force bool) (bool, bool) {
-	if sub == nil || m == nil || !sub.initialized || (sub.newOnHold && !m.Redelivered) {
+	if sub == nil || m == nil || !sub.initialized || sub.ClientID == "" || (sub.newOnHold && !m.Redelivered) {
 		return false, false
 	}
 


### PR DESCRIPTION
Race was possibly sending a message to a closed subscription, which
would set the ack timer, which then server would report that it
is skipping delivery to this subscription due to timeout and showing
no clientID in the debug trace.

Resolves #1058

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>