### PR TITLE
[FIXED] Recover channels even if server information not recovered

### DIFF
--- a/server/clustering_test.go
+++ b/server/clustering_test.go
@@ -6915,7 +6915,7 @@ func TestClusteringRestoreSnapshotWithDifferentVersionsOfSameChannel(t *testing.
 }
 
 func TestClusteringSQLMsgStoreFlushed(t *testing.T) {
-	if !doSQL {
+	if persistentStoreType != stores.TypeSQL {
 		t.SkipNow()
 	}
 

--- a/server/ft_test.go
+++ b/server/ft_test.go
@@ -336,6 +336,9 @@ func TestFTPartition(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error on subscribe: %v", err)
 	}
+	if err := syncNC.Flush(); err != nil {
+		t.Fatalf("Error on flush: %v", err)
+	}
 
 	// Start NATS server independently
 	ns := natsdTest.RunServer(&nOpts)
@@ -363,6 +366,9 @@ func TestFTPartition(t *testing.T) {
 				"-test.v",
 				"-test.run=TestFTPartition$",
 				"-persistent_store", persistentStoreType,
+			}
+			if !doSQL {
+				params = append(params, "-sql=false")
 			}
 			// Start a process that will be the standby
 			if persistentStoreType == stores.TypeSQL {
@@ -482,6 +488,9 @@ func TestFTPartitionReversed(t *testing.T) {
 				"-test.v",
 				"-test.run=TestFTPartitionReversed$",
 				"-persistent_store", persistentStoreType,
+			}
+			if !doSQL {
+				params = append(params, "-sql=false")
 			}
 			// Start a process that will act as the active server
 			if persistentStoreType == stores.TypeSQL {

--- a/server/server_delivery_test.go
+++ b/server/server_delivery_test.go
@@ -262,20 +262,18 @@ func TestPersistentStoreSQLSubsPendingRows(t *testing.T) {
 		t.SkipNow()
 	}
 	source := testSQLSource
+	sourceAdmin := testSQLSourceAdmin
+	// If not running tests with `-persistent_store sql`,
+	// initialize few things and default to MySQL.
 	if persistentStoreType != stores.TypeSQL {
-		// If not running tests with `-persistent_store sql`,
-		// initialize few things and default to MySQL.
 		source = testDefaultMySQLSource
-		sourceAdmin := testDefaultMySQLSourceAdmin
+		sourceAdmin = testDefaultMySQLSourceAdmin
 		if err := test.CreateSQLDatabase(testSQLDriver, sourceAdmin,
 			source, testSQLDatabaseName); err != nil {
 			t.Fatalf("Error setting up test for SQL: %v", err)
 		}
-		defer test.DeleteSQLDatabase(testSQLDriver, sourceAdmin, testSQLDatabaseName)
 	}
-
-	cleanupDatastore(t)
-	defer cleanupDatastore(t)
+	defer test.DeleteSQLDatabase(testSQLDriver, sourceAdmin, testSQLDatabaseName)
 
 	ns := natsdTest.RunDefaultServer()
 	defer ns.Shutdown()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -97,9 +97,7 @@ func TestMain(m *testing.M) {
 	)
 	flag.StringVar(&bst, "bench_store", "", "store type for bench tests (mem, file)")
 	flag.StringVar(&pst, "persistent_store", "", "store type for server recovery related tests (file)")
-	// This one is added here so that if we want to disable sql for stores tests
-	// we can use the same param for all packages as in "go test -v ./... -sql=false"
-	flag.Bool("sql", false, "Not used for server tests")
+	flag.BoolVar(&doSQL, "sql", true, "Enable/disable SQL tests in server package")
 	// Those 2 sql related flags are handled here, not in AddSQLFlags
 	flag.BoolVar(&sqlCreateDb, "sql_create_db", true, "create sql database on startup")
 	flag.BoolVar(&sqlDeleteDb, "sql_delete_db", true, "delete sql database on exit")
@@ -131,7 +129,7 @@ func TestMain(m *testing.M) {
 
 	// If either (or both) bench or tests select an SQL store, we need to do
 	// so initializing and cleaning at the end of the test.
-	doSQL = benchStoreType == stores.TypeSQL || persistentStoreType == stores.TypeSQL
+	doSQL = doSQL || benchStoreType == stores.TypeSQL || persistentStoreType == stores.TypeSQL
 
 	if doSQL {
 		defaultSources := make(map[string][]string)

--- a/stores/common_msg_test.go
+++ b/stores/common_msg_test.go
@@ -638,7 +638,7 @@ func TestCSFirstAndLastMsg(t *testing.T) {
 			defer s.Close()
 
 			limit := testDefaultStoreLimits
-			limit.MaxAge = 100 * time.Millisecond
+			limit.MaxAge = 250 * time.Millisecond
 			if err := s.SetLimits(&limit); err != nil {
 				t.Fatalf("Error setting limits: %v", err)
 			}

--- a/stores/sqlstore.go
+++ b/stores/sqlstore.go
@@ -793,6 +793,13 @@ func (s *SQLStore) Recover() (*RecoveredState, error) {
 		// If there is no row, that means nothing to recover. Return nil for the
 		// state and no error.
 		if err == sql.ErrNoRows {
+			// If there are channels, we should return an error.
+			var maxChannelID int64
+			r := s.db.QueryRow(sqlStmts[sqlRecoverMaxChannelID])
+			r.Scan(&maxChannelID)
+			if maxChannelID > 0 {
+				return nil, ErrNoSrvButChannels
+			}
 			return nil, nil
 		}
 		return nil, sqlStmtError(sqlRecoverServerInfo, err)

--- a/stores/store.go
+++ b/stores/store.go
@@ -34,11 +34,12 @@ const (
 
 // Errors.
 var (
-	ErrTooManyChannels = errors.New("too many channels")
-	ErrTooManySubs     = errors.New("too many subscriptions per channel")
-	ErrNotSupported    = errors.New("not supported")
-	ErrAlreadyExists   = errors.New("already exists")
-	ErrNotFound        = errors.New("not found")
+	ErrTooManyChannels  = errors.New("too many channels")
+	ErrTooManySubs      = errors.New("too many subscriptions per channel")
+	ErrNotSupported     = errors.New("not supported")
+	ErrAlreadyExists    = errors.New("already exists")
+	ErrNotFound         = errors.New("not found")
+	ErrNoSrvButChannels = errors.New("no server state recovered but channels present")
 )
 
 // StoreLimits define limits for a store.


### PR DESCRIPTION
A user reported that the server.dat was missing, which means that
the server did not recover channels (assuming that this was a
fresh start, without any state). This caused issues later on
since if an app publishes a message to an existing (non recovered)
channel, then messages would be added to the channel but with
a reset of the sequence.

The server will now warn of the situation, initialize the server
state and then recover the rest of the state (channels, etc..)

Resolves #1263

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>