### PR TITLE
[FIXED] Possible panic on message redelivery

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -3691,8 +3691,13 @@ func (s *StanServer) performAckExpirationRedelivery(sub *subState, isStartup boo
 		sub.Unlock()
 		return
 	}
-	// Sort our messages outstanding from acksPending, grab some state and unlock.
 	sub.Lock()
+	// Subscriber could have been closed
+	if sub.ackTimer == nil {
+		sub.Unlock()
+		return
+	}
+	// Sort our messages outstanding from acksPending, grab some state and unlock.
 	sortedPendingMsgs := sub.makeSortedPendingMsgs()
 	if len(sortedPendingMsgs) == 0 {
 		sub.clearAckTimer()


### PR DESCRIPTION
If the message redelivery callback fired and a client was marked
with failed heartbeat and the subscription is closed (likely
due to the server closing connection due to failed HBs), there
was a race that could cause a panic trying to reset a timer
that has been set to nil.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>