### PR TITLE
[FIXED] No attempt to redeliver message if error during lookup

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -3677,6 +3677,7 @@ func (s *StanServer) getMsgForRedelivery(c *channel, sub *subState, seq uint64) 
 		if err != nil {
 			s.log.Errorf("Error getting message for redelivery subid=%d, seq=%d, err=%v",
 				sub.ID, seq, err)
+			return nil
 		}
 		// Ack it so that it does not reincarnate on restart
 		s.processAck(c, sub, seq, false)


### PR DESCRIPTION
During a message redelivery, if the lookup were to fail (say due
to a transient storage error), the message would be implicitly
acknowledged and no other attempt to redeliver this message would
be made.
With this change, the server will try again to redeliver at the
next redelivery interval.

Resolves #1060

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>