### PR TITLE
[IMPROVED] Clustering: queue redelivery to different members

### DIFF
--- a/server/clustering.go
+++ b/server/clustering.go
@@ -51,9 +51,13 @@ var (
 	tportTimeout                = defaultTPortTimeout
 )
 
+const (
+	testLazyReplicationInterval = 250 * time.Millisecond
+)
+
 func clusterSetupForTest() {
 	runningInTests = true
-	lazyReplicationInterval = 250 * time.Millisecond
+	lazyReplicationInterval = testLazyReplicationInterval
 	joinRaftGroupTimeout = 250 * time.Millisecond
 	tportTimeout = 250 * time.Millisecond
 }


### PR DESCRIPTION
Until now, queue redeliveries in cluster mode behaved differently
than in standalone/FT mode. That is, messages delivered to a
queue member were always redelivered to that same member.
This could be a problem if the application hosting the queue
member had an issue where it would not acknowledge messages
but at the same time was still running. The leader would always
redeliver those same unacknowledged messages to that same
misbehaving client. With this change, the queue redelivery is
now the same regardless of the streaming server running mode.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>