### PR TITLE
[FIXED] Fail faster subscription requests for invalid clients

### DIFF
--- a/server/server_req_test.go
+++ b/server/server_req_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The NATS Authors
+// Copyright 2016-2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -131,7 +131,7 @@ func TestInvalidSubRequest(t *testing.T) {
 	defer nc.Close()
 
 	// This test is very dependent on the validity tests performed
-	// in StanServer.processSubscriptionRequest(). Any cahnge there
+	// in StanServer.processSubscriptionRequest(). Any change there
 	// may require changes here.
 
 	// Create empty request
@@ -201,20 +201,22 @@ func TestInvalidSubRequest(t *testing.T) {
 	}
 
 	// Test Queue Group DurableName
+	sc := NewDefaultConnection(t)
+	defer sc.Close()
 	req.Subject = "foo"
 	req.QGroup = "queue"
 	req.DurableName = "dur:name"
 	if err := sendInvalidSubRequest(s, nc, req, ErrInvalidDurName); err != nil {
 		t.Fatalf("%v", err)
 	}
+	sc.Close()
 
 	// Reset those
 	req.QGroup = ""
 	req.DurableName = ""
 
-	// Now we should have an error that says that we can't find client ID
-	// (that is, client was not registered).
-	if err := sendInvalidSubRequest(s, nc, req, fmt.Errorf("can't find clientID: %v", clientName)); err != nil {
+	// Now we should have an error that says that we have an unknown client ID.
+	if err := sendInvalidSubRequest(s, nc, req, ErrUnknownClient); err != nil {
 		t.Fatalf("%v", err)
 	}
 
@@ -227,7 +229,7 @@ func TestInvalidSubRequest(t *testing.T) {
 	}
 
 	// Create a durable
-	sc := NewDefaultConnection(t)
+	sc = NewDefaultConnection(t)
 	defer sc.Close()
 	dur, err := sc.Subscribe("foo", func(_ *stan.Msg) {}, stan.DurableName("dur"))
 	if err != nil {
@@ -245,7 +247,7 @@ func TestInvalidSubRequest(t *testing.T) {
 	req.ClientID = clientName
 	req.Subject = "foo"
 	req.DurableName = "dur"
-	if err := sendInvalidSubRequest(s, nc, req, fmt.Errorf("can't find clientID: %v", clientName)); err != nil {
+	if err := sendInvalidSubRequest(s, nc, req, ErrUnknownClient); err != nil {
 		t.Fatalf("%v", err)
 	}
 }


### PR DESCRIPTION
When the server detects that a client is not responding to heartbeats,
it closes it, however, this was done with a barrier that ensures
that all pending protocols on all internal subscriptions are first
processed.
In the case of this close (as opposed to processing a client close
request), this is not welcome because it may causes the server
to process lots of subscription requests that were sent by that
client - maybe in response to timeouts for a server already having
issues handling the load.

The server will now forcefully close the client (without the use
of the barrier) and the detection of an invalid client is done
sooner in the handling of the subscription request.

Also, the internal subscription for client subscription requests
has been reverted to be limited (with possibly dropping requests).

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>