### PR TITLE
[FIXED] Absolute url in streaming monitoring menu

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -166,10 +166,10 @@ func (s *StanServer) handleRootz(w http.ResponseWriter, r *http.Request) {
   <body>
     <img src="http://nats.io/img/logo.png" alt="NATS Streaming">
     <br/>
-	<a href=%s>server</a><br/>
-	<a href=%s>store</a><br/>
-	<a href=%s>clients</a><br/>
-	<a href=%s>channels</a><br/>
+	<a href=.%s>server</a><br/>
+	<a href=.%s>store</a><br/>
+	<a href=.%s>clients</a><br/>
+	<a href=.%s>channels</a><br/>
     <br/>
     <a href=http://nats.io/documentation/server/gnatsd-monitoring/>help</a>
   </body>


### PR DESCRIPTION
Minor fix for monitoring menu.
If we use nginx proxy for 8222 monitoring hosts. **http://host:81/stan/node1/streaming/** urls in menu  **http://host:81/ like http://host:81/streaming/channelsz** not  **http://host:81/stan/node1/streaming/channelsz**
