### PR TITLE
[FIXED] Log failure to create a channel

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -312,7 +312,12 @@ func (cs *channelStore) createChannel(s *StanServer, name string) (*channel, err
 	return c, err
 }
 
-func (cs *channelStore) createChannelLocked(s *StanServer, name string, id uint64) (*channel, error) {
+func (cs *channelStore) createChannelLocked(s *StanServer, name string, id uint64) (retChan *channel, retErr error) {
+	defer func() {
+		if retErr != nil {
+			cs.stan.log.Errorf("Creating channel %q failed: %v", name, retErr)
+		}
+	}()
 	// It is possible that there were 2 concurrent calls to lookupOrCreateChannel
 	// which first uses `channelStore.get()` and if not found, calls this function.
 	// So we need to check now that we have the write lock that the channel has

--- a/server/server_storefailures_test.go
+++ b/server/server_storefailures_test.go
@@ -736,3 +736,23 @@ func TestDeleteChannelStoreError(t *testing.T) {
 		t.Fatalf("Timer should have been stopped")
 	}
 }
+
+func TestCreateChannelError(t *testing.T) {
+	opts := GetDefaultOptions()
+	logger := &checkErrorLogger{checkErrorStr: "Creating channel \"foo\" failed: " + errOnPurpose.Error()}
+	opts.CustomLogger = logger
+	s := runServerWithOpts(t, opts, nil)
+	defer s.Shutdown()
+
+	s.channels.Lock()
+	ms := &testChannelStoreFailStore{Store: s.channels.store}
+	s.channels.store = ms
+	s.channels.Unlock()
+
+	if _, err := s.channels.createChannel(s, "foo"); err == nil {
+		t.Fatal("Expected error, got none")
+	}
+	if !logger.gotError {
+		t.Fatal("Did not log the expected error")
+	}
+}


### PR DESCRIPTION
If creation of a channel failed, this error was not always logged.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>