### PR TITLE
[FIXED] FileStore: possible panic when unable to open an index file

### DIFF
--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -2213,8 +2213,12 @@ func (ms *FileMsgStore) doLockFiles(fslice *fileSlice, onlyIndexFile bool) error
 	}
 	idxWasOpened, err = ms.fm.lockFile(fslice.idxFile)
 	if err != nil {
-		if !datWasOpened {
-			ms.fm.unlockFile(fslice.file)
+		if !onlyIndexFile {
+			if !datWasOpened {
+				ms.fm.closeLockedFile(fslice.file)
+			} else {
+				ms.fm.unlockFile(fslice.file)
+			}
 		}
 		return err
 	}


### PR DESCRIPTION
If an error occurs when trying to open an index file, the server
was incorrectly trying to unlock a data file that was possibly
not locked/opened. For instance in the case of expiring messages
from a slice that is not the current writing slice.

Resolves #1097

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>