### PR TITLE
[ADDED] ClientURL() API and expose an OS-assigned server port via the NATS server options 

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1816,6 +1816,8 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (newServer *
 
 // ClientURL returns the basic URL string representation suitable for a client to use to connect
 func (s *StanServer) ClientURL() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.providedServerURL != "" {
 		return s.providedServerURL
 	} else if s.natsServer != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -1763,6 +1763,9 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (newServer *
 		if err := s.startNATSServer(); err != nil {
 			return nil, err
 		}
+		if natsOpts != nil && natsOpts.Port == server.RANDOM_PORT {
+			natsOpts.Port = nOpts.Port
+		}
 	}
 	// Check for monitoring
 	if nOpts.HTTPPort != 0 || nOpts.HTTPSPort != 0 {

--- a/server/server.go
+++ b/server/server.go
@@ -1808,6 +1808,10 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (newServer *
 	return &s, nil
 }
 
+func (s *StanServer) ClientURL() string {
+	return s.natsServer.ClientURL()
+}
+
 // Logging in STAN
 //
 // The STAN logger is an instance of a NATS logger, (basically duplicated

--- a/server/server.go
+++ b/server/server.go
@@ -756,6 +756,9 @@ type StanServer struct {
 	// cause races when running more than 1 server in a program or test.
 	pingResponseOKBytes            []byte
 	pingResponseInvalidClientBytes []byte
+
+	// If using an external server, capture the URL that was given for return in ClientURL().
+	providedServerURL string
 }
 
 type subsSentAndAckReplication struct {
@@ -1442,6 +1445,9 @@ func (s *StanServer) buildServerURLs() ([]string, error) {
 		}
 		// Use net.Join to support IPV6 addresses.
 		hostport = net.JoinHostPort(host, port)
+
+		// Capture for ClientURL()
+		s.providedServerURL = natsURL
 	} else {
 		// We embed the server, so it is local. If host is "any",
 		// use 127.0.0.1 or ::1 for host address (important for
@@ -1808,8 +1814,15 @@ func RunServerWithOpts(stanOpts *Options, natsOpts *server.Options) (newServer *
 	return &s, nil
 }
 
+// ClientURL returns the basic URL string representation suitable for a client to use to connect
 func (s *StanServer) ClientURL() string {
-	return s.natsServer.ClientURL()
+	if s.providedServerURL != "" {
+		return s.providedServerURL
+	} else if s.natsServer != nil {
+		return s.natsServer.ClientURL()
+	} else {
+		return ""
+	}
 }
 
 // Logging in STAN

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1370,3 +1370,22 @@ func TestAckProcessedBeforeClose(t *testing.T) {
 		dur.Unsubscribe()
 	}
 }
+
+func TestServerRandomPort(t *testing.T) {
+	natsOpts := natsdTest.DefaultTestOptions
+	natsOpts.Port = natsd.RANDOM_PORT
+	opts := GetDefaultOptions()
+	s := runServerWithOpts(t, opts, &natsOpts)
+	defer s.Shutdown()
+
+	if natsOpts.Port == natsd.RANDOM_PORT {
+		t.Fatal("port was not updated")
+	}
+	s.Shutdown()
+
+	// Try with no nats options provided to make sure we don't
+	// access natsOpts without checking that it is not nil
+	s = runServerWithOpts(t, opts, nil)
+	s.Shutdown()
+}
+


### PR DESCRIPTION
If a random port is asked for in a call to `RunServerWithOpts`, return this port
in the `*server.Options argument`. Replaces the Port field with the OS assigned
port.

This PR also adds `ClientURL()` to `StanServer` as an alternate method of
fetching connection information.