### PR TITLE
[ADDED] NKey support

### DIFF
--- a/server/conf.go
+++ b/server/conf.go
@@ -194,6 +194,11 @@ func ProcessConfigFile(configFile string, opts *Options) error {
 				return err
 			}
 			opts.Token = v.(string)
+		case "nkey_seed_file":
+			if err := checkType(k, reflect.String, v); err != nil {
+				return err
+			}
+			opts.NKeySeedFile = v.(string)
 		}
 	}
 	return nil

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -90,6 +90,9 @@ func TestParseConfig(t *testing.T) {
 	if opts.Password != "password" {
 		t.Fatalf("Expected Password to be %q, got %q", "password", opts.Password)
 	}
+	if opts.NKeySeedFile != "seedfile" {
+		t.Fatalf("Expected NKeySeedFile to be %q, got %q", "seedfile", opts.NKeySeedFile)
+	}
 	if opts.Token != "token" {
 		t.Fatalf("Expected Token to be %q, got %q", "token", opts.Token)
 	}
@@ -509,6 +512,7 @@ func TestParseWrongTypes(t *testing.T) {
 	expectFailureFor(t, "username: 123", wrongTypeErr)
 	expectFailureFor(t, "password: 123", wrongTypeErr)
 	expectFailureFor(t, "token: 123", wrongTypeErr)
+	expectFailureFor(t, "nkey_seed_file: 123", wrongTypeErr)
 }
 
 func expectFailureFor(t *testing.T, content, errorMatch string) {

--- a/server/server.go
+++ b/server/server.go
@@ -1322,9 +1322,10 @@ type Options struct {
 	IOSleepTime        int64         // Duration (in micro-seconds) the server waits for more message to fill up a batch.
 	NATSServerURL      string        // URL for external NATS Server to connect to. If empty, NATS Server is embedded.
 	NATSCredentials    string        // Credentials file for connecting to external NATS Server.
-	Username           string        // Username to use if not provided from command line
-	Password           string        // Password to use if not provided from command line
-	Token              string        // Authentication token to use if not provided from command line
+	Username           string        // Username to use if not provided from command line.
+	Password           string        // Password to use if not provided from command line.
+	Token              string        // Authentication token to use if not provided from command line.
+	NKeySeedFile       string        // File name containing NKey private key.
 	ClientHBInterval   time.Duration // Interval at which server sends heartbeat to a client.
 	ClientHBTimeout    time.Duration // How long server waits for a heartbeat response.
 	ClientHBFailCount  int           // Number of failed heartbeats before server closes client connection.
@@ -1511,6 +1512,14 @@ func (s *StanServer) createNatsClientConn(name string) (*nats.Conn, error) {
 	ncOpts.Token = s.natsOpts.Authorization
 	if ncOpts.Token == "" {
 		ncOpts.Token = s.opts.Token
+	}
+
+	if s.opts.NKeySeedFile != "" {
+		nkey, err := nats.NkeyOptionFromSeed(s.opts.NKeySeedFile)
+		if err != nil {
+			return nil, err
+		}
+		nkey(&ncOpts)
 	}
 
 	ncOpts.Name = fmt.Sprintf("_NSS-%s-%s", s.opts.ID, name)

--- a/test/configs/test_parse.conf
+++ b/test/configs/test_parse.conf
@@ -20,6 +20,7 @@ streaming: {
   username: "user"
   password: "password"
   token: "token"
+  nkey_seed_file: "seedfile"
 
   store_limits: {
       max_channels: 11


### PR DESCRIPTION
You can now configure the streaming server by providing a file
to the NKey seed. This will be used when creating the NATS connections
and when NKey authentication is required.
The file is read to get the seed in order to sign the nonce from
the NATS server. The seed is wiped out from memory after this
is done.

Resolves #1095

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>