### PR TITLE
    SQLStore: Channel expiration: Handle sql no rows error.

### DIFF
--- a/stores/sqlstore.go
+++ b/stores/sqlstore.go
@@ -1573,9 +1573,7 @@ func (ms *SQLMsgStore) expireMsgs() {
 		expiredTimestamp := time.Now().UnixNano() - int64(ms.limits.MaxAge)
 		r := ms.sqlStore.preparedStmts[sqlGetExpiredMessages].QueryRow(ms.channelID, expiredTimestamp)
 
-		// It has been observed that, there are cases where sqlErrNoRows
-		// is returned in this case we shouldn't reset the timer
-		if err := r.Scan(&count, &maxSeq, &totalSize); (err != nil) && (err != sql.ErrNoRows) {
+		if err := r.Scan(&count, &maxSeq, &totalSize); err != nil {
 			processErr(sqlGetExpiredMessages, err)
 			return
 		}
@@ -1603,7 +1601,7 @@ func (ms *SQLMsgStore) expireMsgs() {
 		// timer needs to be set to.
 		if ms.totalCount > 0 {
 			r = ms.sqlStore.preparedStmts[sqlGetFirstMsgTimestamp].QueryRow(ms.channelID, ms.first)
-			if err := r.Scan(&ms.fTimestamp); err != nil {
+			if err := r.Scan(&ms.fTimestamp); (err != nil) && (err != sql.ErrNoRows) {
 				processErr(sqlGetFirstMsgTimestamp, err)
 				return
 			}


### PR DESCRIPTION
    Once we get into this scenario, looks like we will be on it for ever -
    Handle sql no rows error gracefully, do not reset the timer and avoid  
    the sqlnorows-timerreset  loop. We already have checks for 
    timestamp = 0, count=0 etc here in this function. 
    
    Example logs from a system that was overloading the log stream
    Looks like this went on for a while .. 

    2020/07/14 07:48:05.271047 [ERR] STREAM: Unable to perform expiration for channel "fd56375b": sql: error executing "SELECT timestamp FROM Messages WHERE id=$1 AND seq>=$2 ORDER BY seq LIMIT 1": sql: no rows in result set
    ...
    2020/07/14 10:16:42.839703 [ERR] STREAM: Unable to perform expiration for channel "fd56375b": sql: error executing "SELECT timestamp FROM Messages WHERE id=$1 AND seq>=$2 ORDER BY seq LIMIT 1": sql: no rows in result set

