### PR TITLE
[IMPROVED] Clustering: Report possible misconfiguration of peers list

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2003,6 +2003,19 @@ func (s *StanServer) start(runningState State) error {
 		}
 		s.log.Noticef("Cluster Node ID : %s", s.info.NodeID)
 		s.log.Noticef("Cluster Log Path: %s", s.opts.Clustering.RaftLogPath)
+		if len(s.opts.Clustering.Peers) > 0 {
+			s.log.Noticef("Cluster known peers:")
+			var alert bool
+			for i, peer := range s.opts.Clustering.Peers {
+				if strings.Contains(peer, ",") {
+					alert = true
+				}
+				s.log.Noticef("peer %d: %q", i+1, peer)
+			}
+			if alert {
+				s.log.Warnf("Peer name contains ',' make sure you provided an array of peer names, not a string with commas")
+			}
+		}
 		if err := s.startRaftNode(recoveredState != nil); err != nil {
 			return err
 		}


### PR DESCRIPTION
The clustering peers list is supposed to contain the list of peer
node ids. However, it happens that users make the mistake of listing
the node peer ids in the same string as such:
```
streaming {
  cluster {
    node_id: "a"
    peers: ["a, b, c"]
  }
}
```
The correct definition of `peers` should be:
```
   peers: ["a", "b", "c"]
```

The server will now list the cluster known peers on startup and
will print a warning if a comma is detected in a peer name:
```
[INF] STREAM: peer 1: "a,b,c"
[WRN] STREAM: Peer name contains ',' make sure you provided an array of peer names, not a string with commas
```

Resolves #990

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>