### PR TITLE
[IMPROVED] Clustering: performance for fragmented RAFT logs

### DIFF
--- a/server/raft_log.go
+++ b/server/raft_log.go
@@ -64,13 +64,15 @@ func newRaftLog(log logger.Logger, fileName string, sync bool, _ int, encrypt bo
 		fileName: fileName,
 		codec:    &codec.MsgpackHandle{},
 	}
-	db, err := bolt.Open(fileName, 0600, nil)
+	dbOpts := &bolt.Options{
+		NoSync:         !sync,
+		NoFreelistSync: true,
+		FreelistType:   bolt.FreelistMapType,
+	}
+	db, err := bolt.Open(fileName, 0600, dbOpts)
 	if err != nil {
 		return nil, err
 	}
-	db.NoSync = !sync
-	db.NoFreelistSync = true
-	db.FreelistType = bolt.FreelistMapType
 	r.conn = db
 	if err := r.init(); err != nil {
 		r.conn.Close()


### PR DESCRIPTION
An option for the `go.etcd.io/bbolt` library allows to set the type
of freelist merge functions, from the default `FreelistArrayType` to
an optional `FreelistMapType`. The doc explains:

```
Array which is simple but endures dramatic performance degradation
if database is large and framentation in freelist is common.
The alternative one is using hashmap, it is faster in almost all
circumstances.
```

However, although most of the options can be set through options
or by setting to the bolt.DB object itself, the `DB.FreelistType`
field was set after opening the bolt.DB object, which was too
late and would therefore always default to the "array" merge
function.
This PR now correctly creates bolt.Options and pass those to
the bolt.Open() call so that the options are properly used.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>