### PR TITLE
[FIXED] Possible panic on startup when monitoring endpoint inspected

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2525,7 +2525,9 @@ func (s *StanServer) processRecoveredChannels(channels map[string]*stores.Recove
 	allSubs := make([]*subState, 0, 16)
 
 	for channelName, recoveredChannel := range channels {
+		s.channels.Lock()
 		channel, err := s.channels.create(s, channelName, recoveredChannel.Channel)
+		s.channels.Unlock()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
If some monitoring endpoints were inspected during the start process
it could result in a panic due to a map read during a map set.

Resolves #1235

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>