### PR TITLE
[ADDED] Authentication fields in streaming configuration block

### DIFF
--- a/server/conf.go
+++ b/server/conf.go
@@ -179,6 +179,21 @@ func ProcessConfigFile(configFile string, opts *Options) error {
 			}
 			opts.Encrypt = true
 			opts.EncryptionKey = []byte(v.(string))
+		case "username", "user":
+			if err := checkType(k, reflect.String, v); err != nil {
+				return err
+			}
+			opts.Username = v.(string)
+		case "password", "pass":
+			if err := checkType(k, reflect.String, v); err != nil {
+				return err
+			}
+			opts.Password = v.(string)
+		case "token":
+			if err := checkType(k, reflect.String, v); err != nil {
+				return err
+			}
+			opts.Token = v.(string)
 		}
 	}
 	return nil

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -84,6 +84,15 @@ func TestParseConfig(t *testing.T) {
 	if opts.NATSCredentials != "credentials.creds" {
 		t.Fatalf("Expected Credentials to be %q, got %q", "credentials.creds", opts.NATSCredentials)
 	}
+	if opts.Username != "user" {
+		t.Fatalf("Expected Username to be %q, got %q", "user", opts.Username)
+	}
+	if opts.Password != "password" {
+		t.Fatalf("Expected Password to be %q, got %q", "password", opts.Password)
+	}
+	if opts.Token != "token" {
+		t.Fatalf("Expected Token to be %q, got %q", "token", opts.Token)
+	}
 	if !opts.FileStoreOpts.CompactEnabled {
 		t.Fatalf("Expected CompactEnabled to be true, got false")
 	}
@@ -497,6 +506,9 @@ func TestParseWrongTypes(t *testing.T) {
 	expectFailureFor(t, "encryption_cipher: 123", wrongTypeErr)
 	expectFailureFor(t, "encryption_key: 123", wrongTypeErr)
 	expectFailureFor(t, "credentials: 123", wrongTypeErr)
+	expectFailureFor(t, "username: 123", wrongTypeErr)
+	expectFailureFor(t, "password: 123", wrongTypeErr)
+	expectFailureFor(t, "token: 123", wrongTypeErr)
 }
 
 func expectFailureFor(t *testing.T, content, errorMatch string) {

--- a/server/server.go
+++ b/server/server.go
@@ -1322,6 +1322,9 @@ type Options struct {
 	IOSleepTime        int64         // Duration (in micro-seconds) the server waits for more message to fill up a batch.
 	NATSServerURL      string        // URL for external NATS Server to connect to. If empty, NATS Server is embedded.
 	NATSCredentials    string        // Credentials file for connecting to external NATS Server.
+	Username           string        // Username to use if not provided from command line
+	Password           string        // Password to use if not provided from command line
+	Token              string        // Authentication token to use if not provided from command line
 	ClientHBInterval   time.Duration // Interval at which server sends heartbeat to a client.
 	ClientHBTimeout    time.Duration // How long server waits for a heartbeat response.
 	ClientHBFailCount  int           // Number of failed heartbeats before server closes client connection.
@@ -1495,9 +1498,20 @@ func (s *StanServer) createNatsClientConn(name string) (*nats.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
+	// From executable, these are provided through the command line `-user ...`,
+	// so they take precedence over streaming's configuration file
 	ncOpts.User = s.natsOpts.Username
+	if ncOpts.User == "" {
+		ncOpts.User = s.opts.Username
+	}
 	ncOpts.Password = s.natsOpts.Password
+	if ncOpts.Password == "" {
+		ncOpts.Password = s.opts.Password
+	}
 	ncOpts.Token = s.natsOpts.Authorization
+	if ncOpts.Token == "" {
+		ncOpts.Token = s.opts.Token
+	}
 
 	ncOpts.Name = fmt.Sprintf("_NSS-%s-%s", s.opts.ID, name)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -409,6 +409,28 @@ func createConnectionWithNatsOpts(t tLogger, clientName string,
 	return sc, nc
 }
 
+func createConfFile(t *testing.T, content []byte) string {
+	t.Helper()
+	conf, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("Error creating conf file: %v", err)
+	}
+	fName := conf.Name()
+	conf.Close()
+	if err := ioutil.WriteFile(fName, content, 0666); err != nil {
+		os.Remove(fName)
+		t.Fatalf("Error writing conf file: %v", err)
+	}
+	return fName
+}
+
+func changeCurrentConfigContentWithNewContent(t *testing.T, curConfig string, content []byte) {
+	t.Helper()
+	if err := ioutil.WriteFile(curConfig, content, 0666); err != nil {
+		t.Fatalf("Error writing config: %v", err)
+	}
+}
+
 func NewDefaultConnection(t tLogger) stan.Conn {
 	sc, err := stan.Connect(clusterName, clientName)
 	if err != nil {

--- a/server/signal_test.go
+++ b/server/signal_test.go
@@ -156,28 +156,6 @@ func TestSignalTrapsSIGTERM(t *testing.T) {
 	}
 }
 
-func createConfFile(t *testing.T, content []byte) string {
-	t.Helper()
-	conf, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("Error creating conf file: %v", err)
-	}
-	fName := conf.Name()
-	conf.Close()
-	if err := ioutil.WriteFile(fName, content, 0666); err != nil {
-		os.Remove(fName)
-		t.Fatalf("Error writing conf file: %v", err)
-	}
-	return fName
-}
-
-func changeCurrentConfigContentWithNewContent(t *testing.T, curConfig string, content []byte) {
-	t.Helper()
-	if err := ioutil.WriteFile(curConfig, content, 0666); err != nil {
-		t.Fatalf("Error writing config: %v", err)
-	}
-}
-
 func TestSignalReload(t *testing.T) {
 	conf := createConfFile(t, []byte(`debug: false`))
 	defer os.Remove(conf)

--- a/test/configs/test_parse.conf
+++ b/test/configs/test_parse.conf
@@ -17,6 +17,9 @@ streaming: {
   encryption_cipher: "AES"
   encryption_key: "key"
   credentials: "credentials.creds"
+  username: "user"
+  password: "password"
+  token: "token"
 
   store_limits: {
       max_channels: 11


### PR DESCRIPTION
Abiltity to provide Username, Password or Token in the streaming
configuration block.

If the configuration is:
```
authorization {
  users [
    { user: foo, password: bar}
  ]
}
streaming {
  ..
}
```
the server would fail to start unless user passes `-user foo -pass bar`
from the command line. But there was no way to pass those from the
configuration file. You can now configure this way:

```
streaming {
  ..
  username: "foo"
  password: "bar"
}
```
in order for the server to be able to start without the additional
`-user` and `-pass` command line parameters.

Also adding the `token` configuration option.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>