### PR TITLE
[FIXED] Clustering: snapshot queue group's last_sent

### DIFF
--- a/server/snapshot.go
+++ b/server/snapshot.go
@@ -164,6 +164,9 @@ func (s *serverSnapshot) snapshotChannels(snap *spb.RaftSnapshot) error {
 				i++
 			}
 		}
+		if sub.qstate != nil && sub.qstate.lastSent > state.LastSent {
+			state.LastSent = sub.qstate.lastSent
+		}
 		return snapSub
 	}
 


### PR DESCRIPTION
In some situations where a member has fallen behind and other
members left the group, a snapshot would have the lone member
with a lower last_sent, which could cause older messages to
be redelivered.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>