### PR TITLE
[FIXED] Subscription redelivery count map was not cleaned-up

### DIFF
--- a/server/server_redelivery_test.go
+++ b/server/server_redelivery_test.go
@@ -1748,6 +1748,15 @@ func TestPersistentStoreRedeliveryCount(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatalf("Timedout")
 	}
+
+	// Make sure that deliver count map gets cleaned-up once messages are acknowledged.
+	sub := s.clients.getSubs(clientName)[0]
+	waitForCount(t, 0, func() (string, int) {
+		sub.RLock()
+		l := len(sub.rdlvCount)
+		sub.RUnlock()
+		return "redelivery map size", l
+	})
 }
 
 type testRdlvRaceWithAck struct {


### PR DESCRIPTION
PR #997 introduced a map to keep track of how many times a message
was redelivered to a subscription (or a queue group). However, sequences
added to this map was never removed when the ACK was processed from
the subscription!

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>