### PR TITLE
[FIXED] FileStore: index file may be recreated with wrong offsets

### DIFF
--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -2378,6 +2378,9 @@ func (ms *FileMsgStore) recoverOneMsgFile(fslice *fileSlice, fseq int, useIdxFil
 		// We are going to write the index file while recovering the data file
 		bw := bufio.NewWriterSize(fslice.idxFile.handle, msgIndexRecSize*1000)
 
+		// Reset offset in case we come from a mismatch between .dat and .idx files.
+		offset = int64(4)
+
 		for {
 			ms.tmpMsgBuf, msgSize, _, err = readRecord(br, ms.tmpMsgBuf, false, crcTable, doCRC)
 			if err != nil {


### PR DESCRIPTION
This could happen if recovery of an index does not have matching
information with the last message in corresponding ".dat" file.
In that case, the server wipes the index file and recreate it
based on the data file. However, the offset was not reset, which
means that the index file would contain wrong offsets.

Resolves #1086

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>