### PR TITLE
[FIXED] Clustering: possible panic on restart with "log not found"

### DIFF
--- a/stores/filestore_test.go
+++ b/stores/filestore_test.go
@@ -1781,7 +1781,7 @@ func TestFSFilesClosedOnRecovery(t *testing.T) {
 	cleanupFSDatastore(t)
 	defer cleanupFSDatastore(t)
 
-	s := createDefaultFileStore(t, SliceConfig(1, 0, 0, ""))
+	s := createDefaultFileStore(t, SliceConfig(1, 0, 0, ""), DoSync(false))
 	defer s.Close()
 
 	limits := testDefaultStoreLimits


### PR DESCRIPTION
Was found by chance when causing backend boltdb store to throw
error when storing the raft log. The fact that a front-end log
cache was used and improperly caching logs that had failed to
be stored caused an issue for raft library. I have filed an
issue (and PR to fix) to the hashicorp/raft repo, but actually
decided to not use their LogCache since it can be easily added
to our raftLog implementation, reducing locking.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>