### PR TITLE
[FIXED] Avoid possibly dropping client protocol requests

### DIFF
--- a/server/partitions.go
+++ b/server/partitions.go
@@ -150,8 +150,10 @@ func (p *partitions) initSubscriptions() error {
 	// NOTE: Use the server's nc connection here, not the partitions' one.
 	for _, channelName := range p.channels {
 		pubSubject := fmt.Sprintf("%s.%s", p.s.info.Publish, channelName)
-		if _, err := p.s.nc.Subscribe(pubSubject, p.s.processClientPublish); err != nil {
+		if sub, err := p.s.nc.Subscribe(pubSubject, p.s.processClientPublish); err != nil {
 			return fmt.Errorf("could not subscribe to publish subject %q, %v", channelName, err)
+		} else {
+			sub.SetPendingLimits(-1, -1)
 		}
 	}
 	return nil

--- a/server/server.go
+++ b/server/server.go
@@ -2749,7 +2749,6 @@ func (s *StanServer) initInternalSubs(createPub bool) error {
 		if err != nil {
 			return err
 		}
-		s.pubSub.SetPendingLimits(-1, -1)
 	}
 	// Receive subscription requests from clients.
 	s.subSub, err = s.createSub(s.info.Subscribe, s.processSubscriptionRequest, "subscribe request")
@@ -2839,6 +2838,7 @@ func (s *StanServer) createSub(subj string, f nats.MsgHandler, errTxt string) (*
 	if err != nil {
 		return nil, fmt.Errorf("could not subscribe to %s subject: %v", errTxt, err)
 	}
+	sub.SetPendingLimits(-1, -1)
 	return sub, nil
 }
 


### PR DESCRIPTION
The NATS Streaming server uses NATS subscriptions to receive protocols
from the streaming clients. Except for the publish requests, these
internal subscriptions did not set the limits to "unlimited", which
could possibly lead to situation where some requests would be dropped
while other would not (if the server was slowing down to a point where
the NATS library would start to drop messages if the those internal
subscriptions queues were at the limit).

Of course, it is always possible that protocols be missed because
clients may be connected to a different server, and there could be
network issues, etc.. but this will reduce the risk.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>