### PR TITLE
[FIXED] Clustering: don't report "sub close request missing subject" on replay

### DIFF
--- a/server/snapshot.go
+++ b/server/snapshot.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The NATS Authors
+// Copyright 2017-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -297,7 +297,7 @@ func (r *raftFSM) Restore(snapshot io.ReadCloser) (retErr error) {
 			sub.RLock()
 			clientID := sub.ClientID
 			sub.RUnlock()
-			if err := s.unsubscribeSub(c, clientID, "unsub", sub, false, false); err != nil {
+			if err := s.unsubscribeSub(c, clientID, sub, false, false); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Suppose that a channel exists and there is a subscription for this
channel. A snapshot occurs, then later the subscription is closed.
After a while, the channel is removed.

If a server restarts and replays the snapshot and the rest of the
RAFT log, it will skip the recovery of the channel because it
would detect that the channel no longer exists, however, the
replay of the log would try to process the subscription close
and not find the channel.
We detect this case now and simply ignore the sub close protocol.

We also changed the error message, that still can be reported when
processing the request in the leader (before replication), from
"missing subject" to "unknown channel".

Resolves #1229

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>