### PR TITLE
[ADDED] Configuration parameters for RAFT's BoltDB store

### DIFF
--- a/server/conf.go
+++ b/server/conf.go
@@ -351,6 +351,16 @@ func parseCluster(itf interface{}, opts *Options) error {
 			case "raft_commit_timeout":
 				opts.Clustering.RaftCommitTimeout = dur
 			}
+		case "bolt_free_list_sync":
+			if err := checkType(k, reflect.Bool, v); err != nil {
+				return err
+			}
+			opts.Clustering.BoltFreeListSync = v.(bool)
+		case "bolt_free_list_array":
+			if err := checkType(k, reflect.Bool, v); err != nil {
+				return err
+			}
+			opts.Clustering.BoltFreeListArray = v.(bool)
 		}
 	}
 	return nil

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -275,6 +275,12 @@ func TestParseConfig(t *testing.T) {
 	if !opts.Clustering.AllowAddRemoveNode {
 		t.Fatal("Expected AllowAddRemoveNode to be true")
 	}
+	if !opts.Clustering.BoltFreeListSync {
+		t.Fatal("Expected BoltFreeListSync to be true")
+	}
+	if !opts.Clustering.BoltFreeListArray {
+		t.Fatal("Expected BoltFreeListArray to be true")
+	}
 	if opts.SQLStoreOpts.Driver != "mysql" {
 		t.Fatalf("Expected SQL Driver to be %q, got %q", "mysql", opts.SQLStoreOpts.Driver)
 	}
@@ -505,6 +511,8 @@ func TestParseWrongTypes(t *testing.T) {
 	expectFailureFor(t, "cluster:{raft_commit_timeout:123}", wrongTypeErr)
 	expectFailureFor(t, "cluster:{raft_commit_timeout:\"not_a_time\"}", wrongTimeErr)
 	expectFailureFor(t, "cluster:{allow_add_remove_node:1}", wrongTypeErr)
+	expectFailureFor(t, "cluster:{bolt_free_list_sync:123}", wrongTypeErr)
+	expectFailureFor(t, "cluster:{bolt_free_list_array:123}", wrongTypeErr)
 	expectFailureFor(t, "sql:{driver:false}", wrongTypeErr)
 	expectFailureFor(t, "sql:{source:false}", wrongTypeErr)
 	expectFailureFor(t, "sql:{no_caching:123}", wrongTypeErr)

--- a/test/configs/test_parse.conf
+++ b/test/configs/test_parse.conf
@@ -92,6 +92,8 @@ streaming: {
       raft_lease_timeout: "500ms"
       raft_commit_timeout: "50ms"
       allow_add_remove_node: true
+      bolt_free_list_sync: true
+      bolt_free_list_array: true
   }
 
   sql: {


### PR DESCRIPTION
Two new options can be configured:

`bolt_free_list_sync: <bool>` will cause free list to be sync'ed
on write. The default is `false` which means no sync.
You would enable this option if startup time matters more than
write performance because with this option, the DB does not need
to perform a full database re-sync.

`bolt_free_list_array: <bool>` switches to the "array" type of
free list, which may suffer for large databases with fragmented
free list. Up to v0.20.0 (included), this was the default but
PR #1155 made the "hashmap" free list type now the default.
This option allows you to revert to previous behavior.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>