### PR TITLE
[FIXED] Command line `-file_slice_max_bytes 0` was not working

### DIFF
--- a/server/conf.go
+++ b/server/conf.go
@@ -761,6 +761,8 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 			var i64 int64
 			i64, flagErr = getBytes(f)
 			sopts.FileStoreOpts.ReadBufferSize = int(i64)
+		case "file_slice_max_bytes":
+			sopts.FileStoreOpts.SliceMaxBytes, flagErr = getBytes(f)
 		}
 	})
 	if flagErr != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1607,3 +1607,21 @@ SUAKYRHVIOREXV7EUZTBHUHL7NUMHPMAS7QMDU3GTIUWEI5LDNOXD43IZY
 		t.Fatal("Expected failure to start")
 	}
 }
+
+func TestFileSliceMaxBytesCmdLine(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	noPrint := func() {}
+	sopts, nopts, err := ConfigureOptions(fs, []string{"-store", "file", "-dir", defaultDataStore, "-file_slice_max_bytes", "0"}, noPrint, noPrint, noPrint)
+	if err != nil {
+		t.Fatalf("Error on configure: %v", err)
+	}
+	s := runServerWithOpts(t, sopts, nopts)
+	defer s.Shutdown()
+
+	s.mu.Lock()
+	smb := s.opts.FileStoreOpts.SliceMaxBytes
+	s.mu.Unlock()
+	if smb != 0 {
+		t.Fatalf("Expected value to be 0, got %v", smb)
+	}
+}


### PR DESCRIPTION
It was impossible to set the file slice max bytes to 0. The default
64MB value would be used. Note that setting it in the configuration
file would work, only the command line would not.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>