### PR TITLE
[FIXED] Possible race causing ack'ed message to be redelivered

### DIFF
--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -275,8 +275,10 @@ func (n *natsStreamLayer) Dial(address raft.ServerAddress, timeout time.Duration
 		return nil, err
 	}
 
+	peerConn.mu.Lock()
 	peerConn.sub = sub
 	peerConn.outbox = resp.Inbox
+	peerConn.mu.Unlock()
 	n.mu.Lock()
 	n.conns[peerConn] = struct{}{}
 	n.mu.Unlock()

--- a/server/server_redelivery_test.go
+++ b/server/server_redelivery_test.go
@@ -1767,68 +1767,85 @@ func (ms *testRdlvRaceWithAck) Lookup(seq uint64) (*pb.MsgProto, error) {
 }
 
 func TestRedeliveryRaceWithAck(t *testing.T) {
-	s := runServer(t, clusterName)
-	defer s.Shutdown()
+	for _, test := range []struct {
+		name  string
+		queue string
+	}{
+		{"plain", ""},
+		{"queue", "queue"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s := runServer(t, clusterName)
+			defer s.Shutdown()
 
-	c, err := s.lookupOrCreateChannel("foo")
-	if err != nil {
-		t.Fatalf("Error on lookup: %v", err)
-	}
-	ms := &testRdlvRaceWithAck{
-		MsgStore: c.store.Msgs,
-		ch:       make(chan struct{}, 1),
-		dch:      make(chan struct{}),
-	}
-	s.clients.Lock()
-	c.store.Msgs = ms
-	s.clients.Unlock()
-
-	sc := NewDefaultConnection(t)
-	defer sc.Close()
-
-	msgCh := make(chan *stan.Msg, 10)
-	if _, err := sc.Subscribe("foo", func(m *stan.Msg) {
-		msgCh <- m
-	}, stan.SetManualAckMode(), stan.AckWait(ackWaitInMs(250))); err != nil {
-		t.Fatalf("Error on subscribe: %v", err)
-	}
-
-	sc.Publish("foo", []byte("msg"))
-
-	var m *stan.Msg
-	select {
-	case m = <-msgCh:
-	case <-time.After(time.Second):
-		t.Fatalf("Did not get the message")
-	}
-	ms.Lock()
-	ms.block = true
-	ch := ms.ch
-	dch := ms.dch
-	ms.Unlock()
-
-	select {
-	case <-ch:
-		m.Ack()
-		sub := c.ss.getAllSubs()[0]
-		waitFor(t, time.Second, 15*time.Millisecond, func() error {
-			sub.RLock()
-			done := len(sub.acksPending) == 0
-			sub.RUnlock()
-			if !done {
-				return fmt.Errorf("message still pending")
+			c, err := s.lookupOrCreateChannel("foo")
+			if err != nil {
+				t.Fatalf("Error on lookup: %v", err)
 			}
-			return nil
+			ms := &testRdlvRaceWithAck{
+				MsgStore: c.store.Msgs,
+				ch:       make(chan struct{}, 1),
+				dch:      make(chan struct{}),
+			}
+			s.clients.Lock()
+			c.store.Msgs = ms
+			s.clients.Unlock()
+
+			sc := NewDefaultConnection(t)
+			defer sc.Close()
+
+			msgCh := make(chan *stan.Msg, 10)
+			if _, err := sc.QueueSubscribe("foo", test.queue, func(m *stan.Msg) {
+				msgCh <- m
+			}, stan.SetManualAckMode(), stan.AckWait(ackWaitInMs(250))); err != nil {
+				t.Fatalf("Error on subscribe: %v", err)
+			}
+
+			sc.Publish("foo", []byte("msg"))
+
+			var m *stan.Msg
+			select {
+			case m = <-msgCh:
+			case <-time.After(time.Second):
+				t.Fatalf("Did not get the message")
+			}
+			ms.Lock()
+			ms.block = true
+			ch := ms.ch
+			dch := ms.dch
+			ms.Unlock()
+
+			select {
+			case <-ch:
+				m.Ack()
+				sub := c.ss.getAllSubs()[0]
+				waitFor(t, time.Second, 15*time.Millisecond, func() error {
+					if test.queue != "" {
+						sub.qstate.RLock()
+					}
+					sub.RLock()
+					done := len(sub.acksPending) == 0
+					sub.RUnlock()
+					if test.queue != "" {
+						sub.qstate.RUnlock()
+					}
+					if !done {
+						return fmt.Errorf("message still pending")
+					}
+					return nil
+				})
+				close(dch)
+			case <-time.After(time.Second):
+				t.Fatalf("Lookup not invoked for redelivery")
+			}
+
+			select {
+			case m := <-msgCh:
+				t.Fatalf("Should not have received redelivered message: %+v", m)
+			case <-time.After(250 * time.Millisecond):
+				// OK
+			}
 		})
-		close(dch)
-	case <-time.After(time.Second):
-		t.Fatalf("Lookup not invoked for redelivery")
 	}
 
-	select {
-	case m := <-msgCh:
-		t.Fatalf("Should not have received redelivered message: %+v", m)
-	case <-time.After(250 * time.Millisecond):
-		// OK
-	}
 }


### PR DESCRIPTION
During redelivery, a go routine gathers all pending messages under
a lock. However, the actual send of messages is done one by one
and by then, one of the message in the list of messages to redeliver
may have been acknowledged. So during the send, under the sub's lock,
we need to check that if a message marked as redelivered is no longer
in the pending list, it should not be sent to the client.

Also fixed an unrelated data race that was just found running tests.

Resolves #1138

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>