### PR TITLE
[FIXED] Display all configured channels

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -459,8 +459,8 @@ func getTestDefaultOptsForPersistentStore() *Options {
 	case stores.TypeFile:
 		opts.FilestoreDir = defaultDataStore
 		opts.FileStoreOpts.BufferSize = 1024
-		// Go 1.12 on macOS is very slow at doing sync writes...
-		if runtime.GOOS == "darwin" && strings.HasPrefix(runtime.Version(), "go1.12") {
+		// Since Go 1.12, on macOS it is very slow to do sync writes...
+		if runtime.GOOS == "darwin" {
 			opts.FileStoreOpts.DoSync = false
 		}
 	case stores.TypeSQL:

--- a/util/sublist.go
+++ b/util/sublist.go
@@ -490,7 +490,6 @@ func (s *Sublist) Subjects() []string {
 
 func getSubjects(l *level, subject string, res *[]string) {
 	if l == nil || l.numNodes() == 0 {
-		*res = append(*res, subject)
 		return
 	}
 	var fs string
@@ -500,13 +499,16 @@ func getSubjects(l *level, subject string, res *[]string) {
 		} else {
 			fs = sfwc
 		}
-		getSubjects(l.fwc.next, fs, res)
+		*res = append(*res, fs)
 	}
 	if l.pwc != nil {
 		if subject != "" {
 			fs = subject + tsep + spwc
 		} else {
 			fs = spwc
+		}
+		if len(l.pwc.elements) > 0 {
+			*res = append(*res, fs)
 		}
 		getSubjects(l.pwc.next, fs, res)
 	}
@@ -515,6 +517,9 @@ func getSubjects(l *level, subject string, res *[]string) {
 			fs = subject + tsep + s
 		} else {
 			fs = s
+		}
+		if len(n.elements) > 0 {
+			*res = append(*res, fs)
 		}
 		getSubjects(n.next, fs, res)
 	}

--- a/util/sublist_test.go
+++ b/util/sublist_test.go
@@ -405,4 +405,33 @@ func TestSublistSubjects(t *testing.T) {
 			t.Fatalf("Result expected to be either %v or %v, got %v", pOne, pTwo, r)
 		}
 	}
+
+	subjects = []string{"bar", "bar.*", "bar.baz", "bar.>", "bar.*.bat", "bar.baz.*", "bar.baz.biz.box", "bar.baz.>"}
+	expected := []string{"bar", "bar.>", "bar.*", "bar.*.bat", "bar.baz", "bar.baz.>", "bar.baz.*", "bar.baz.biz.box"}
+	s := NewSublist()
+	for _, subj := range subjects {
+		s.Insert(subj, subj)
+	}
+	r := s.Match("bar")
+	if len(r) == 0 {
+		t.Fatalf("bar should be in the sublist")
+	}
+	if r[0].(string) != "bar" {
+		t.Fatalf("invalid value for bar: %q", r[0].(string))
+	}
+	subjs := s.Subjects()
+	if !reflect.DeepEqual(subjs, expected) {
+		t.Fatalf("Expected subject:\n%q\n got\n%q", expected, subjs)
+	}
+
+	subjects = []string{"bar", "bar.*.*.box", "bar.baz.bat.*", ">", "*", "bar.baz.bat"}
+	expected = []string{">", "*", "bar", "bar.*.*.box", "bar.baz.bat", "bar.baz.bat.*"}
+	s = NewSublist()
+	for _, subj := range subjects {
+		s.Insert(subj, subj)
+	}
+	subjs = s.Subjects()
+	if !reflect.DeepEqual(subjs, expected) {
+		t.Fatalf("Expected subject:\n%q\n got\n%q", expected, subjs)
+	}
 }


### PR DESCRIPTION
With this fix, the channels bar and bar.> will be properly displayed.
```
[13010] 2020/10/12 18:08:35.531185 [INF] STREAM: -------- List of Channels --------
[13010] 2020/10/12 18:08:35.531188 [INF] STREAM: bar
[13010] 2020/10/12 18:08:35.531193 [INF] STREAM:  |-> Messages                    5
[13010] 2020/10/12 18:08:35.531196 [INF] STREAM: bar.>
[13010] 2020/10/12 18:08:35.531198 [INF] STREAM:  |-> Messages                   10
[13010] 2020/10/12 18:08:35.531200 [INF] STREAM: ----------------------------------
```

Resolves #1106

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>