### PR TITLE
[FIXED] Check expected record size before loading the payload

### DIFF
--- a/server/conf.go
+++ b/server/conf.go
@@ -577,11 +577,6 @@ func parseFileOptions(itf interface{}, opts *Options) error {
 				return err
 			}
 			opts.FileStoreOpts.AutoSync = dur
-		case "record_size_limit":
-			if err := checkType(k, reflect.Int64, v); err != nil {
-				return err
-			}
-			opts.FileStoreOpts.RecordSizeLimit = int(v.(int64))
 		}
 	}
 	return nil

--- a/server/conf_test.go
+++ b/server/conf_test.go
@@ -144,9 +144,6 @@ func TestParseConfig(t *testing.T) {
 	if opts.FileStoreOpts.AutoSync != 2*time.Minute {
 		t.Fatalf("Expected AutoSync to be 2minutes, got %v", opts.FileStoreOpts.AutoSync)
 	}
-	if opts.FileStoreOpts.RecordSizeLimit != 1024 {
-		t.Fatalf("Expected RecordSizeLimit to be 1024, got %v", opts.FileStoreOpts.RecordSizeLimit)
-	}
 	if opts.MaxChannels != 11 {
 		t.Fatalf("Expected MaxChannels to be 11, got %v", opts.MaxChannels)
 	}
@@ -498,7 +495,6 @@ func TestParseWrongTypes(t *testing.T) {
 	expectFailureFor(t, "file:{parallel_recovery:false}", wrongTypeErr)
 	expectFailureFor(t, "file:{auto_sync:123}", wrongTypeErr)
 	expectFailureFor(t, "file:{auto_sync:\"1h:0m\"}", wrongTimeErr)
-	expectFailureFor(t, "file:{record_size_limit:true}", wrongTypeErr)
 	expectFailureFor(t, "cluster:{node_id:false}", wrongTypeErr)
 	expectFailureFor(t, "cluster:{bootstrap:1}", wrongTypeErr)
 	expectFailureFor(t, "cluster:{peers:1}", wrongTypeErr)

--- a/test/configs/test_parse.conf
+++ b/test/configs/test_parse.conf
@@ -74,7 +74,6 @@ streaming: {
       parallel_recovery: 9
       read_buffer_size: 10
       auto_sync: "2m"
-      record_size_limit: 1024
   }
 
   cluster: {


### PR DESCRIPTION
Reverted addition of record_size_limit (#1259, #1260, #1262)

But still address the memory usage caused by a corrupted data message
on recovery.

By using the expected record size from the index file, when checking
that the last message matches the index information, we would find
out that the index's stored message record size does not match the
record size in the ".dat" file and would not allocate the memory
to read the rest of the message.

The record_size_limit that was added to solve that issue would have
likely caused a lot of issues if mis-used.

Resolves #1255

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>